### PR TITLE
feat(engine): validate expressions on case definition registration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git pull:*)",
+      "Bash(git remote:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git pull:*)",
-      "Bash(git remote:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ nb-configuration.xml
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+.claude/

--- a/api/src/main/java/io/casehub/api/engine/ExpressionEngine.java
+++ b/api/src/main/java/io/casehub/api/engine/ExpressionEngine.java
@@ -43,4 +43,12 @@ public interface ExpressionEngine {
    * @return {@code true} if the expression matches, {@code false} otherwise
    */
   boolean evaluate(ExpressionEvaluator evaluator, StateContext context);
+
+  /**
+   * Validates the expression syntax without evaluating it against any context.
+   *
+   * @param evaluator the expression to validate — guaranteed to match {@link #type()}
+   * @throws IllegalArgumentException if the expression is syntactically invalid
+   */
+  void validate(ExpressionEvaluator evaluator);
 }

--- a/api/src/main/java/io/casehub/api/engine/ExpressionEngine.java
+++ b/api/src/main/java/io/casehub/api/engine/ExpressionEngine.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+
+/**
+ * SPI for pluggable expression evaluation engines.
+ *
+ * <p>Each engine declares the {@link ExpressionEvaluator#type()} it handles and evaluates
+ * expressions of that type against a {@link StateContext}. Register additional engines as CDI beans
+ * to support new expression languages (e.g. Drools, SpEL) without modifying the runtime.
+ *
+ * @see io.casehub.api.model.evaluator.JQExpressionEvaluator
+ * @see io.casehub.api.model.evaluator.LambdaExpressionEvaluator
+ */
+public interface ExpressionEngine {
+
+  /**
+   * Returns the evaluator type this engine handles, matching {@link ExpressionEvaluator#type()}.
+   */
+  String type();
+
+  /**
+   * Evaluates the expression against the given context.
+   *
+   * @param evaluator the expression to evaluate — guaranteed to match {@link #type()}
+   * @param context the current case state
+   * @return {@code true} if the expression matches, {@code false} otherwise
+   */
+  boolean evaluate(ExpressionEvaluator evaluator, StateContext context);
+}

--- a/api/src/main/java/io/casehub/api/model/evaluator/ExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/ExpressionEvaluator.java
@@ -15,4 +15,12 @@
  */
 package io.casehub.api.model.evaluator;
 
-public interface ExpressionEvaluator {}
+public interface ExpressionEvaluator {
+
+  /**
+   * Returns the type identifier for this evaluator, used by {@link
+   * io.casehub.api.engine.ExpressionEngine} implementations to declare which evaluator type they
+   * handle.
+   */
+  String type();
+}

--- a/api/src/main/java/io/casehub/api/model/evaluator/ExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/ExpressionEvaluator.java
@@ -15,4 +15,4 @@
  */
 package io.casehub.api.model.evaluator;
 
-public sealed interface ExpressionEvaluator permits JQExpressionEvaluator {}
+public interface ExpressionEvaluator {}

--- a/api/src/main/java/io/casehub/api/model/evaluator/JQExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/JQExpressionEvaluator.java
@@ -15,4 +15,12 @@
  */
 package io.casehub.api.model.evaluator;
 
