### PR TITLE
feat(api): unseal ExpressionEvaluator, add LambdaExpressionEvaluator

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git pull:*)",
+      "Bash(git remote:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git pull:*)",
-      "Bash(git remote:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ nb-configuration.xml
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+.claude/

--- a/api/src/main/java/io/casehub/api/engine/ExpressionEngine.java
+++ b/api/src/main/java/io/casehub/api/engine/ExpressionEngine.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+
+/**
+ * SPI for pluggable expression evaluation engines.
+ *
+ * <p>Each engine declares the {@link ExpressionEvaluator#type()} it handles and evaluates
+ * expressions of that type against a {@link StateContext}. Register additional engines as CDI beans
+ * to support new expression languages (e.g. Drools, SpEL) without modifying the runtime.
+ *
+ * @see io.casehub.api.model.evaluator.JQExpressionEvaluator
+ * @see io.casehub.api.model.evaluator.LambdaExpressionEvaluator
+ */
+public interface ExpressionEngine {
+
+  /**
+   * Returns the evaluator type this engine handles, matching {@link ExpressionEvaluator#type()}.
+   */
+  String type();
+
+  /**
+   * Evaluates the expression against the given context.
+   *
+   * @param evaluator the expression to evaluate — guaranteed to match {@link #type()}
+   * @param context the current case state
+   * @return {@code true} if the expression matches, {@code false} otherwise
+   */
+  boolean evaluate(ExpressionEvaluator evaluator, StateContext context);
+}

--- a/api/src/main/java/io/casehub/api/model/evaluator/ExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/ExpressionEvaluator.java
@@ -15,4 +15,12 @@
  */
 package io.casehub.api.model.evaluator;
 
-public interface ExpressionEvaluator {}
+public interface ExpressionEvaluator {
+
+  /**
+   * Returns the type identifier for this evaluator, used by {@link
+   * io.casehub.api.engine.ExpressionEngine} implementations to declare which evaluator type they
+   * handle.
+   */
+  String type();
+}

--- a/api/src/main/java/io/casehub/api/model/evaluator/ExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/ExpressionEvaluator.java
@@ -15,4 +15,4 @@
  */
 package io.casehub.api.model.evaluator;
 
-public sealed interface ExpressionEvaluator permits JQExpressionEvaluator {}
+public interface ExpressionEvaluator {}

--- a/api/src/main/java/io/casehub/api/model/evaluator/JQExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/JQExpressionEvaluator.java
@@ -15,4 +15,12 @@
  */
 package io.casehub.api.model.evaluator;
 
