### PR TITLE
feat(engine): add LoopControl SPI for pluggable dispatch rule selection

### DIFF
--- a/api/src/main/java/io/casehub/api/engine/LoopControl.java
+++ b/api/src/main/java/io/casehub/api/engine/LoopControl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.model.DispatchRule;
+import java.util.List;
+
+/**
+ * SPI for controlling which eligible dispatch rules are selected for execution after their trigger
+ * conditions have been evaluated.
+ *
+ * <p>The default implementation ({@link io.casehub.engine.internal.engine.ChoreographyLoopControl})
+ * fires all eligible rules concurrently — pure choreography. Provide an alternative CDI bean
+ * ({@code @Alternative @Priority} ) to introduce deliberate ordering, prioritisation, or sequential
+ * execution.
+ */
+public interface LoopControl {
+
+  /**
+   * Select the dispatch rules to fire from the set of rules whose trigger conditions have already
+   * been evaluated and matched.
+   *
+   * @param context the current case state context
+   * @param eligible rules whose trigger conditions matched — may be empty, never null
+   * @return the subset to fire; may be empty, may be the full list, must not be null
+   */
+  List<DispatchRule> select(StateContext context, List<DispatchRule> eligible);
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/ChoreographyLoopControl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/ChoreographyLoopControl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.engine.LoopControl;
+import io.casehub.api.model.DispatchRule;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+/**
+ * Default {@link LoopControl} — fires all eligible dispatch rules concurrently.
+ *
+ * <p>Pure choreography: every rule whose trigger condition matched is scheduled for execution
+ * without deliberate ordering or prioritisation. Replace this bean via
+ * {@code @Alternative @Priority} to introduce a planning strategy or sequential execution model.
+ */
+@ApplicationScoped
+public class ChoreographyLoopControl implements LoopControl {
+
+  @Override
+  public List<DispatchRule> select(final StateContext context, final List<DispatchRule> eligible) {
+    return eligible;
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
+import io.casehub.api.engine.LoopControl;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseHubDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
@@ -53,6 +54,8 @@ public class CaseStateContextChangedEventHandler {
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
 
   @Inject JQEvaluator jqEvaluator;
+
+  @Inject LoopControl loopControl;
 
   @ConsumeEvent(value = EventBusAddresses.CONTEXT_CHANGED)
   public Uni<Void> onCaseStateContextChangedEventHandler(CaseStateContextChangedEvent event) {
@@ -95,28 +98,34 @@ public class CaseStateContextChangedEventHandler {
 
     List<Worker> workers = definition.getWorkers();
 
-    List<Uni<Void>> unis = new ArrayList<>();
-
+    // Evaluate trigger conditions to find eligible rules
+    List<DispatchRule> eligible = new ArrayList<>();
     for (DispatchRule rule : rules) {
       if (!(rule.getOn() instanceof ContextChangeTrigger cct)) {
         continue;
       }
 
-      String jqExpression = normalizeJqFilter(rule, cct);
-
       ValidationResult matches =
-          jqEvaluator.eval(jqExpression, caseInstance.getStateContext().asJsonNode());
+          jqEvaluator.eval(
+              normalizeJqFilter(rule, cct), caseInstance.getStateContext().asJsonNode());
       if (!matches.ok() || !matches.isTrue()) {
         continue;
       }
 
-      Capability capability = rule.getCapability();
-      if (capability == null) {
+      if (rule.getCapability() == null) {
         LOG.warnf("Capability referenced by rule '%s' is null", rule.getName());
         continue;
       }
 
-      unis.add(publishWorkerSchedules(caseInstance, workers, rule, capability));
+      eligible.add(rule);
+    }
+
+    // LoopControl decides which eligible rules to fire (default: all of them)
+    List<DispatchRule> selected = loopControl.select(caseInstance.getStateContext(), eligible);
+
+    List<Uni<Void>> unis = new ArrayList<>(selected.size());
+    for (DispatchRule rule : selected) {
+      unis.add(publishWorkerSchedules(caseInstance, workers, rule, rule.getCapability()));
     }
 
     if (unis.isEmpty()) {


### PR DESCRIPTION
Closes #31
Refs #30

## Summary

Introduces a `LoopControl` SPI that controls which eligible dispatch rules are fired after their trigger conditions have been evaluated.

- `LoopControl` interface in `api/` — pure Java, no framework deps
- `ChoreographyLoopControl` in `engine/` — default `@ApplicationScoped` impl, returns all eligible rules unchanged (existing behaviour preserved exactly)
- `CaseStateContextChangedEventHandler` wired to evaluate conditions → collect eligible → `loopControl.select()` → fire selected

## Why

Currently all matching rules fire concurrently with no extension point. This SPI makes the selection step pluggable so a `PlanningStrategy`-backed orchestration layer can be added as an opt-in module without touching the engine core.

## Override pattern

```java
@Alternative @Priority(1)
@ApplicationScoped
public class PlanningStrategyLoopControl implements LoopControl {
    public List<DispatchRule> select(StateContext ctx, List<DispatchRule> eligible) {
        // deliberate selection logic
    }
}
```

## Testing

All existing tests pass. `SignalTest#workerRunsOnceOnDuplicateSignal` is a pre-existing flaky test (shared DB state, passes in isolation, unrelated to this change).