-public record JQExpressionEvaluator(String expression) implements ExpressionEvaluator {}
+public record JQExpressionEvaluator(String expression) implements ExpressionEvaluator {
+
+  public static final String TYPE = "jq";
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
@@ -26,10 +26,17 @@ import java.util.function.Predicate;
  */
 public final class LambdaExpressionEvaluator implements ExpressionEvaluator {
 
+  public static final String TYPE = "lambda";
+
   private final Predicate<StateContext> predicate;
 
   public LambdaExpressionEvaluator(final Predicate<StateContext> predicate) {
     this.predicate = predicate;
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
   }
 
   public boolean test(final StateContext context) {

--- a/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.evaluator;
+
+import io.casehub.api.context.StateContext;
+import java.util.function.Predicate;
+
+/**
+ * An {@link ExpressionEvaluator} backed by a Java lambda. Provides type-safe, IDE-friendly
+ * conditions for Java DSL users as an alternative to {@link JQExpressionEvaluator} JQ strings.
+ *
+ * <p>Not serialisable — use {@link JQExpressionEvaluator} for YAML-defined cases.
+ */
+public final class LambdaExpressionEvaluator implements ExpressionEvaluator {
+
+  private final Predicate<StateContext> predicate;
+
+  public LambdaExpressionEvaluator(final Predicate<StateContext> predicate) {
+    this.predicate = predicate;
+  }
+
+  public boolean test(final StateContext context) {
+    return predicate.test(context);
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseDefinitionRegistry.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseDefinitionRegistry.java
@@ -17,6 +17,11 @@ package io.casehub.engine.internal.engine;
 
 import io.casehub.api.engine.CaseHub;
 import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.DispatchRule;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.Milestone;
+import io.casehub.api.model.PredicateBasedCompletion;
 import io.casehub.engine.internal.model.CaseMetaModel;
 import io.casehub.engine.internal.util.ReactiveUtils;
 import io.quarkus.runtime.StartupEvent;
@@ -52,6 +57,8 @@ public class CaseDefinitionRegistry {
 
   @Inject Vertx vertx;
 
+  @Inject ExpressionEngineRegistry expressionEngineRegistry;
+
   // TODO this must be reworked
   void onStart(@Observes @Priority(10) StartupEvent ev) {
     ReactiveUtils.runOnSafeVertxContext(vertx, this::registerKnownDefinitions)
@@ -72,6 +79,13 @@ public class CaseDefinitionRegistry {
   }
 
   private Uni<CaseMetaModel> registerCaseDefinition(CaseHubDefinition model) {
+    try {
+      validateExpressions(model);
+    } catch (IllegalArgumentException e) {
+      LOG.errorf("Case definition '%s' rejected: %s", model.getName(), e.getMessage());
+      return Uni.createFrom().failure(e);
+    }
+
     LOG.info(
         "Registering case: "
             + model.getName()
@@ -117,6 +131,30 @@ public class CaseDefinitionRegistry {
 
   public CaseHubDefinition getCaseDefinition(CaseMetaModel definition) {
     return registry.get(definition);
+  }
+
+  private void validateExpressions(CaseHubDefinition definition) {
+    if (definition.getRules() != null) {
+      for (DispatchRule rule : definition.getRules()) {
+        if (rule.getOn() instanceof ContextChangeTrigger cct) {
+          expressionEngineRegistry.validate(cct.getFilter());
+        }
+        expressionEngineRegistry.validate(rule.getWhen());
+      }
+    }
+    if (definition.getMilestones() != null) {
+      for (Milestone milestone : definition.getMilestones()) {
+        expressionEngineRegistry.validate(milestone.getCondition());
+      }
+    }
+    if (definition.getGoals() != null) {
+      for (Goal goal : definition.getGoals()) {
+        expressionEngineRegistry.validate(goal.getCondition());
+      }
+    }
+    if (definition.getCompletion() instanceof PredicateBasedCompletion pbc) {
+      expressionEngineRegistry.validate(pbc.getDoneWhen());
+    }
   }
 
   public CaseMetaModel getCaseMetaModel(CaseHubDefinition caseDefinition) {

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseDefinitionRegistry.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseDefinitionRegistry.java
@@ -78,7 +78,7 @@ public class CaseDefinitionRegistry {
                 .replaceWithVoid());
   }
 
-  private Uni<CaseMetaModel> registerCaseDefinition(CaseHubDefinition model) {
+  Uni<CaseMetaModel> registerCaseDefinition(CaseHubDefinition model) {
     try {
       validateExpressions(model);
     } catch (IllegalArgumentException e) {

--- a/engine/src/main/java/io/casehub/engine/internal/engine/ExpressionEngineRegistry.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/ExpressionEngineRegistry.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.engine.ExpressionEngine;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+/**
+ * Dispatches expression evaluation to the appropriate {@link ExpressionEngine} by evaluator type.
+ *
+ * <p>All CDI beans implementing {@link ExpressionEngine} are discovered automatically. Add a new
+ * engine bean to support additional expression languages without modifying this class or the
+ * runtime.
+ */
+@ApplicationScoped
+public class ExpressionEngineRegistry {
+
+  private static final Logger LOG = Logger.getLogger(ExpressionEngineRegistry.class);
+
+  @Inject Instance<ExpressionEngine> engines;
+
+  /**
+   * Evaluates the expression against the given context.
+   *
+   * @param evaluator the expression to evaluate; returns {@code true} if {@code null}
+   * @param context the current case state
+   * @return {@code true} if the expression matches or is absent
+   * @throws IllegalArgumentException if no engine is registered for the evaluator type
+   */
+  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+    if (evaluator == null) {
+      return true;
+    }
+    final String type = evaluator.type();
+    for (ExpressionEngine engine : engines) {
+      if (engine.type().equals(type)) {
+        return engine.evaluate(evaluator, context);
+      }
+    }
+    throw new IllegalArgumentException("No ExpressionEngine registered for type '" + type + "'");
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/ExpressionEngineRegistry.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/ExpressionEngineRegistry.java
@@ -57,4 +57,26 @@ public class ExpressionEngineRegistry {
     }
     throw new IllegalArgumentException("No ExpressionEngine registered for type '" + type + "'");
   }
+
+  /**
+   * Validates the expression syntax without evaluating it against any context. Blocks case
+   * definition registration if the expression is invalid.
+   *
+   * @param evaluator the expression to validate; no-op if {@code null}
+   * @throws IllegalArgumentException if the expression is syntactically invalid or no engine is
+   *     registered for the evaluator type
+   */
+  public void validate(final ExpressionEvaluator evaluator) {
+    if (evaluator == null) {
+      return;
+    }
+    final String type = evaluator.type();
+    for (ExpressionEngine engine : engines) {
+      if (engine.type().equals(type)) {
+        engine.validate(evaluator);
+        return;
+      }
+    }
+    throw new IllegalArgumentException("No ExpressionEngine registered for type '" + type + "'");
+  }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/JQExpressionEngine.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/JQExpressionEngine.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.engine.ExpressionEngine;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.engine.internal.jq.JQEvaluator;
+import io.casehub.engine.internal.jq.ValidationResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/** {@link ExpressionEngine} for JQ expressions. */
+@ApplicationScoped
+public class JQExpressionEngine implements ExpressionEngine {
+
+  @Inject JQEvaluator jqEvaluator;
+
+  @Override
+  public String type() {
+    return JQExpressionEvaluator.TYPE;
+  }
+
+  @Override
+  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+    final String expr = ((JQExpressionEvaluator) evaluator).expression();
+    if (expr == null || expr.isBlank()) {
+      return true;
+    }
+    final ValidationResult result = jqEvaluator.eval(expr, context.asJsonNode());
+    return result.ok() && result.isTrue();
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/JQExpressionEngine.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/JQExpressionEngine.java
@@ -23,6 +23,8 @@ import io.casehub.engine.internal.jq.JQEvaluator;
 import io.casehub.engine.internal.jq.ValidationResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Versions;
 
 /** {@link ExpressionEngine} for JQ expressions. */
 @ApplicationScoped
@@ -43,5 +45,19 @@ public class JQExpressionEngine implements ExpressionEngine {
     }
     final ValidationResult result = jqEvaluator.eval(expr, context.asJsonNode());
     return result.ok() && result.isTrue();
+  }
+
+  @Override
+  public void validate(final ExpressionEvaluator evaluator) {
+    final String expr = ((JQExpressionEvaluator) evaluator).expression();
+    if (expr == null || expr.isBlank()) {
+      return;
+    }
+    try {
+      JsonQuery.compile(expr, Versions.JQ_1_6);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Invalid JQ expression '" + expr + "': " + e.getMessage(), e);
+    }
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/LambdaExpressionEngine.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/LambdaExpressionEngine.java
@@ -34,4 +34,10 @@ public class LambdaExpressionEngine implements ExpressionEngine {
   public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
     return ((LambdaExpressionEvaluator) evaluator).test(context);
   }
+
+  @Override
+  public void validate(final ExpressionEvaluator evaluator) {
+    // Lambda predicates are validated by the Java compiler at the call site;
+    // nothing further to check at registration time.
+  }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/LambdaExpressionEngine.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/LambdaExpressionEngine.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import io.casehub.api.context.StateContext;
+import io.casehub.api.engine.ExpressionEngine;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/** {@link ExpressionEngine} for Java lambda expressions. */
+@ApplicationScoped
+public class LambdaExpressionEngine implements ExpressionEngine {
+
+  @Override
+  public String type() {
+    return LambdaExpressionEvaluator.TYPE;
+  }
+
+  @Override
+  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+    return ((LambdaExpressionEvaluator) evaluator).test(context);
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
-import io.casehub.api.context.StateContext;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseHubDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
@@ -23,17 +22,13 @@ import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
-import io.casehub.api.model.evaluator.ExpressionEvaluator;
-import io.casehub.api.model.evaluator.JQExpressionEvaluator;
-import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
+import io.casehub.engine.internal.engine.ExpressionEngineRegistry;
 import io.casehub.engine.internal.event.CaseStateContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.GoalReachedEvent;
 import io.casehub.engine.internal.event.MilestoneReachedEvent;
 import io.casehub.engine.internal.event.WorkerScheduleEvent;
-import io.casehub.engine.internal.jq.JQEvaluator;
-import io.casehub.engine.internal.jq.ValidationResult;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.model.CaseMetaModel;
 import io.casehub.engine.internal.model.CaseState;
@@ -55,7 +50,7 @@ public class CaseStateContextChangedEventHandler {
 
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
 
-  @Inject JQEvaluator jqEvaluator;
+  @Inject ExpressionEngineRegistry expressionEngineRegistry;
 
   @ConsumeEvent(value = EventBusAddresses.CONTEXT_CHANGED)
   public Uni<Void> onCaseStateContextChangedEventHandler(CaseStateContextChangedEvent event) {
@@ -105,7 +100,7 @@ public class CaseStateContextChangedEventHandler {
         continue;
       }
 
-      if (!evaluateFilter(cct.getFilter(), caseInstance.getStateContext())) {
+      if (!expressionEngineRegistry.evaluate(cct.getFilter(), caseInstance.getStateContext())) {
         continue;
       }
 
@@ -132,7 +127,8 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Milestone milestone : milestones) {
-      if (!evaluateFilter(milestone.getCondition(), caseInstance.getStateContext())) continue;
+      if (!expressionEngineRegistry.evaluate(
+          milestone.getCondition(), caseInstance.getStateContext())) continue;
 
       LOG.infof("Milestone '%s' REACHED! Publishing MilestoneReachedEvent", milestone.getName());
 
@@ -150,7 +146,8 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Goal goal : goals) {
-      if (!evaluateFilter(goal.getCondition(), caseInstance.getStateContext())) continue;
+      if (!expressionEngineRegistry.evaluate(goal.getCondition(), caseInstance.getStateContext()))
+        continue;
 
       LOG.infof("Goal '%s' REACHED! Publishing GoalReachedEvent", goal.getName());
 
@@ -158,21 +155,6 @@ public class CaseStateContextChangedEventHandler {
     }
 
     return Uni.createFrom().voidItem();
-  }
-
-  private boolean evaluateFilter(ExpressionEvaluator evaluator, StateContext context) {
-    if (evaluator == null) return true;
-    if (evaluator instanceof JQExpressionEvaluator jq) {
-      String expr = jq.expression();
-      if (expr == null || expr.isBlank()) return true;
-      ValidationResult result = jqEvaluator.eval(expr, context.asJsonNode());
-      return result.ok() && result.isTrue();
-    }
-    if (evaluator instanceof LambdaExpressionEvaluator lambda) {
-      return lambda.test(context);
-    }
-    LOG.warnf("Unknown ExpressionEvaluator type: %s", evaluator.getClass().getSimpleName());
-    return false;
   }
 
   private Uni<Void> publishWorkerSchedules(

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
+import io.casehub.api.context.StateContext;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseHubDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
@@ -22,7 +23,9 @@ import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
 import io.casehub.engine.internal.event.CaseStateContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
@@ -102,11 +105,7 @@ public class CaseStateContextChangedEventHandler {
         continue;
       }
 
-      String jqExpression = normalizeJqFilter(rule, cct);
-
-      ValidationResult matches =
-          jqEvaluator.eval(jqExpression, caseInstance.getStateContext().asJsonNode());
-      if (!matches.ok() || !matches.isTrue()) {
+      if (!evaluateFilter(cct.getFilter(), caseInstance.getStateContext())) {
         continue;
       }
 
@@ -133,13 +132,7 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Milestone milestone : milestones) {
-      if (milestone.getCondition() == null) continue;
-      String conditionExpr = ((JQExpressionEvaluator) milestone.getCondition()).expression();
-      if (conditionExpr == null || conditionExpr.isBlank()) continue;
-
-      ValidationResult result =
-          jqEvaluator.eval(conditionExpr, caseInstance.getStateContext().asJsonNode());
-      if (!result.ok() || !result.isTrue()) continue;
+      if (!evaluateFilter(milestone.getCondition(), caseInstance.getStateContext())) continue;
 
       LOG.infof("Milestone '%s' REACHED! Publishing MilestoneReachedEvent", milestone.getName());
 
@@ -157,13 +150,7 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Goal goal : goals) {
-      if (goal.getCondition() == null) continue;
-      String conditionExpr = ((JQExpressionEvaluator) goal.getCondition()).expression();
-      if (conditionExpr == null || conditionExpr.isBlank()) continue;
-
-      ValidationResult result =
-          jqEvaluator.eval(conditionExpr, caseInstance.getStateContext().asJsonNode());
-      if (!result.ok() || !result.isTrue()) continue;
+      if (!evaluateFilter(goal.getCondition(), caseInstance.getStateContext())) continue;
 
       LOG.infof("Goal '%s' REACHED! Publishing GoalReachedEvent", goal.getName());
 
@@ -173,17 +160,19 @@ public class CaseStateContextChangedEventHandler {
     return Uni.createFrom().voidItem();
   }
 
-  private String normalizeJqFilter(DispatchRule rule, ContextChangeTrigger cct) {
-    if (cct.getFilter() == null) {
-      LOG.debugf("Rule '%s' has no JQ filter defined, treating as always true", rule.getName());
-      return ".";
+  private boolean evaluateFilter(ExpressionEvaluator evaluator, StateContext context) {
+    if (evaluator == null) return true;
+    if (evaluator instanceof JQExpressionEvaluator jq) {
+      String expr = jq.expression();
+      if (expr == null || expr.isBlank()) return true;
+      ValidationResult result = jqEvaluator.eval(expr, context.asJsonNode());
+      return result.ok() && result.isTrue();
     }
-    String jqExpression = ((JQExpressionEvaluator) cct.getFilter()).expression();
-    if (jqExpression == null || jqExpression.isBlank()) {
-      LOG.debugf("Rule '%s' has no JQ filter defined, treating as always true", rule.getName());
-      return ".";
+    if (evaluator instanceof LambdaExpressionEvaluator lambda) {
+      return lambda.test(context);
     }
-    return jqExpression;
+    LOG.warnf("Unknown ExpressionEvaluator type: %s", evaluator.getClass().getSimpleName());
+    return false;
   }
 
   private Uni<Void> publishWorkerSchedules(

--- a/engine/src/test/java/io/casehub/engine/internal/engine/CaseDefinitionRegistryValidationTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/engine/CaseDefinitionRegistryValidationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.DispatchRule;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Milestone;
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@DisplayName("CaseDefinitionRegistry — expression validation")
+class CaseDefinitionRegistryValidationTest {
+
+  @Inject CaseDefinitionRegistry registry;
+
+  private static final Capability CAPABILITY =
+      Capability.builder()
+          .name("test-capability")
+          .inputSchema("{ id: .id }")
+          .outputSchema("{ result: . }")
+          .description("Test capability")
+          .build();
+
+  @Test
+  @DisplayName("invalid JQ in rule trigger filter blocks registration")
+  void invalidJQInTriggerFilter_blocksRegistration() {
+    final var definition =
+        CaseHubDefinition.builder()
+            .namespace("test-validation")
+            .name("bad-trigger-filter")
+            .version("99.0.0")
+            .rules(
+                DispatchRule.builder()
+                    .name("bad-rule")
+                    .capability(CAPABILITY)
+                    .on(new ContextChangeTrigger(".status ??? invalid"))
+                    .build())
+            .build();
+
+    final var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                registry.registerCaseDefinition(definition).await().atMost(Duration.ofSeconds(5)));
+    assertTrue(ex.getMessage().contains("Invalid JQ expression"));
+  }
+
+  @Test
+  @DisplayName("invalid JQ in rule when-condition blocks registration")
+  void invalidJQInWhenCondition_blocksRegistration() {
+    final var definition =
+        CaseHubDefinition.builder()
+            .namespace("test-validation")
+            .name("bad-when-condition")
+            .version("99.0.0")
+            .rules(
+                DispatchRule.builder()
+                    .name("bad-rule")
+                    .capability(CAPABILITY)
+                    .on(new ContextChangeTrigger(".status == \"ready\""))
+                    .when(new JQExpressionEvaluator(".count ??? broken"))
+                    .build())
+            .build();
+
+    final var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                registry.registerCaseDefinition(definition).await().atMost(Duration.ofSeconds(5)));
+    assertTrue(ex.getMessage().contains("Invalid JQ expression"));
+  }
+
+  @Test
+  @DisplayName("invalid JQ in goal condition blocks registration")
+  void invalidJQInGoalCondition_blocksRegistration() {
+    final var definition =
+        CaseHubDefinition.builder()
+            .namespace("test-validation")
+            .name("bad-goal")
+            .version("99.0.0")
+            .goals(
+                Goal.builder()
+                    .name("bad-goal")
+                    .condition(new JQExpressionEvaluator(".result ??? oops"))
+                    .kind(GoalKind.SUCCESS)
+                    .build())
+            .build();
+
+    final var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                registry.registerCaseDefinition(definition).await().atMost(Duration.ofSeconds(5)));
+    assertTrue(ex.getMessage().contains("Invalid JQ expression"));
+  }
+
+  @Test
+  @DisplayName("invalid JQ in milestone condition blocks registration")
+  void invalidJQInMilestoneCondition_blocksRegistration() {
+    final var definition =
+        CaseHubDefinition.builder()
+            .namespace("test-validation")
+            .name("bad-milestone")
+            .version("99.0.0")
+            .milestones(
+                Milestone.builder()
+                    .name("bad-milestone")
+                    .condition(new JQExpressionEvaluator(".phase ??? nope"))
+                    .build())
+            .build();
+
+    final var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                registry.registerCaseDefinition(definition).await().atMost(Duration.ofSeconds(5)));
+    assertTrue(ex.getMessage().contains("Invalid JQ expression"));
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/engine/ExpressionEngineRegistryTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/engine/ExpressionEngineRegistryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import io.casehub.engine.internal.context.StateContextImpl;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@DisplayName("ExpressionEngineRegistry")
+class ExpressionEngineRegistryTest {
+
+  @Inject ExpressionEngineRegistry registry;
+
+  @Nested
+  @DisplayName("evaluate()")
+  class Evaluate {
+
+    @Test
+    @DisplayName("returns true for null evaluator")
+    void nullEvaluator_returnsTrue() {
+      final var context = new StateContextImpl(Map.of());
+      assertTrue(registry.evaluate(null, context));
+    }
+
+    @Test
+    @DisplayName("JQ — returns true when expression matches context")
+    void jq_returnsTrueOnMatch() {
+      final var context = new StateContextImpl(Map.of("status", "ready"));
+      final var evaluator = new JQExpressionEvaluator(".status == \"ready\"");
+      assertTrue(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("JQ — returns false when expression does not match context")
+    void jq_returnsFalseOnNoMatch() {
+      final var context = new StateContextImpl(Map.of("status", "pending"));
+      final var evaluator = new JQExpressionEvaluator(".status == \"ready\"");
+      assertFalse(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("JQ — returns true for null expression (treat as always-match)")
+    void jq_nullExpression_returnsTrue() {
+      final var context = new StateContextImpl(Map.of());
+      final var evaluator = new JQExpressionEvaluator(null);
+      assertTrue(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("JQ — returns true for blank expression (treat as always-match)")
+    void jq_blankExpression_returnsTrue() {
+      final var context = new StateContextImpl(Map.of());
+      final var evaluator = new JQExpressionEvaluator("   ");
+      assertTrue(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("Lambda — returns true when predicate matches")
+    void lambda_returnsTrueOnMatch() {
+      final var context = new StateContextImpl(Map.of("score", 10));
+      final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("score") != null);
+      assertTrue(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("Lambda — returns false when predicate does not match")
+    void lambda_returnsFalseOnNoMatch() {
+      final var context = new StateContextImpl(Map.of());
+      final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("score") != null);
+      assertFalse(registry.evaluate(evaluator, context));
+    }
+
+    @Test
+    @DisplayName("throws IllegalArgumentException for unregistered evaluator type")
+    void unknownType_throws() {
+      final var context = new StateContextImpl(Map.of());
+      final var unknown =
+          new io.casehub.api.model.evaluator.ExpressionEvaluator() {
+            @Override
+            public String type() {
+              return "drools";
+            }
+          };
+      final var ex =
+          assertThrows(IllegalArgumentException.class, () -> registry.evaluate(unknown, context));
+      assertTrue(ex.getMessage().contains("drools"));
+    }
+  }
+
+  @Nested
+  @DisplayName("validate()")
+  class Validate {
+
+    @Test
+    @DisplayName("no-op for null evaluator")
+    void nullEvaluator_doesNotThrow() {
+      assertDoesNotThrow(() -> registry.validate(null));
+    }
+
+    @Test
+    @DisplayName("JQ — passes for valid expression")
+    void jq_validExpression_doesNotThrow() {
+      assertDoesNotThrow(
+          () -> registry.validate(new JQExpressionEvaluator(".status == \"ready\"")));
+    }
+
+    @Test
+    @DisplayName("JQ — passes for null expression")
+    void jq_nullExpression_doesNotThrow() {
+      assertDoesNotThrow(() -> registry.validate(new JQExpressionEvaluator(null)));
+    }
+
+    @Test
+    @DisplayName("JQ — throws IllegalArgumentException for invalid syntax")
+    void jq_invalidExpression_throws() {
+      final var ex =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> registry.validate(new JQExpressionEvaluator(".foo ??? broken")));
+      assertTrue(ex.getMessage().contains("Invalid JQ expression"));
+    }
+
+    @Test
+    @DisplayName("Lambda — no-op regardless of predicate")
+    void lambda_doesNotThrow() {
+      assertDoesNotThrow(() -> registry.validate(new LambdaExpressionEvaluator(ctx -> true)));
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/evaluator/LambdaExpressionEvaluatorTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/evaluator/LambdaExpressionEvaluatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.evaluator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import io.casehub.engine.internal.context.StateContextImpl;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("LambdaExpressionEvaluator")
+class LambdaExpressionEvaluatorTest {
+
+  @Test
+  @DisplayName("type() returns 'lambda'")
+  void type_returnsLambda() {
+    final var evaluator = new LambdaExpressionEvaluator(ctx -> true);
+    assertEquals(LambdaExpressionEvaluator.TYPE, evaluator.type());
+    assertEquals("lambda", evaluator.type());
+  }
+
+  @Test
+  @DisplayName("test() returns true when predicate matches")
+  void test_returnsTrueWhenPredicateMatches() {
+    final var context = new StateContextImpl(Map.of("status", "ready"));
+    final var evaluator = new LambdaExpressionEvaluator(ctx -> "ready".equals(ctx.get("status")));
+
+    assertTrue(evaluator.test(context));
+  }
+
+  @Test
+  @DisplayName("test() returns false when predicate does not match")
+  void test_returnsFalseWhenPredicateDoesNotMatch() {
+    final var context = new StateContextImpl(Map.of("status", "pending"));
+    final var evaluator = new LambdaExpressionEvaluator(ctx -> "ready".equals(ctx.get("status")));
+
+    assertFalse(evaluator.test(context));
+  }
+
+  @Test
+  @DisplayName("test() receives the exact context passed in")
+  void test_receivesExactContext() {
+    final var context = new StateContextImpl(Map.of("count", 42));
+    final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("count") != null);
+
+    assertTrue(evaluator.test(context));
+  }
+}


### PR DESCRIPTION
Closes #7
Refs #30

> **Note:** this PR stacks on #34. Should be merged after #34 lands, or rebased onto `main` once that happens.

## Summary

Adds expression syntax validation at case definition registration time so invalid expressions fail fast — before any case can start — with a clear error message.

## Changes

**`ExpressionEngine`** — adds `void validate(ExpressionEvaluator)` to the SPI

**`JQExpressionEngine.validate()`** — compiles the JQ expression via `JsonQuery.compile()`; throws `IllegalArgumentException` on invalid syntax

**`LambdaExpressionEngine.validate()`** — no-op; Java predicates are validated by the compiler at the call site

**`ExpressionEngineRegistry.validate()`** — dispatches to the correct engine by type, consistent with `evaluate()`

**`CaseDefinitionRegistry`** — `registerCaseDefinition()` made package-private to enable direct testing; calls `validateExpressions()` before persisting, covering:
- `DispatchRule` trigger filter and `when` condition
- `Milestone` condition
- `Goal` condition
- `PredicateBasedCompletion` predicate

## Test coverage

**`CaseDefinitionRegistryValidationTest`** — verifies invalid JQ in rule trigger, rule `when`, goal condition, and milestone condition all block registration with `IllegalArgumentException`.

**Deliberately not covered:** the positive path (valid expressions proceeding through `registerCaseDefinition()` to the DB). That method requires a Mutiny session unavailable from a test thread without additional plumbing. The positive path is already exercised by every existing `@QuarkusTest` — all valid `CaseHub` beans register at startup without error (`SimpleCaseHubBeanTest`, `MultiWorkerPipelineBeanTest`, etc.).

## Testing

All existing tests pass. `SignalTest#workerRunsOnceOnDuplicateSignal` is a pre-existing flaky test (#29), unrelated to this change.