-public record JQExpressionEvaluator(String expression) implements ExpressionEvaluator {}
+public record JQExpressionEvaluator(String expression) implements ExpressionEvaluator {
+
+  public static final String TYPE = "jq";
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
@@ -26,10 +26,17 @@ import java.util.function.Predicate;
  */
 public final class LambdaExpressionEvaluator implements ExpressionEvaluator {
 
+  public static final String TYPE = "lambda";
+
   private final Predicate<StateContext> predicate;
 
   public LambdaExpressionEvaluator(final Predicate<StateContext> predicate) {
     this.predicate = predicate;
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
   }
 
   public boolean test(final StateContext context) {

--- a/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.evaluator;
+
+import io.casehub.api.context.StateContext;
+import java.util.function.Predicate;
+
+/**
+ * An {@link ExpressionEvaluator} backed by a Java lambda. Provides type-safe, IDE-friendly
+ * conditions for Java DSL users as an alternative to {@link JQExpressionEvaluator} JQ strings.
+ *
+ * <p>Not serialisable — use {@link JQExpressionEvaluator} for YAML-defined cases.
+ */
+public final class LambdaExpressionEvaluator implements ExpressionEvaluator {
+
+  private final Predicate<StateContext> predicate;
+
+  public LambdaExpressionEvaluator(final Predicate<StateContext> predicate) {
+    this.predicate = predicate;
+  }
+
+  public boolean test(final StateContext context) {
+    return predicate.test(context);
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/ExpressionEngineRegistry.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/ExpressionEngineRegistry.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.engine.ExpressionEngine;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+/**
+ * Dispatches expression evaluation to the appropriate {@link ExpressionEngine} by evaluator type.
+ *
+ * <p>All CDI beans implementing {@link ExpressionEngine} are discovered automatically. Add a new
+ * engine bean to support additional expression languages without modifying this class or the
+ * runtime.
+ */
+@ApplicationScoped
+public class ExpressionEngineRegistry {
+
+  private static final Logger LOG = Logger.getLogger(ExpressionEngineRegistry.class);
+
+  @Inject Instance<ExpressionEngine> engines;
+
+  /**
+   * Evaluates the expression against the given context.
+   *
+   * @param evaluator the expression to evaluate; returns {@code true} if {@code null}
+   * @param context the current case state
+   * @return {@code true} if the expression matches or is absent
+   * @throws IllegalArgumentException if no engine is registered for the evaluator type
+   */
+  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+    if (evaluator == null) {
+      return true;
+    }
+    final String type = evaluator.type();
+    for (ExpressionEngine engine : engines) {
+      if (engine.type().equals(type)) {
+        return engine.evaluate(evaluator, context);
+      }
+    }
+    throw new IllegalArgumentException("No ExpressionEngine registered for type '" + type + "'");
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/JQExpressionEngine.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/JQExpressionEngine.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.engine.ExpressionEngine;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.engine.internal.jq.JQEvaluator;
+import io.casehub.engine.internal.jq.ValidationResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/** {@link ExpressionEngine} for JQ expressions. */
+@ApplicationScoped
+public class JQExpressionEngine implements ExpressionEngine {
+
+  @Inject JQEvaluator jqEvaluator;
+
+  @Override
+  public String type() {
+    return JQExpressionEvaluator.TYPE;
+  }
+
+  @Override
+  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+    final String expr = ((JQExpressionEvaluator) evaluator).expression();
+    if (expr == null || expr.isBlank()) {
+      return true;
+    }
+    final ValidationResult result = jqEvaluator.eval(expr, context.asJsonNode());
+    return result.ok() && result.isTrue();
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/LambdaExpressionEngine.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/LambdaExpressionEngine.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.engine.ExpressionEngine;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/** {@link ExpressionEngine} for Java lambda expressions. */
+@ApplicationScoped
+public class LambdaExpressionEngine implements ExpressionEngine {
+
+  @Override
+  public String type() {
+    return LambdaExpressionEvaluator.TYPE;
+  }
+
+  @Override
+  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+    return ((LambdaExpressionEvaluator) evaluator).test(context);
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
-import io.casehub.api.context.StateContext;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseHubDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
@@ -23,17 +22,13 @@ import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
-import io.casehub.api.model.evaluator.ExpressionEvaluator;
-import io.casehub.api.model.evaluator.JQExpressionEvaluator;
-import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
+import io.casehub.engine.internal.engine.ExpressionEngineRegistry;
 import io.casehub.engine.internal.event.CaseStateContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.GoalReachedEvent;
 import io.casehub.engine.internal.event.MilestoneReachedEvent;
 import io.casehub.engine.internal.event.WorkerScheduleEvent;
-import io.casehub.engine.internal.jq.JQEvaluator;
-import io.casehub.engine.internal.jq.ValidationResult;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.model.CaseMetaModel;
 import io.casehub.engine.internal.model.CaseState;
@@ -55,7 +50,7 @@ public class CaseStateContextChangedEventHandler {
 
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
 
-  @Inject JQEvaluator jqEvaluator;
+  @Inject ExpressionEngineRegistry expressionEngineRegistry;
 
   @ConsumeEvent(value = EventBusAddresses.CONTEXT_CHANGED)
   public Uni<Void> onCaseStateContextChangedEventHandler(CaseStateContextChangedEvent event) {
@@ -105,7 +100,7 @@ public class CaseStateContextChangedEventHandler {
         continue;
       }
 
-      if (!evaluateFilter(cct.getFilter(), caseInstance.getStateContext())) {
+      if (!expressionEngineRegistry.evaluate(cct.getFilter(), caseInstance.getStateContext())) {
         continue;
       }
 
@@ -132,7 +127,8 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Milestone milestone : milestones) {
-      if (!evaluateFilter(milestone.getCondition(), caseInstance.getStateContext())) continue;
+      if (!expressionEngineRegistry.evaluate(
+          milestone.getCondition(), caseInstance.getStateContext())) continue;
 
       LOG.infof("Milestone '%s' REACHED! Publishing MilestoneReachedEvent", milestone.getName());
 
@@ -150,7 +146,8 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Goal goal : goals) {
-      if (!evaluateFilter(goal.getCondition(), caseInstance.getStateContext())) continue;
+      if (!expressionEngineRegistry.evaluate(goal.getCondition(), caseInstance.getStateContext()))
+        continue;
 
       LOG.infof("Goal '%s' REACHED! Publishing GoalReachedEvent", goal.getName());
 
@@ -158,21 +155,6 @@ public class CaseStateContextChangedEventHandler {
     }
 
     return Uni.createFrom().voidItem();
-  }
-
-  private boolean evaluateFilter(ExpressionEvaluator evaluator, StateContext context) {
-    if (evaluator == null) return true;
-    if (evaluator instanceof JQExpressionEvaluator jq) {
-      String expr = jq.expression();
-      if (expr == null || expr.isBlank()) return true;
-      ValidationResult result = jqEvaluator.eval(expr, context.asJsonNode());
-      return result.ok() && result.isTrue();
-    }
-    if (evaluator instanceof LambdaExpressionEvaluator lambda) {
-      return lambda.test(context);
-    }
-    LOG.warnf("Unknown ExpressionEvaluator type: %s", evaluator.getClass().getSimpleName());
-    return false;
   }
 
   private Uni<Void> publishWorkerSchedules(

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
+import io.casehub.api.context.StateContext;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseHubDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
@@ -22,7 +23,9 @@ import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
 import io.casehub.engine.internal.event.CaseStateContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
@@ -102,11 +105,7 @@ public class CaseStateContextChangedEventHandler {
         continue;
       }
 
-      String jqExpression = normalizeJqFilter(rule, cct);
-
-      ValidationResult matches =
-          jqEvaluator.eval(jqExpression, caseInstance.getStateContext().asJsonNode());
-      if (!matches.ok() || !matches.isTrue()) {
+      if (!evaluateFilter(cct.getFilter(), caseInstance.getStateContext())) {
         continue;
       }
 
@@ -133,13 +132,7 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Milestone milestone : milestones) {
-      if (milestone.getCondition() == null) continue;
-      String conditionExpr = ((JQExpressionEvaluator) milestone.getCondition()).expression();
-      if (conditionExpr == null || conditionExpr.isBlank()) continue;
-
-      ValidationResult result =
-          jqEvaluator.eval(conditionExpr, caseInstance.getStateContext().asJsonNode());
-      if (!result.ok() || !result.isTrue()) continue;
+      if (!evaluateFilter(milestone.getCondition(), caseInstance.getStateContext())) continue;
 
       LOG.infof("Milestone '%s' REACHED! Publishing MilestoneReachedEvent", milestone.getName());
 
@@ -157,13 +150,7 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Goal goal : goals) {
-      if (goal.getCondition() == null) continue;
-      String conditionExpr = ((JQExpressionEvaluator) goal.getCondition()).expression();
-      if (conditionExpr == null || conditionExpr.isBlank()) continue;
-
-      ValidationResult result =
-          jqEvaluator.eval(conditionExpr, caseInstance.getStateContext().asJsonNode());
-      if (!result.ok() || !result.isTrue()) continue;
+      if (!evaluateFilter(goal.getCondition(), caseInstance.getStateContext())) continue;
 
       LOG.infof("Goal '%s' REACHED! Publishing GoalReachedEvent", goal.getName());
 
@@ -173,17 +160,19 @@ public class CaseStateContextChangedEventHandler {
     return Uni.createFrom().voidItem();
   }
 
-  private String normalizeJqFilter(DispatchRule rule, ContextChangeTrigger cct) {
-    if (cct.getFilter() == null) {
-      LOG.debugf("Rule '%s' has no JQ filter defined, treating as always true", rule.getName());
-      return ".";
+  private boolean evaluateFilter(ExpressionEvaluator evaluator, StateContext context) {
+    if (evaluator == null) return true;
+    if (evaluator instanceof JQExpressionEvaluator jq) {
+      String expr = jq.expression();
+      if (expr == null || expr.isBlank()) return true;
+      ValidationResult result = jqEvaluator.eval(expr, context.asJsonNode());
+      return result.ok() && result.isTrue();
     }
-    String jqExpression = ((JQExpressionEvaluator) cct.getFilter()).expression();
-    if (jqExpression == null || jqExpression.isBlank()) {
-      LOG.debugf("Rule '%s' has no JQ filter defined, treating as always true", rule.getName());
-      return ".";
+    if (evaluator instanceof LambdaExpressionEvaluator lambda) {
+      return lambda.test(context);
     }
-    return jqExpression;
+    LOG.warnf("Unknown ExpressionEvaluator type: %s", evaluator.getClass().getSimpleName());
+    return false;
   }
 
   private Uni<Void> publishWorkerSchedules(

--- a/engine/src/test/java/io/casehub/engine/internal/engine/ExpressionEngineRegistryTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/engine/ExpressionEngineRegistryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import io.casehub.engine.internal.context.StateContextImpl;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@DisplayName("ExpressionEngineRegistry")
+class ExpressionEngineRegistryTest {
+
+  @Inject ExpressionEngineRegistry registry;
+
+  @Nested
+  @DisplayName("evaluate()")
+  class Evaluate {
+
+    @Test
+    @DisplayName("returns true for null evaluator")
+    void nullEvaluator_returnsTrue() {
+      final var context = new StateContextImpl(Map.of());
+      assertTrue(registry.evaluate(null, context));
+    }
+
+    @Test
+    @DisplayName("JQ — returns true when expression matches context")
+    void jq_returnsTrueOnMatch() {
+      final var context = new StateContextImpl(Map.of("status", "ready"));
+      final var evaluator = new JQExpressionEvaluator(".status == \"ready\"");
+      assertTrue(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("JQ — returns false when expression does not match context")
+    void jq_returnsFalseOnNoMatch() {
+      final var context = new StateContextImpl(Map.of("status", "pending"));
+      final var evaluator = new JQExpressionEvaluator(".status == \"ready\"");
+      assertFalse(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("JQ — returns true for null expression (treat as always-match)")
+    void jq_nullExpression_returnsTrue() {
+      final var context = new StateContextImpl(Map.of());
+      final var evaluator = new JQExpressionEvaluator(null);
+      assertTrue(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("JQ — returns true for blank expression (treat as always-match)")
+    void jq_blankExpression_returnsTrue() {
+      final var context = new StateContextImpl(Map.of());
+      final var evaluator = new JQExpressionEvaluator("   ");
+      assertTrue(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("Lambda — returns true when predicate matches")
+    void lambda_returnsTrueOnMatch() {
+      final var context = new StateContextImpl(Map.of("score", 10));
+      final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("score") != null);
+      assertTrue(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("Lambda — returns false when predicate does not match")
+    void lambda_returnsFalseOnNoMatch() {
+      final var context = new StateContextImpl(Map.of());
+      final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("score") != null);
+      assertFalse(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("throws IllegalArgumentException for unregistered evaluator type")
+    void unknownType_throws() {
+      final var context = new StateContextImpl(Map.of());
+      final var unknown =
+          new io.casehub.api.model.evaluator.ExpressionEvaluator() {
+            @Override
+            public String type() {
+              return "drools";
+            }
+          };
+      final var ex =
+          assertThrows(IllegalArgumentException.class, () -> registry.evaluate(unknown, context));
+      assertTrue(ex.getMessage().contains("drools"));
+    }
+  }
+
+  @Nested
+  @DisplayName("validate()")
+  class Validate {
+
+    @Test
+    @DisplayName("no-op for null evaluator")
+    void nullEvaluator_doesNotThrow() {
+      assertDoesNotThrow(() -> registry.validate(null));
+    }
+
+    @Test
+    @DisplayName("JQ — passes for valid expression")
+    void jq_validExpression_doesNotThrow() {
+      assertDoesNotThrow(
+          () -> registry.validate(new JQExpressionEvaluator(".status == \"ready\"")));
+    }
+
+    @Test
+    @DisplayName("JQ — passes for null expression")
+    void jq_nullExpression_doesNotThrow() {
+      assertDoesNotThrow(() -> registry.validate(new JQExpressionEvaluator(null)));
+    }
+
+    @Test
+    @DisplayName("JQ — throws IllegalArgumentException for invalid syntax")
+    void jq_invalidExpression_throws() {
+      final var ex =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> registry.validate(new JQExpressionEvaluator(".foo ??? broken")));
+      assertTrue(ex.getMessage().contains("Invalid JQ expression"));
+    }
+
+    @Test
+    @DisplayName("Lambda — no-op regardless of predicate")
+    void lambda_doesNotThrow() {
+      assertDoesNotThrow(() -> registry.validate(new LambdaExpressionEvaluator(ctx -> true)));
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/evaluator/LambdaExpressionEvaluatorTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/evaluator/LambdaExpressionEvaluatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.evaluator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import io.casehub.engine.internal.context.StateContextImpl;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("LambdaExpressionEvaluator")
+class LambdaExpressionEvaluatorTest {
+
+  @Test
+  @DisplayName("type() returns 'lambda'")
+  void type_returnsLambda() {
+    final var evaluator = new LambdaExpressionEvaluator(ctx -> true);
+    assertEquals(LambdaExpressionEvaluator.TYPE, evaluator.type());
+    assertEquals("lambda", evaluator.type());
+  }
+
+  @Test
+  @DisplayName("test() returns true when predicate matches")
+  void test_returnsTrueWhenPredicateMatches() {
+    final var context = new StateContextImpl(Map.of("status", "ready"));
+    final var evaluator = new LambdaExpressionEvaluator(ctx -> "ready".equals(ctx.get("status")));
+
+    assertTrue(evaluator.test(context));
+  }
+
+  @Test
+  @DisplayName("test() returns false when predicate does not match")
+  void test_returnsFalseWhenPredicateDoesNotMatch() {
+    final var context = new StateContextImpl(Map.of("status", "pending"));
+    final var evaluator = new LambdaExpressionEvaluator(ctx -> "ready".equals(ctx.get("status")));
+
+    assertFalse(evaluator.test(context));
+  }
+
+  @Test
+  @DisplayName("test() receives the exact context passed in")
+  void test_receivesExactContext() {
+    final var context = new StateContextImpl(Map.of("count", 42));
+    final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("count") != null);
+
+    assertTrue(evaluator.test(context));
+  }
+}


### PR DESCRIPTION
Closes #33
Refs #3, #4, #6, #8, #30

## Summary

Aligns expression evaluation with the pluggable framework described in issues #2–#8.

### Changes

**`ExpressionEvaluator`** — adds `String type()` so engines can declare which evaluator type they handle (refs #4)

**`JQExpressionEvaluator`** — implements `type()` → `JQExpressionEvaluator.TYPE = "jq"`

**`LambdaExpressionEvaluator`** — new class wrapping `Predicate<StateContext>`; implements `type()` → `LambdaExpressionEvaluator.TYPE = "lambda"` (refs #6)

**`ExpressionEngine`** — new SPI in `api/`; register CDI beans to support new engines (Drools, SpEL, etc.) without modifying the runtime (refs #3)

**`JQExpressionEngine`** + **`LambdaExpressionEngine`** — built-in implementations

**`ExpressionEngineRegistry`** — CDI `Instance<ExpressionEngine>` registry; dispatches `evaluate()` by type (refs #3, #8)

**`CaseStateContextChangedEventHandler`** — now delegates all expression evaluation to `ExpressionEngineRegistry`; direct `JQEvaluator` dependency removed from the handler entirely (refs #8)

## Usage

```java
// JQ — portable, serialisable, YAML-friendly
new JQExpressionEvaluator(".status == \"ready\"")

// Lambda — type-safe, Java DSL only, not serialisable
new LambdaExpressionEvaluator(ctx -> "ready".equals(ctx.get("status")))

// Custom engine — just register a CDI bean:
@ApplicationScoped
public class DroolsExpressionEngine implements ExpressionEngine {
    public String type() { return "drools"; }
    public boolean evaluate(ExpressionEvaluator evaluator, StateContext ctx) { ... }
}
```

## Open question

Naming: this PR uses `LambdaExpressionEvaluator` / `"lambda"` type. Issue #6 proposes `JavaPredicateEvaluator`. Happy to rename if preferred — keeping it for now pending feedback.

## Testing

All existing tests pass. `SignalTest#workerRunsOnceOnDuplicateSignal` is a pre-existing flaky test (#29), unrelated to this change.