### PR TITLE
refactor(api): rename DispatchRule → Binding, CaseHubDefinition → CaseDefinition

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git pull:*)",
+      "Bash(git remote:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git pull:*)",
-      "Bash(git remote:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ nb-configuration.xml
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+.claude/

--- a/api/src/main/java/io/casehub/api/engine/CaseHub.java
+++ b/api/src/main/java/io/casehub/api/engine/CaseHub.java
@@ -15,7 +15,7 @@
  */
 package io.casehub.api.engine;
 
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import jakarta.inject.Inject;
 import java.util.Map;
 import java.util.UUID;
@@ -25,7 +25,7 @@ public abstract class CaseHub {
 
   @Inject CaseHubRuntime runtime;
 
-  public abstract CaseHubDefinition getDefinition();
+  public abstract CaseDefinition getDefinition();
 
   public CompletionStage<UUID> startCase() {
     return runtime.startCase(getDefinition());

--- a/api/src/main/java/io/casehub/api/engine/CaseHubRuntime.java
+++ b/api/src/main/java/io/casehub/api/engine/CaseHubRuntime.java
@@ -15,16 +15,16 @@
  */
 package io.casehub.api.engine;
 
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
 public interface CaseHubRuntime {
 
-  CompletionStage<UUID> startCase(CaseHubDefinition definition);
+  CompletionStage<UUID> startCase(CaseDefinition definition);
 
-  CompletionStage<UUID> startCase(CaseHubDefinition definition, Map<String, Object> inputData);
+  CompletionStage<UUID> startCase(CaseDefinition definition, Map<String, Object> inputData);
 
   void signal(UUID caseId, String path, Object value);
 

--- a/api/src/main/java/io/casehub/api/model/Binding.java
+++ b/api/src/main/java/io/casehub/api/model/Binding.java
@@ -19,14 +19,14 @@ import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import java.util.Objects;
 
-public class DispatchRule {
+public class Binding {
 
   private final Capability capability;
   private final String name;
   private final Trigger on;
   private ExpressionEvaluator when;
 
-  public DispatchRule(String name, Capability capability, Trigger on) {
+  public Binding(String name, Capability capability, Trigger on) {
     this.name = name;
     this.capability = capability;
     this.on = on;
@@ -90,9 +90,9 @@ public class DispatchRule {
       return this;
     }
 
-    public DispatchRule build() {
-      DispatchRule rule =
-          new DispatchRule(
+    public Binding build() {
+      Binding rule =
+          new Binding(
               Objects.requireNonNull(name),
               Objects.requireNonNull(capability),
               Objects.requireNonNull(on));

--- a/api/src/main/java/io/casehub/api/model/CaseDefinition.java
+++ b/api/src/main/java/io/casehub/api/model/CaseDefinition.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class CaseHubDefinition {
+public class CaseDefinition {
 
   private final String namespace;
   private final String name;
@@ -30,12 +30,12 @@ public class CaseHubDefinition {
   private String summary;
   private final List<Capability> capabilities;
   private final List<Worker> workers;
-  private final List<DispatchRule> rules;
+  private final List<Binding> rules;
   private final List<Milestone> milestones;
   private final List<Goal> goals;
   private CaseCompletion completion;
 
-  public CaseHubDefinition(String namespace, String name, String version) {
+  public CaseDefinition(String namespace, String name, String version) {
     this.namespace = namespace;
     this.name = name;
     this.version = version;
@@ -90,7 +90,7 @@ public class CaseHubDefinition {
     return workers;
   }
 
-  public List<DispatchRule> getRules() {
+  public List<Binding> getRules() {
     return rules;
   }
 
@@ -123,7 +123,7 @@ public class CaseHubDefinition {
     private String summary;
     private List<Capability> capabilities;
     private List<Worker> workers;
-    private List<DispatchRule> rules;
+    private List<Binding> rules;
     private List<Milestone> milestones;
     private List<Goal> goals;
     private CaseCompletion completion;
@@ -175,12 +175,12 @@ public class CaseHubDefinition {
       return this;
     }
 
-    public Builder rules(List<DispatchRule> rules) {
+    public Builder rules(List<Binding> rules) {
       this.rules = rules;
       return this;
     }
 
-    public Builder rules(DispatchRule... rules) {
+    public Builder rules(Binding... rules) {
       this.rules = List.of(rules);
       return this;
     }
@@ -219,9 +219,9 @@ public class CaseHubDefinition {
       return this;
     }
 
-    public CaseHubDefinition build() {
-      CaseHubDefinition caseHubDefinition =
-          new CaseHubDefinition(
+    public CaseDefinition build() {
+      CaseDefinition caseHubDefinition =
+          new CaseDefinition(
               Objects.requireNonNull(namespace),
               Objects.requireNonNull(name),
               Objects.requireNonNull(version));
@@ -250,7 +250,7 @@ public class CaseHubDefinition {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof CaseHubDefinition that)) return false;
+    if (!(o instanceof CaseDefinition that)) return false;
     return Objects.equals(namespace, that.namespace)
         && Objects.equals(name, that.name)
         && Objects.equals(version, that.version);

--- a/api/src/main/java/io/casehub/api/model/CaseDefinition.java
+++ b/api/src/main/java/io/casehub/api/model/CaseDefinition.java
@@ -30,7 +30,7 @@ public class CaseDefinition {
   private String summary;
   private final List<Capability> capabilities;
   private final List<Worker> workers;
-  private final List<Binding> rules;
+  private final List<Binding> bindings;
   private final List<Milestone> milestones;
   private final List<Goal> goals;
   private CaseCompletion completion;
@@ -40,7 +40,7 @@ public class CaseDefinition {
     this.name = name;
     this.version = version;
     this.capabilities = new ArrayList<>();
-    this.rules = new ArrayList<>();
+    this.bindings = new ArrayList<>();
     this.milestones = new ArrayList<>();
     this.goals = new ArrayList<>();
     this.workers = new ArrayList<>();
@@ -90,8 +90,8 @@ public class CaseDefinition {
     return workers;
   }
 
-  public List<Binding> getRules() {
-    return rules;
+  public List<Binding> getBindings() {
+    return bindings;
   }
 
   public List<Milestone> getMilestones() {
@@ -123,7 +123,7 @@ public class CaseDefinition {
     private String summary;
     private List<Capability> capabilities;
     private List<Worker> workers;
-    private List<Binding> rules;
+    private List<Binding> bindings;
     private List<Milestone> milestones;
     private List<Goal> goals;
     private CaseCompletion completion;
@@ -175,13 +175,13 @@ public class CaseDefinition {
       return this;
     }
 
-    public Builder rules(List<Binding> rules) {
-      this.rules = rules;
+    public Builder bindings(List<Binding> bindings) {
+      this.bindings = bindings;
       return this;
     }
 
-    public Builder rules(Binding... rules) {
-      this.rules = List.of(rules);
+    public Builder bindings(Binding... bindings) {
+      this.bindings = List.of(bindings);
       return this;
     }
 
@@ -233,8 +233,8 @@ public class CaseDefinition {
       if (workers != null) {
         caseHubDefinition.workers.addAll(workers);
       }
-      if (rules != null) {
-        caseHubDefinition.rules.addAll(rules);
+      if (bindings != null) {
+        caseHubDefinition.bindings.addAll(bindings);
       }
       if (milestones != null) {
         caseHubDefinition.milestones.addAll(milestones);

--- a/api/src/main/java/io/casehub/api/model/Goal.java
+++ b/api/src/main/java/io/casehub/api/model/Goal.java
@@ -19,6 +19,40 @@ import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import java.util.Objects;
 
+/**
+ * A named outcome that a case is trying to achieve, with success or failure polarity.
+ *
+ * <p>Milestones and goals answer different questions:
+ *
+ * <ul>
+ *   <li><b>Goals</b> — what outcome are we trying to achieve? A goal carries {@link GoalKind}
+ *       (SUCCESS or FAILURE) and drives case completion via {@link
+ *       io.casehub.api.model.GoalBasedCompletion}. You <em>achieve</em> goals.
+ *   <li><b>Milestones</b> — where are we? A milestone marks a neutral point of progress on the way
+ *       to a goal. It has no success/failure polarity. You <em>pass</em> milestones.
+ * </ul>
+ *
+ * <p>Example — loan application case:
+ *
+ * <pre>{@code
+ * // Milestones: intermediate waypoints (no polarity)
+ * Milestone.builder().name("documents-received").condition(".docsUploaded == true").build()
+ * Milestone.builder().name("credit-check-complete").condition(".creditScore != null").build()
+ *
+ * // Goals: terminal outcomes (SUCCESS or FAILURE)
+ * Goal.builder().name("loan-approved").condition(".decision == \"approved\"").kind(GoalKind.SUCCESS).build()
+ * Goal.builder().name("loan-rejected").condition(".decision == \"rejected\"").kind(GoalKind.FAILURE).build()
+ * }</pre>
+ *
+ * <p>When a goal's condition becomes true, a {@code GoalReachedEvent} is published and recorded in
+ * the {@link io.casehub.engine.internal.history.EventLog}. If the goal is referenced by a {@link
+ * io.casehub.api.model.GoalBasedCompletion}, the engine evaluates whether the case should
+ * transition to COMPLETED or FAILED.
+ *
+ * <p>Non-terminal goals — goals not referenced in completion logic — behave as observable
+ * checkpoints with polarity. Use {@link Milestone} instead when the checkpoint has no
+ * success/failure meaning.
+ */
 public class Goal {
 
   private final String name;

--- a/api/src/main/java/io/casehub/api/model/Milestone.java
+++ b/api/src/main/java/io/casehub/api/model/Milestone.java
@@ -19,6 +19,47 @@ import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import java.util.Objects;
 
+/**
+ * A named waypoint that a case passes through on its way to a {@link Goal}.
+ *
+ * <p>Milestones and goals answer different questions:
+ *
+ * <ul>
+ *   <li><b>Milestones</b> — where are we? A milestone marks a point of progress. It has no
+ *       success/failure polarity; it is a neutral checkpoint that the case either has or has not
+ *       reached. You <em>pass</em> milestones.
+ *   <li><b>Goals</b> — what outcome are we trying to achieve? A goal carries {@link GoalKind}
+ *       (SUCCESS or FAILURE) and drives case completion. You <em>achieve</em> goals.
+ * </ul>
+ *
+ * <p>Example — loan application case:
+ *
+ * <pre>{@code
+ * // Milestones: intermediate waypoints
+ * Milestone.builder().name("documents-received").condition(".docsUploaded == true").build()
+ * Milestone.builder().name("credit-check-complete").condition(".creditScore != null").build()
+ * Milestone.builder().name("underwriting-done").condition(".underwritingStatus == \"complete\"").build()
+ *
+ * // Goals: terminal outcomes
+ * Goal.builder().name("loan-approved").condition(".decision == \"approved\"").kind(GoalKind.SUCCESS).build()
+ * Goal.builder().name("loan-rejected").condition(".decision == \"rejected\"").kind(GoalKind.FAILURE).build()
+ * }</pre>
+ *
+ * <h3>Lightweight use</h3>
+ *
+ * <p>By default, when the condition becomes true, a {@code MilestoneReachedEvent} is published on
+ * the event bus and recorded in the {@link io.casehub.engine.internal.history.EventLog} as {@code
+ * MILESTONE_REACHED}. No further tracking occurs. This is sufficient for observability, dashboards,
+ * and audit trails.
+ *
+ * <h3>Lifecycle use (Phase 2 — with {@code CasePlanModel})</h3>
+ *
+ * <p>When a {@code CasePlanModel} is present (the CMMN/Blackboard layer), milestones are promoted
+ * to lifecycle-tracked achievement markers with PENDING → ACHIEVED states. The {@code
+ * MilestoneReachedEvent} triggers the PENDING → ACHIEVED transition, and the achieved state can be
+ * referenced in stage exit criteria and case completion logic. The {@code Milestone} class itself
+ * does not change — the lifecycle tracking is a {@code CasePlanModel} concern.
+ */
 public class Milestone {
 
   private final String name;

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseDefinitionRegistry.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseDefinitionRegistry.java
@@ -16,7 +16,7 @@
 package io.casehub.engine.internal.engine;
 
 import io.casehub.api.engine.CaseHub;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.engine.internal.model.CaseMetaModel;
 import io.casehub.engine.internal.util.ReactiveUtils;
 import io.quarkus.runtime.StartupEvent;
@@ -37,12 +37,12 @@ import org.jboss.logging.Logger;
 
 /**
  * Registry for case definitions. TODO: it's a shim for now, simple becase it's not possible to
- * ser/deser CaseHubDefinition to yaml if it contains references to agents or java code
+ * ser/deser CaseDefinition to yaml if it contains references to agents or java code
  */
 @ApplicationScoped
 public class CaseDefinitionRegistry {
 
-  private final Map<CaseMetaModel, CaseHubDefinition> registry = new ConcurrentHashMap<>();
+  private final Map<CaseMetaModel, CaseDefinition> registry = new ConcurrentHashMap<>();
 
   private static final Logger LOG = Logger.getLogger(CaseDefinitionRegistry.class);
 
@@ -71,7 +71,7 @@ public class CaseDefinitionRegistry {
                 .replaceWithVoid());
   }
 
-  private Uni<CaseMetaModel> registerCaseDefinition(CaseHubDefinition model) {
+  private Uni<CaseMetaModel> registerCaseDefinition(CaseDefinition model) {
     LOG.info(
         "Registering case: "
             + model.getName()
@@ -115,12 +115,12 @@ public class CaseDefinitionRegistry {
             });
   }
 
-  public CaseHubDefinition getCaseDefinition(CaseMetaModel definition) {
+  public CaseDefinition getCaseDefinition(CaseMetaModel definition) {
     return registry.get(definition);
   }
 
-  public CaseMetaModel getCaseMetaModel(CaseHubDefinition caseDefinition) {
-    for (Map.Entry<CaseMetaModel, CaseHubDefinition> entry : registry.entrySet()) {
+  public CaseMetaModel getCaseMetaModel(CaseDefinition caseDefinition) {
+    for (Map.Entry<CaseMetaModel, CaseDefinition> entry : registry.entrySet()) {
       if (entry.getValue().equals(caseDefinition)) {
         return entry.getKey();
       }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -19,7 +19,7 @@ import static io.casehub.engine.internal.event.EventBusAddresses.CASE_STARTED;
 import static io.casehub.engine.internal.event.EventBusAddresses.SIGNAL_RECEIVED;
 
 import io.casehub.api.context.StateContext;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.event.CaseStartedEvent;
 import io.casehub.engine.internal.event.SignalReceivedEvent;
@@ -49,7 +49,7 @@ class CaseHubReactor {
 
   @Inject EventBus eventBus;
 
-  CompletionStage<UUID> startCase(CaseHubDefinition definition, StateContext context) {
+  CompletionStage<UUID> startCase(CaseDefinition definition, StateContext context) {
     return getCaseInstance(definition, context)
         .invoke(
             instance -> {
@@ -61,7 +61,7 @@ class CaseHubReactor {
         .subscribeAsCompletionStage();
   }
 
-  private Uni<CaseInstance> getCaseInstance(CaseHubDefinition definition, StateContext context) {
+  private Uni<CaseInstance> getCaseInstance(CaseDefinition definition, StateContext context) {
     CaseMetaModel model = caseDefinitionRegistry.getCaseMetaModel(definition);
 
     CaseInstance instance = new CaseInstance();

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
@@ -16,7 +16,7 @@
 package io.casehub.engine.internal.engine;
 
 import io.casehub.api.engine.CaseHubRuntime;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.engine.internal.context.StateContextImpl;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -30,13 +30,12 @@ class CaseHubRuntimeImpl implements CaseHubRuntime {
   @Inject CaseHubReactor reactor;
 
   @Override
-  public CompletionStage<UUID> startCase(CaseHubDefinition definition) {
+  public CompletionStage<UUID> startCase(CaseDefinition definition) {
     return reactor.startCase(definition, new StateContextImpl());
   }
 
   @Override
-  public CompletionStage<UUID> startCase(
-      CaseHubDefinition definition, Map<String, Object> inputData) {
+  public CompletionStage<UUID> startCase(CaseDefinition definition, Map<String, Object> inputData) {
     return reactor.startCase(definition, new StateContextImpl(inputData));
   }
 

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
@@ -88,8 +88,8 @@ public class CaseStateContextChangedEventHandler {
   }
 
   private Uni<Void> rules(CaseInstance caseInstance, CaseDefinition definition) {
-    List<Binding> rules = definition.getRules();
-    if (rules == null || rules.isEmpty()) {
+    List<Binding> bindings = definition.getBindings();
+    if (bindings == null || bindings.isEmpty()) {
       return Uni.createFrom().voidItem();
     }
 
@@ -97,7 +97,7 @@ public class CaseStateContextChangedEventHandler {
 
     List<Uni<Void>> unis = new ArrayList<>();
 
-    for (Binding rule : rules) {
+    for (Binding rule : bindings) {
       if (!(rule.getOn() instanceof ContextChangeTrigger cct)) {
         continue;
       }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStateContextChangedEventHandler.java
@@ -15,10 +15,10 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
+import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
-import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
@@ -62,7 +62,7 @@ public class CaseStateContextChangedEventHandler {
     }
 
     CaseMetaModel caseMetaModel = caseInstance.getCaseMetaModel();
-    CaseHubDefinition caseHubDefinition = caseDefinitionRegistry.getCaseDefinition(caseMetaModel);
+    CaseDefinition caseHubDefinition = caseDefinitionRegistry.getCaseDefinition(caseMetaModel);
 
     if (caseHubDefinition == null) {
       return Uni.createFrom()
@@ -87,8 +87,8 @@ public class CaseStateContextChangedEventHandler {
                     t, "Failed handling context changed for caseId: %s", caseInstance.getUuid()));
   }
 
-  private Uni<Void> rules(CaseInstance caseInstance, CaseHubDefinition definition) {
-    List<DispatchRule> rules = definition.getRules();
+  private Uni<Void> rules(CaseInstance caseInstance, CaseDefinition definition) {
+    List<Binding> rules = definition.getRules();
     if (rules == null || rules.isEmpty()) {
       return Uni.createFrom().voidItem();
     }
@@ -97,7 +97,7 @@ public class CaseStateContextChangedEventHandler {
 
     List<Uni<Void>> unis = new ArrayList<>();
 
-    for (DispatchRule rule : rules) {
+    for (Binding rule : rules) {
       if (!(rule.getOn() instanceof ContextChangeTrigger cct)) {
         continue;
       }
@@ -126,7 +126,7 @@ public class CaseStateContextChangedEventHandler {
     return Uni.combine().all().unis(unis).discardItems();
   }
 
-  private Uni<Void> milestones(CaseInstance caseInstance, CaseHubDefinition definition) {
+  private Uni<Void> milestones(CaseInstance caseInstance, CaseDefinition definition) {
     List<Milestone> milestones = definition.getMilestones();
     if (milestones == null || milestones.isEmpty()) {
       return Uni.createFrom().voidItem();
@@ -150,7 +150,7 @@ public class CaseStateContextChangedEventHandler {
     return Uni.createFrom().voidItem();
   }
 
-  private Uni<Void> goals(CaseInstance caseInstance, CaseHubDefinition definition) {
+  private Uni<Void> goals(CaseInstance caseInstance, CaseDefinition definition) {
     List<Goal> goals = definition.getGoals();
     if (goals == null || goals.isEmpty()) {
       return Uni.createFrom().voidItem();
@@ -173,7 +173,7 @@ public class CaseStateContextChangedEventHandler {
     return Uni.createFrom().voidItem();
   }
 
-  private String normalizeJqFilter(DispatchRule rule, ContextChangeTrigger cct) {
+  private String normalizeJqFilter(Binding rule, ContextChangeTrigger cct) {
     if (cct.getFilter() == null) {
       LOG.debugf("Rule '%s' has no JQ filter defined, treating as always true", rule.getName());
       return ".";
@@ -187,7 +187,7 @@ public class CaseStateContextChangedEventHandler {
   }
 
   private Uni<Void> publishWorkerSchedules(
-      CaseInstance caseInstance, List<Worker> workers, DispatchRule rule, Capability capability) {
+      CaseInstance caseInstance, List<Worker> workers, Binding rule, Capability capability) {
 
     if (workers == null || workers.isEmpty()) {
       LOG.warnf(

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/GoalReachedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/GoalReachedEventHandler.java
@@ -19,7 +19,7 @@ import static io.casehub.engine.internal.history.CaseHubEventType.GOAL_REACHED;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.CaseCompletion;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalBasedCompletion;
 import io.casehub.api.model.GoalExpression;
@@ -56,7 +56,7 @@ public class GoalReachedEventHandler {
   @ConsumeEvent(value = EventBusAddresses.GOAL_REACHED)
   public Uni<Void> onGoalReachedEventHandler(GoalReachedEvent event) {
     CaseInstance caseInstance = event.caseInstance();
-    CaseHubDefinition definition =
+    CaseDefinition definition =
         caseDefinitionRegistry.getCaseDefinition(caseInstance.getCaseMetaModel());
     Goal goal = event.goal();
 

--- a/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
@@ -20,7 +20,7 @@ import static org.quartz.TriggerBuilder.newTrigger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ExecutionPolicy;
 import io.casehub.api.model.RetryPolicy;
 import io.casehub.api.model.Worker;
@@ -191,11 +191,11 @@ public class WorkerExecutionJobListener implements JobListener {
   }
 
   private RetryPolicy resolveRetryPolicy(String jobName, CaseInstance instance, String workerId) {
-    CaseHubDefinition definition =
+    CaseDefinition definition =
         caseDefinitionRegistry.getCaseDefinition(instance.getCaseMetaModel());
     if (definition == null) {
-      LOG.errorf("Cannot reschedule job %s: CaseHubDefinition not found", jobName);
-      throw new RuntimeException("CaseHubDefinition not found for caseId=" + instance.getUuid());
+      LOG.errorf("Cannot reschedule job %s: CaseDefinition not found", jobName);
+      throw new RuntimeException("CaseDefinition not found for caseId=" + instance.getUuid());
     }
 
     Worker worker =

--- a/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionTask.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionTask.java
@@ -19,7 +19,7 @@ import static io.casehub.engine.internal.event.EventBusAddresses.WORKER_EXECUTIO
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.Worker;
 import io.casehub.engine.internal.context.StateContextImpl;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
@@ -94,12 +94,12 @@ public class WorkerExecutionTask implements Job {
             .await()
             .atMost(Duration.ofSeconds(10));
 
-    CaseHubDefinition definition =
+    CaseDefinition definition =
         caseDefinitionRegistry.getCaseDefinition(instance.getCaseMetaModel());
 
     if (definition == null) {
       throw new JobExecutionException(
-          "CaseHubDefinition not found for caseId=" + eventLog.getCaseId());
+          "CaseDefinition not found for caseId=" + eventLog.getCaseId());
     }
     String workflowId = eventLog.getWorkerId();
     String capabilityName = eventLog.getMetadata().get("capabilityName").asText();

--- a/engine/src/test/java/io/casehub/engine/AgentPipelineBean.java
+++ b/engine/src/test/java/io/casehub/engine/AgentPipelineBean.java
@@ -20,10 +20,10 @@ import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.agent;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.get;
 
 import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
-import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
@@ -45,7 +45,7 @@ public class AgentPipelineBean extends CaseHub {
   }
 
   @Override
-  public CaseHubDefinition getDefinition() {
+  public CaseDefinition getDefinition() {
 
     // --- Capabilities ---
 
@@ -81,7 +81,7 @@ public class AgentPipelineBean extends CaseHub {
             .description("Document review is complete with sentiment and summary")
             .build();
 
-    return CaseHubDefinition.builder()
+    return CaseDefinition.builder()
         .namespace("test")
         .name("Agent Document Review Pipeline")
         .version("1.0.0")
@@ -125,17 +125,17 @@ public class AgentPipelineBean extends CaseHub {
                 .description("Summarizes document content via LLM")
                 .build())
         .rules(
-            DispatchRule.builder()
+            Binding.builder()
                 .name("trigger-on-submitted")
                 .capability(fetchCap)
                 .on(new ContextChangeTrigger(".step == \"submitted\""))
                 .build(),
-            DispatchRule.builder()
+            Binding.builder()
                 .name("trigger-on-fetched")
                 .capability(sentimentCap)
                 .on(new ContextChangeTrigger(".step == \"fetched\""))
                 .build(),
-            DispatchRule.builder()
+            Binding.builder()
                 .name("trigger-on-analyzed")
                 .capability(summaryCap)
                 .on(new ContextChangeTrigger(".step == \"analyzed\""))

--- a/engine/src/test/java/io/casehub/engine/AgentPipelineBean.java
+++ b/engine/src/test/java/io/casehub/engine/AgentPipelineBean.java
@@ -124,7 +124,7 @@ public class AgentPipelineBean extends CaseHub {
                         .build())
                 .description("Summarizes document content via LLM")
                 .build())
-        .rules(
+        .bindings(
             Binding.builder()
                 .name("trigger-on-submitted")
                 .capability(fetchCap)

--- a/engine/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
+++ b/engine/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
@@ -19,10 +19,10 @@ import static io.serverlessworkflow.fluent.func.FuncWorkflowBuilder.workflow;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
 
 import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
-import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
@@ -36,7 +36,7 @@ import java.util.Map;
 public class MultiWorkerPipelineBean extends CaseHub {
 
   @Override
-  public CaseHubDefinition getDefinition() {
+  public CaseDefinition getDefinition() {
 
     Capability validateCap =
         Capability.builder()
@@ -70,7 +70,7 @@ public class MultiWorkerPipelineBean extends CaseHub {
             .description("All pipeline steps completed successfully")
             .build();
 
-    return CaseHubDefinition.builder()
+    return CaseDefinition.builder()
         .namespace("test")
         .name("Multi-Worker Document Pipeline")
         .version("1.0.0")
@@ -143,17 +143,17 @@ public class MultiWorkerPipelineBean extends CaseHub {
                 .description("Publishes enriched documents")
                 .build())
         .rules(
-            DispatchRule.builder()
+            Binding.builder()
                 .name("trigger-on-received")
                 .capability(validateCap)
                 .on(new ContextChangeTrigger(".step == \"received\""))
                 .build(),
-            DispatchRule.builder()
+            Binding.builder()
                 .name("trigger-on-validated")
                 .capability(enrichCap)
                 .on(new ContextChangeTrigger(".step == \"validated\" and .valid == true"))
                 .build(),
-            DispatchRule.builder()
+            Binding.builder()
                 .name("trigger-on-enriched")
                 .capability(publishCap)
                 .on(new ContextChangeTrigger(".step == \"enriched\""))

--- a/engine/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
+++ b/engine/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
@@ -142,7 +142,7 @@ public class MultiWorkerPipelineBean extends CaseHub {
                         .build())
                 .description("Publishes enriched documents")
                 .build())
-        .rules(
+        .bindings(
             Binding.builder()
                 .name("trigger-on-received")
                 .capability(validateCap)

--- a/engine/src/test/java/io/casehub/engine/SignalTest.java
+++ b/engine/src/test/java/io/casehub/engine/SignalTest.java
@@ -229,7 +229,7 @@ public class SignalTest {
                         return Map.of("status", "paid");
                       })
                   .build())
-          .rules(
+          .bindings(
               Binding.builder()
                   .name("on-payment-received")
                   .capability(paymentCapability)
@@ -298,7 +298,7 @@ public class SignalTest {
                         return Map.of("documentProcessed", true);
                       })
                   .build())
-          .rules(
+          .bindings(
               Binding.builder()
                   .name("on-payment-approved")
                   .capability(paymentCapability)

--- a/engine/src/test/java/io/casehub/engine/SignalTest.java
+++ b/engine/src/test/java/io/casehub/engine/SignalTest.java
@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
-import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
@@ -213,8 +213,8 @@ public class SignalTest {
             .build();
 
     @Override
-    public CaseHubDefinition getDefinition() {
-      return CaseHubDefinition.builder()
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
           .namespace("test-signal")
           .name("Signal Test")
           .version("1.0.0")
@@ -230,7 +230,7 @@ public class SignalTest {
                       })
                   .build())
           .rules(
-              DispatchRule.builder()
+              Binding.builder()
                   .name("on-payment-received")
                   .capability(paymentCapability)
                   .on(new ContextChangeTrigger(".payment != null"))
@@ -273,8 +273,8 @@ public class SignalTest {
             .build();
 
     @Override
-    public CaseHubDefinition getDefinition() {
-      return CaseHubDefinition.builder()
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
           .namespace("test-signal-two")
           .name("Two Signal Test")
           .version("1.0.0")
@@ -299,12 +299,12 @@ public class SignalTest {
                       })
                   .build())
           .rules(
-              DispatchRule.builder()
+              Binding.builder()
                   .name("on-payment-approved")
                   .capability(paymentCapability)
                   .on(new ContextChangeTrigger(".paymentApproved != null"))
                   .build(),
-              DispatchRule.builder()
+              Binding.builder()
                   .name("on-document-uploaded")
                   .capability(documentCapability)
                   .on(new ContextChangeTrigger(".documentUploaded != null"))

--- a/engine/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
+++ b/engine/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
@@ -90,7 +90,7 @@ public class SimpleCaseHubBean extends CaseHub {
                         .build())
                 .description("Processes documents and updates case context")
                 .build())
-        .rules(
+        .bindings(
             Binding.builder()
                 .name("trigger-on-processing-status")
                 .capability(capability)

--- a/engine/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
+++ b/engine/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
@@ -19,10 +19,10 @@ import static io.serverlessworkflow.fluent.func.FuncWorkflowBuilder.workflow;
 import static io.serverlessworkflow.fluent.func.dsl.FuncDSL.function;
 
 import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
-import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
@@ -35,7 +35,7 @@ import java.util.Map;
 public class SimpleCaseHubBean extends CaseHub {
 
   @Override
-  public CaseHubDefinition getDefinition() {
+  public CaseDefinition getDefinition() {
 
     Capability capability =
         Capability.builder()
@@ -53,7 +53,7 @@ public class SimpleCaseHubBean extends CaseHub {
             .description("Goal achieved when document processing is complete")
             .build();
 
-    return CaseHubDefinition.builder()
+    return CaseDefinition.builder()
         .namespace("test")
         .name("Document Processing Test")
         .version("1.0.0")
@@ -91,7 +91,7 @@ public class SimpleCaseHubBean extends CaseHub {
                 .description("Processes documents and updates case context")
                 .build())
         .rules(
-            DispatchRule.builder()
+            Binding.builder()
                 .name("trigger-on-processing-status")
                 .capability(capability)
                 .on(new ContextChangeTrigger(".status == \"processing\""))

--- a/engine/src/test/java/io/casehub/engine/WorkerRecoveryTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerRecoveryTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.engine.CaseHub;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.Worker;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
@@ -124,8 +124,8 @@ public class WorkerRecoveryTest {
             .build();
 
     @Override
-    public CaseHubDefinition getDefinition() {
-      return CaseHubDefinition.builder()
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
           .namespace("test-worker-recovery")
           .name("Worker Recovery Test")
           .version("1.0.0")

--- a/engine/src/test/java/io/casehub/engine/WorkerRetryTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerRetryTest.java
@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
-import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.ExecutionPolicy;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
@@ -106,8 +106,8 @@ public class WorkerRetryTest {
             .build();
 
     @Override
-    public CaseHubDefinition getDefinition() {
-      return CaseHubDefinition.builder()
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
           .namespace("test-worker-retry")
           .name("Worker Retry Test")
           .version("1.0.0")
@@ -141,7 +141,7 @@ public class WorkerRetryTest {
                   .description("Processes documents and updates case context")
                   .build())
           .rules(
-              DispatchRule.builder()
+              Binding.builder()
                   .name("trigger-on-processing-status")
                   .capability(capability)
                   .on(new ContextChangeTrigger(".status == \"processing\""))

--- a/engine/src/test/java/io/casehub/engine/WorkerRetryTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerRetryTest.java
@@ -140,7 +140,7 @@ public class WorkerRetryTest {
                   .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(3, 1000)))
                   .description("Processes documents and updates case context")
                   .build())
-          .rules(
+          .bindings(
               Binding.builder()
                   .name("trigger-on-processing-status")
                   .capability(capability)

--- a/engine/src/test/java/io/casehub/engine/WorkerScheduleDedupTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerScheduleDedupTest.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.engine.CaseHub;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.Worker;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.engine.handler.WorkerScheduleEventHandler;
@@ -249,8 +249,8 @@ public class WorkerScheduleDedupTest {
             .build();
 
     @Override
-    public CaseHubDefinition getDefinition() {
-      return CaseHubDefinition.builder()
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
           .namespace("test-worker-schedule-dedup")
           .name("Worker Schedule Dedup Test")
           .version("1.0.0")

--- a/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBean.java
+++ b/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBean.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.casehub.api.engine.CaseHub;
 import io.casehub.api.model.AllOfGoalExpression;
 import io.casehub.api.model.AnyOfGoalExpression;
+import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
-import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalBasedCompletion;
 import io.casehub.api.model.GoalExpression;
@@ -45,7 +45,7 @@ public class YamlSimpleCaseHubBean extends CaseHub {
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 
   @Override
-  public CaseHubDefinition getDefinition() {
+  public CaseDefinition getDefinition() {
     try (InputStream is =
         Thread.currentThread().getContextClassLoader().getResourceAsStream("casehub/simple.yaml")) {
       if (is == null) {
@@ -59,9 +59,9 @@ public class YamlSimpleCaseHubBean extends CaseHub {
     }
   }
 
-  private CaseHubDefinition convertToApiModel(io.casehub.model.CaseHubDefinition schema) {
-    CaseHubDefinition def =
-        new CaseHubDefinition(schema.getNamespace(), schema.getName(), schema.getVersion());
+  private CaseDefinition convertToApiModel(io.casehub.model.CaseHubDefinition schema) {
+    CaseDefinition def =
+        new CaseDefinition(schema.getNamespace(), schema.getName(), schema.getVersion());
     def.setDsl(schema.getDsl());
     def.setTitle(schema.getTitle());
 
@@ -98,7 +98,7 @@ public class YamlSimpleCaseHubBean extends CaseHub {
               new ContextChangeTrigger(
                   new JQExpressionEvaluator(sr.getOn().getContextChange().getFilter()));
         }
-        DispatchRule rule = new DispatchRule(sr.getName(), cap, trigger);
+        Binding rule = new Binding(sr.getName(), cap, trigger);
         def.getRules().add(rule);
       }
     }

--- a/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBean.java
+++ b/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBean.java
@@ -99,7 +99,7 @@ public class YamlSimpleCaseHubBean extends CaseHub {
                   new JQExpressionEvaluator(sr.getOn().getContextChange().getFilter()));
         }
         Binding rule = new Binding(sr.getName(), cap, trigger);
-        def.getRules().add(rule);
+        def.getBindings().add(rule);
       }
     }
 

--- a/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBean.java
+++ b/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBean.java
@@ -51,15 +51,15 @@ public class YamlSimpleCaseHubBean extends CaseHub {
       if (is == null) {
         throw new IllegalStateException("Resource casehub/simple.yaml not found on classpath");
       }
-      io.casehub.model.CaseHubDefinition schema =
-          YAML_MAPPER.readValue(is, io.casehub.model.CaseHubDefinition.class);
+      io.casehub.model.CaseDefinition schema =
+          YAML_MAPPER.readValue(is, io.casehub.model.CaseDefinition.class);
       return convertToApiModel(schema);
     } catch (IOException e) {
       throw new RuntimeException("Failed to load CaseHub definition from casehub/simple.yaml", e);
     }
   }
 
-  private CaseDefinition convertToApiModel(io.casehub.model.CaseHubDefinition schema) {
+  private CaseDefinition convertToApiModel(io.casehub.model.CaseDefinition schema) {
     CaseDefinition def =
         new CaseDefinition(schema.getNamespace(), schema.getName(), schema.getVersion());
     def.setDsl(schema.getDsl());
@@ -89,8 +89,8 @@ public class YamlSimpleCaseHubBean extends CaseHub {
     }
 
     // Convert rules
-    if (schema.getSpec().getRules() != null) {
-      for (io.casehub.model.DispatchRule sr : schema.getSpec().getRules()) {
+    if (schema.getSpec().getBindings() != null) {
+      for (io.casehub.model.Binding sr : schema.getSpec().getBindings()) {
         Capability cap = capabilityMap.get(sr.getCapability());
         Trigger trigger = null;
         if (sr.getOn() != null && sr.getOn().getContextChange() != null) {

--- a/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBeanTest.java
+++ b/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBeanTest.java
@@ -63,11 +63,11 @@ public class YamlSimpleCaseHubBeanTest {
     assertInstanceOf(Workflow.class, def.getWorkers().get(0).getFunction().getValue());
 
     // rules
-    assertEquals(1, def.getRules().size());
-    assertEquals("trigger-on-processing-status", def.getRules().get(0).getName());
-    assertEquals("processDocument", def.getRules().get(0).getCapability().getName());
-    assertInstanceOf(ContextChangeTrigger.class, def.getRules().get(0).getOn());
-    ContextChangeTrigger cct = (ContextChangeTrigger) def.getRules().get(0).getOn();
+    assertEquals(1, def.getBindings().size());
+    assertEquals("trigger-on-processing-status", def.getBindings().get(0).getName());
+    assertEquals("processDocument", def.getBindings().get(0).getCapability().getName());
+    assertInstanceOf(ContextChangeTrigger.class, def.getBindings().get(0).getOn());
+    ContextChangeTrigger cct = (ContextChangeTrigger) def.getBindings().get(0).getOn();
     assertEquals(
         ".status == \"processing\"", ((JQExpressionEvaluator) cct.getFilter()).expression());
 

--- a/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBeanTest.java
+++ b/engine/src/test/java/io/casehub/engine/YamlSimpleCaseHubBeanTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.casehub.api.model.AllOfGoalExpression;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.GoalBasedCompletion;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
@@ -36,7 +36,7 @@ public class YamlSimpleCaseHubBeanTest {
 
   @Test
   public void test() {
-    CaseHubDefinition def = yamlSimpleCaseHubBean.getDefinition();
+    CaseDefinition def = yamlSimpleCaseHubBean.getDefinition();
     assertNotNull(def);
 
     assertEquals("0.1", def.getDsl());

--- a/engine/src/test/java/io/casehub/engine/internal/context/StateContextImplTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/context/StateContextImplTest.java
@@ -1,0 +1,939 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for {@link StateContextImpl} — methods not covered by {@link
+ * StateContextImplApplyDiffTest}.
+ *
+ * <p>Focused on: set/get, typed accessors, compareAndSet, update, merge, getPath/setPath,
+ * computeIfAbsent, putIfAbsent, getAll/setAll, clear, evalObjectTemplate, version semantics.
+ */
+@DisplayName("StateContextImpl")
+class StateContextImplTest {
+
+  // ================================================================== //
+  //  Construction                                                       //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("construction")
+  class Construction {
+
+    @Test
+    @DisplayName("empty constructor creates empty context at version 0")
+    void empty_createsEmptyContext() {
+      final var ctx = new StateContextImpl();
+      assertTrue(ctx.isEmpty());
+      assertEquals(0, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("map constructor populates data without incrementing version")
+    void mapConstructor_populatesData() {
+      final var ctx = new StateContextImpl(Map.of("a", "1", "b", 2));
+      assertEquals("1", ctx.getString("a"));
+      assertEquals(2, ctx.getInt("b"));
+      // version stays 0 because the constructor doesn't call set()
+      assertEquals(0, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("null map constructor produces empty context")
+    void nullMapConstructor_empty() {
+      final var ctx = new StateContextImpl(null);
+      assertTrue(ctx.isEmpty());
+    }
+  }
+
+  // ================================================================== //
+  //  set / get / version                                                //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("set / get / version")
+  class SetGetVersion {
+
+    @Test
+    @DisplayName("set increments version on first write")
+    void set_incrementsVersion() {
+      final var ctx = new StateContextImpl();
+      ctx.set("k", "v");
+      assertEquals(1, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("setting the same value twice does not increment version the second time")
+    void set_sameValue_noVersionIncrement() {
+      final var ctx = new StateContextImpl();
+      ctx.set("k", "v");
+      final long v1 = ctx.getVersion();
+      ctx.set("k", "v");
+      assertEquals(v1, ctx.getVersion(), "no-op set must not increment version");
+    }
+
+    @Test
+    @DisplayName("setting a different value increments version again")
+    void set_differentValue_incrementsAgain() {
+      final var ctx = new StateContextImpl();
+      ctx.set("k", "a");
+      final long v1 = ctx.getVersion();
+      ctx.set("k", "b");
+      assertEquals(v1 + 1, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("get returns null for absent key")
+    void get_absentKey_null() {
+      final var ctx = new StateContextImpl();
+      assertNull(ctx.get("missing"));
+    }
+
+    @Test
+    @DisplayName("get returns value for present key")
+    void get_presentKey_returnsValue() {
+      final var ctx = new StateContextImpl(Map.of("x", "hello"));
+      assertEquals("hello", ctx.get("x"));
+    }
+
+    @Test
+    @DisplayName("contains returns true for present key, false for absent")
+    void contains_presentAndAbsent() {
+      final var ctx = new StateContextImpl(Map.of("x", "y"));
+      assertTrue(ctx.contains("x"));
+      assertFalse(ctx.contains("z"));
+    }
+
+    @Test
+    @DisplayName("remove decrements size and increments version")
+    void remove_presentKey() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      ctx.remove("a");
+      assertFalse(ctx.contains("a"));
+      assertEquals(1, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("remove absent key is a no-op (version unchanged)")
+    void remove_absentKey_noOp() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final long before = ctx.getVersion();
+      ctx.remove("missing");
+      assertEquals(before, ctx.getVersion());
+    }
+  }
+
+  // ================================================================== //
+  //  Typed accessors                                                    //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("typed accessors")
+  class TypedAccessors {
+
+    @Test
+    @DisplayName("getString returns null for absent key")
+    void getString_absent_null() {
+      assertEquals(null, new StateContextImpl().getString("k"));
+    }
+
+    @Test
+    @DisplayName("getString converts int to string")
+    void getString_int_convertsToString() {
+      final var ctx = new StateContextImpl(Map.of("n", 42));
+      assertEquals("42", ctx.getString("n"));
+    }
+
+    @Test
+    @DisplayName("getInt parses integer from string")
+    void getInt_stringValue_parsed() {
+      final var ctx = new StateContextImpl(Map.of("n", "7"));
+      assertEquals(7, ctx.getInt("n"));
+    }
+
+    @Test
+    @DisplayName("getInt returns null for absent key")
+    void getInt_absent_null() {
+      assertNull(new StateContextImpl().getInt("n"));
+    }
+
+    @Test
+    @DisplayName("getLong returns long value")
+    void getLong_returnsLong() {
+      final var ctx = new StateContextImpl(Map.of("n", 123456789012345L));
+      assertEquals(123456789012345L, ctx.getLong("n"));
+    }
+
+    @Test
+    @DisplayName("getLong parses from string")
+    void getLong_stringValue_parsed() {
+      final var ctx = new StateContextImpl(Map.of("n", "9999999999"));
+      assertEquals(9999999999L, ctx.getLong("n"));
+    }
+
+    @Test
+    @DisplayName("getLong returns null for absent key")
+    void getLong_absent_null() {
+      assertNull(new StateContextImpl().getLong("n"));
+    }
+
+    @Test
+    @DisplayName("getDouble returns double value")
+    void getDouble_returnsDouble() {
+      final var ctx = new StateContextImpl(Map.of("d", 3.14));
+      assertEquals(3.14, ctx.getDouble("d"), 0.001);
+    }
+
+    @Test
+    @DisplayName("getDouble parses from string")
+    void getDouble_stringValue_parsed() {
+      final var ctx = new StateContextImpl(Map.of("d", "2.71"));
+      assertEquals(2.71, ctx.getDouble("d"), 0.001);
+    }
+
+    @Test
+    @DisplayName("getDouble returns null for absent key")
+    void getDouble_absent_null() {
+      assertNull(new StateContextImpl().getDouble("d"));
+    }
+
+    @Test
+    @DisplayName("getBoolean returns true for Boolean.TRUE")
+    void getBoolean_trueValue() {
+      final var ctx = new StateContextImpl(Map.of("b", Boolean.TRUE));
+      assertTrue(ctx.getBoolean("b"));
+    }
+
+    @Test
+    @DisplayName("getBoolean returns false for Boolean.FALSE")
+    void getBoolean_falseValue() {
+      final var ctx = new StateContextImpl(Map.of("b", Boolean.FALSE));
+      assertFalse(ctx.getBoolean("b"));
+    }
+
+    @Test
+    @DisplayName("getBoolean parses 'true' string")
+    void getBoolean_stringTrue_parsed() {
+      final var ctx = new StateContextImpl(Map.of("b", "true"));
+      assertTrue(ctx.getBoolean("b"));
+    }
+
+    @Test
+    @DisplayName("getBoolean returns null for absent key")
+    void getBoolean_absent_null() {
+      assertNull(new StateContextImpl().getBoolean("b"));
+    }
+
+    @Test
+    @DisplayName("getOrDefault returns stored value when present")
+    void getOrDefault_present_returnsStored() {
+      final var ctx = new StateContextImpl(Map.of("k", "stored"));
+      assertEquals("stored", ctx.getOrDefault("k", "default"));
+    }
+
+    @Test
+    @DisplayName("getOrDefault returns default when key absent")
+    void getOrDefault_absent_returnsDefault() {
+      final var ctx = new StateContextImpl();
+      assertEquals("default", ctx.getOrDefault("k", "default"));
+    }
+
+    @Test
+    @DisplayName("getAs converts numeric to target type via Jackson")
+    void getAs_numericConversion() {
+      final var ctx = new StateContextImpl(Map.of("n", 42));
+      assertEquals(Long.valueOf(42L), ctx.getAs("n", Long.class));
+    }
+  }
+
+  // ================================================================== //
+  //  compareAndSet                                                      //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("compareAndSet")
+  class CompareAndSetTests {
+
+    @Test
+    @DisplayName("succeeds when current value matches expected")
+    void cas_match_returnsTrue() {
+      final var ctx = new StateContextImpl(Map.of("status", "pending"));
+      final boolean result = ctx.compareAndSet("status", "pending", "active");
+      assertTrue(result);
+      assertEquals("active", ctx.getString("status"));
+    }
+
+    @Test
+    @DisplayName("fails when current value does not match expected")
+    void cas_mismatch_returnsFalse() {
+      final var ctx = new StateContextImpl(Map.of("status", "running"));
+      final boolean result = ctx.compareAndSet("status", "pending", "active");
+      assertFalse(result);
+      assertEquals("running", ctx.getString("status"), "value must be unchanged after failed CAS");
+    }
+
+    @Test
+    @DisplayName("succeeds for absent key when expected is null")
+    void cas_nullExpected_absentKey_succeeds() {
+      final var ctx = new StateContextImpl();
+      final boolean result = ctx.compareAndSet("k", null, "new-value");
+      assertTrue(result);
+      assertEquals("new-value", ctx.getString("k"));
+    }
+
+    @Test
+    @DisplayName("does not increment version when new value equals current value")
+    void cas_sameValue_noVersionIncrement() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final long before = ctx.getVersion();
+      ctx.compareAndSet("k", "v", "v"); // same value
+      assertEquals(before, ctx.getVersion(), "no-op CAS must not increment version");
+    }
+
+    @Test
+    @DisplayName("increments version on successful value change")
+    void cas_successfulChange_incrementsVersion() {
+      final var ctx = new StateContextImpl(Map.of("k", "old"));
+      final long before = ctx.getVersion();
+      ctx.compareAndSet("k", "old", "new");
+      assertEquals(before + 1, ctx.getVersion());
+    }
+  }
+
+  // ================================================================== //
+  //  update                                                             //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("update")
+  class UpdateTests {
+
+    @Test
+    @DisplayName("update applies function to current value")
+    void update_transformsValue() {
+      final var ctx = new StateContextImpl(Map.of("count", 5));
+      ctx.update("count", v -> ((Number) v).intValue() + 1);
+      assertEquals(6, ctx.getInt("count"));
+    }
+
+    @Test
+    @DisplayName("update with null result removes the key")
+    void update_nullResult_removesKey() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      ctx.update("k", v -> null);
+      assertFalse(ctx.contains("k"));
+    }
+
+    @Test
+    @DisplayName("update with no-op (same value) does not increment version")
+    void update_noOpSameValue_noVersionIncrement() {
+      final var ctx = new StateContextImpl(Map.of("k", "same"));
+      final long before = ctx.getVersion();
+      ctx.update("k", v -> "same");
+      assertEquals(before, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("update receives null for absent key")
+    void update_absentKey_receivesNull() {
+      final var ctx = new StateContextImpl();
+      final Object[] received = {new Object()}; // sentinel
+      ctx.update(
+          "absent",
+          v -> {
+            received[0] = v;
+            return null;
+          });
+      assertNull(received[0]);
+    }
+  }
+
+  // ================================================================== //
+  //  computeIfAbsent / putIfAbsent                                      //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("computeIfAbsent / putIfAbsent")
+  class AbsentOperations {
+
+    @Test
+    @DisplayName("computeIfAbsent computes and stores when key absent")
+    void computeIfAbsent_absent_computesAndStores() {
+      final var ctx = new StateContextImpl();
+      final Object result = ctx.computeIfAbsent("k", key -> "computed");
+      assertEquals("computed", result);
+      assertEquals("computed", ctx.getString("k"));
+    }
+
+    @Test
+    @DisplayName("computeIfAbsent returns existing value without calling function")
+    void computeIfAbsent_present_returnsExisting() {
+      final var ctx = new StateContextImpl(Map.of("k", "existing"));
+      final boolean[] called = {false};
+      final Object result =
+          ctx.computeIfAbsent(
+              "k",
+              key -> {
+                called[0] = true;
+                return "computed";
+              });
+      assertEquals("existing", result);
+      assertFalse(called[0], "mapping function must not be called when key is present");
+    }
+
+    @Test
+    @DisplayName("computeIfAbsent does not store when function returns null")
+    void computeIfAbsent_functionReturnsNull_notStored() {
+      final var ctx = new StateContextImpl();
+      final long before = ctx.getVersion();
+      ctx.computeIfAbsent("k", key -> null);
+      assertFalse(ctx.contains("k"));
+      assertEquals(before, ctx.getVersion(), "no-op must not increment version");
+    }
+
+    @Test
+    @DisplayName("putIfAbsent stores value when key absent")
+    void putIfAbsent_absent_stores() {
+      final var ctx = new StateContextImpl();
+      final Object previous = ctx.putIfAbsent("k", "new");
+      assertNull(previous, "previous should be null when key was absent");
+      assertEquals("new", ctx.getString("k"));
+    }
+
+    @Test
+    @DisplayName("putIfAbsent returns existing value without overwriting")
+    void putIfAbsent_present_returnsExisting() {
+      final var ctx = new StateContextImpl(Map.of("k", "existing"));
+      final Object previous = ctx.putIfAbsent("k", "new");
+      assertEquals("existing", previous);
+      assertEquals("existing", ctx.getString("k"), "existing value must not be overwritten");
+    }
+  }
+
+  // ================================================================== //
+  //  setAll / getAll                                                    //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("setAll / getAll")
+  class SetAllGetAll {
+
+    @Test
+    @DisplayName("setAll stores all provided key-value pairs")
+    void setAll_storesAll() {
+      final var ctx = new StateContextImpl();
+      ctx.setAll(Map.of("a", "1", "b", "2"));
+      assertEquals("1", ctx.getString("a"));
+      assertEquals("2", ctx.getString("b"));
+    }
+
+    @Test
+    @DisplayName("setAll with null map is a no-op")
+    void setAll_nullMap_noOp() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final long before = ctx.getVersion();
+      ctx.setAll(null);
+      assertEquals(before, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("setAll with empty map is a no-op")
+    void setAll_emptyMap_noOp() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final long before = ctx.getVersion();
+      ctx.setAll(Map.of());
+      assertEquals(before, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("setAll only increments version once for multiple changes")
+    void setAll_multipleChanges_singleVersionIncrement() {
+      final var ctx = new StateContextImpl();
+      final long before = ctx.getVersion();
+      ctx.setAll(Map.of("a", "1", "b", "2", "c", "3"));
+      assertEquals(before + 1, ctx.getVersion(), "setAll should increment version exactly once");
+    }
+
+    @Test
+    @DisplayName("setAll no-op when all values are identical")
+    void setAll_allSameValues_noVersionIncrement() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final long before = ctx.getVersion();
+      ctx.setAll(Map.of("a", "1")); // no actual change
+      assertEquals(before, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("getAll returns only present keys")
+    void getAll_returnsOnlyPresentKeys() {
+      final var ctx = new StateContextImpl(Map.of("a", "1", "b", "2"));
+      final var result = ctx.getAll("a", "c"); // 'c' is missing
+      assertEquals(1, result.size());
+      assertEquals("1", result.get("a"));
+      assertFalse(result.containsKey("c"));
+    }
+
+    @Test
+    @DisplayName("getAll with no matching keys returns empty map")
+    void getAll_noMatchingKeys_empty() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var result = ctx.getAll("x", "y");
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  // ================================================================== //
+  //  clear                                                              //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("clear")
+  class ClearTests {
+
+    @Test
+    @DisplayName("clear empties the context and increments version")
+    void clear_emptiesContext() {
+      final var ctx = new StateContextImpl(Map.of("a", "1", "b", "2"));
+      ctx.clear();
+      assertTrue(ctx.isEmpty());
+      assertEquals(0, ctx.size());
+      assertEquals(1, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("clear on already-empty context is a no-op")
+    void clear_alreadyEmpty_noOp() {
+      final var ctx = new StateContextImpl();
+      final long before = ctx.getVersion();
+      ctx.clear();
+      assertEquals(before, ctx.getVersion(), "clearing empty context must not increment version");
+    }
+  }
+
+  // ================================================================== //
+  //  getPath / setPath                                                  //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("getPath / setPath")
+  class PathOperations {
+
+    @Test
+    @DisplayName("setPath creates nested structure and getPath retrieves it")
+    void setPath_createsNested_getPathRetrieve() {
+      final var ctx = new StateContextImpl();
+      ctx.setPath("payment.amount", 500);
+      assertEquals(500, ctx.getPath("payment.amount"));
+    }
+
+    @Test
+    @DisplayName("setPath creates intermediate map nodes")
+    void setPath_createsIntermediateNodes() {
+      final var ctx = new StateContextImpl();
+      ctx.setPath("a.b.c", "deep");
+      assertEquals("deep", ctx.getPath("a.b.c"));
+    }
+
+    @Test
+    @DisplayName("getPath returns null for absent top-level key")
+    void getPath_absentTopLevel_null() {
+      final var ctx = new StateContextImpl();
+      assertNull(ctx.getPath("missing.path"));
+    }
+
+    @Test
+    @DisplayName("getPath returns null when intermediate key is absent")
+    void getPath_absentIntermediate_null() {
+      final var ctx = new StateContextImpl(Map.of("a", Map.of("x", "1")));
+      assertNull(ctx.getPath("a.b.c"));
+    }
+
+    @Test
+    @DisplayName("setPath on non-map node throws IllegalStateException")
+    void setPath_nonMapNode_throws() {
+      final var ctx = new StateContextImpl(Map.of("a", "scalar"));
+      assertThrows(
+          IllegalStateException.class,
+          () -> ctx.setPath("a.b", "value"),
+          "cannot set path through a non-map node");
+    }
+
+    @Test
+    @DisplayName("getPathAsString returns string representation")
+    void getPathAsString_returnsString() {
+      final var ctx = new StateContextImpl();
+      ctx.setPath("x.y", 42);
+      assertEquals("42", ctx.getPathAsString("x.y"));
+    }
+
+    @Test
+    @DisplayName("getPathAsString returns null for absent path")
+    void getPathAsString_absent_null() {
+      assertNull(new StateContextImpl().getPathAsString("missing"));
+    }
+
+    @Test
+    @DisplayName("setPath with same value does not increment version")
+    void setPath_sameValue_noVersionIncrement() {
+      final var ctx = new StateContextImpl();
+      ctx.setPath("a.b", "v");
+      final long before = ctx.getVersion();
+      ctx.setPath("a.b", "v");
+      assertEquals(before, ctx.getVersion());
+    }
+  }
+
+  // ================================================================== //
+  //  merge                                                              //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("merge")
+  class MergeTests {
+
+    @Test
+    @DisplayName("merge adds new keys from other context")
+    void merge_addsNewKeys() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var other = new StateContextImpl(Map.of("b", "2"));
+      ctx.merge(other);
+      assertEquals("1", ctx.getString("a"));
+      assertEquals("2", ctx.getString("b"));
+    }
+
+    @Test
+    @DisplayName("merge overwrites existing keys with values from other")
+    void merge_overwritesExisting() {
+      final var ctx = new StateContextImpl(Map.of("k", "old"));
+      final var other = new StateContextImpl(Map.of("k", "new"));
+      ctx.merge(other);
+      assertEquals("new", ctx.getString("k"));
+    }
+
+    @Test
+    @DisplayName("merge with null is a no-op")
+    void merge_null_noOp() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final long before = ctx.getVersion();
+      ctx.merge(null);
+      assertEquals(before, ctx.getVersion());
+      assertEquals("v", ctx.getString("k"));
+    }
+
+    @Test
+    @DisplayName("merge with empty context is a no-op")
+    void merge_emptyOther_noOp() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final long before = ctx.getVersion();
+      ctx.merge(new StateContextImpl());
+      assertEquals(before, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("merge with identical values does not increment version")
+    void merge_sameValues_noVersionIncrement() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var other = new StateContextImpl(Map.of("k", "v"));
+      final long before = ctx.getVersion();
+      ctx.merge(other);
+      assertEquals(before, ctx.getVersion());
+    }
+  }
+
+  // ================================================================== //
+  //  snapshot                                                           //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("snapshot")
+  class SnapshotTests {
+
+    @Test
+    @DisplayName("snapshot captures current data at current version")
+    void snapshot_capturesState() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var snap = (StateContextImpl) ctx.snapshot();
+      assertEquals("v", snap.getString("k"));
+      assertEquals(ctx.getVersion(), snap.getVersion());
+    }
+
+    @Test
+    @DisplayName("modifying original after snapshot does not affect snapshot")
+    void snapshot_isIndependent() {
+      final var ctx = new StateContextImpl(Map.of("k", "original"));
+      final var snap = (StateContextImpl) ctx.snapshot();
+      ctx.set("k", "modified");
+      assertEquals("original", snap.getString("k"), "snapshot must be independent of original");
+    }
+
+    @Test
+    @DisplayName("modifying snapshot does not affect original")
+    void snapshot_modifySnap_doesNotAffectOriginal() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var snap = (StateContextImpl) ctx.snapshot();
+      snap.set("k", "changed");
+      assertEquals("v", ctx.getString("k"), "original must be unaffected by snapshot changes");
+    }
+  }
+
+  // ================================================================== //
+  //  getKeys / size / isEmpty                                           //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("getKeys / size / isEmpty")
+  class InspectionTests {
+
+    @Test
+    @DisplayName("getKeys returns all stored keys")
+    void getKeys_returnsAllKeys() {
+      final var ctx = new StateContextImpl(Map.of("a", "1", "b", "2"));
+      final var keys = ctx.getKeys();
+      assertEquals(2, keys.size());
+      assertTrue(keys.contains("a"));
+      assertTrue(keys.contains("b"));
+    }
+
+    @Test
+    @DisplayName("size returns count of stored entries")
+    void size_returnsCount() {
+      final var ctx = new StateContextImpl(Map.of("a", "1", "b", "2", "c", "3"));
+      assertEquals(3, ctx.size());
+    }
+
+    @Test
+    @DisplayName("isEmpty returns true for empty context")
+    void isEmpty_empty_true() {
+      assertTrue(new StateContextImpl().isEmpty());
+    }
+
+    @Test
+    @DisplayName("isEmpty returns false after adding entry")
+    void isEmpty_afterAdd_false() {
+      final var ctx = new StateContextImpl();
+      ctx.set("k", "v");
+      assertFalse(ctx.isEmpty());
+    }
+  }
+
+  // ================================================================== //
+  //  asJsonNode / getData                                               //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("asJsonNode / getData")
+  class JsonNodeTests {
+
+    @Test
+    @DisplayName("asJsonNode returns an object node with all entries")
+    void asJsonNode_returnsObjectNode() {
+      final var ctx = new StateContextImpl(Map.of("status", "active", "count", 3));
+      final var node = ctx.asJsonNode();
+      assertNotNull(node);
+      assertEquals("active", node.get("status").asText());
+      assertEquals(3, node.get("count").asInt());
+    }
+
+    @Test
+    @DisplayName("getData returns a copy — modifying it does not affect context")
+    void getData_returnsCopy() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var data = ctx.getData();
+      data.put("k", "modified");
+      assertEquals("v", ctx.getString("k"), "getData must return a defensive copy");
+    }
+  }
+
+  // ================================================================== //
+  //  evalObjectTemplate                                                 //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("evalObjectTemplate")
+  class EvalObjectTemplateTests {
+
+    @Test
+    @DisplayName("extracts single field via path expression")
+    void singleField_extracted() {
+      final var ctx = new StateContextImpl(Map.of("documentId", "doc-123", "status", "active"));
+      final var result = ctx.evalObjectTemplate("{ documentId: .documentId }");
+      assertEquals("doc-123", result.get("documentId"));
+      assertFalse(result.containsKey("status"), "only requested field should be present");
+    }
+
+    @Test
+    @DisplayName("extracts multiple fields")
+    void multipleFields_extracted() {
+      final var ctx = new StateContextImpl(Map.of("id", "x1", "status", "ok", "extra", "ignored"));
+      final var result = ctx.evalObjectTemplate("{ id: .id, status: .status }");
+      assertEquals("x1", result.get("id"));
+      assertEquals("ok", result.get("status"));
+      assertFalse(result.containsKey("extra"));
+    }
+
+    @Test
+    @DisplayName("dot expression maps to whole context snapshot")
+    void dotExpression_wholeContext() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var result = ctx.evalObjectTemplate("{ all: . }");
+      assertNotNull(result.get("all"));
+    }
+
+    @Test
+    @DisplayName("absent path produces null value for the key")
+    void absentPath_nullValue() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var result = ctx.evalObjectTemplate("{ missing: .nonExistent }");
+      assertTrue(result.containsKey("missing"), "key must still be present");
+      assertNull(result.get("missing"), "value for absent path must be null");
+    }
+
+    @Test
+    @DisplayName("JSON literal value is included directly")
+    void jsonLiteralValue_included() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var result = ctx.evalObjectTemplate("{ fixed: \"hello\" }");
+      assertEquals("hello", result.get("fixed"));
+    }
+
+    @Test
+    @DisplayName("null template returns empty map")
+    void nullTemplate_returnsEmpty() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      assertTrue(ctx.evalObjectTemplate(null).isEmpty());
+    }
+
+    @Test
+    @DisplayName("blank template returns empty map")
+    void blankTemplate_returnsEmpty() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      assertTrue(ctx.evalObjectTemplate("   ").isEmpty());
+    }
+
+    @Test
+    @DisplayName("empty braces {} returns empty map")
+    void emptyBraces_returnsEmpty() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      assertTrue(ctx.evalObjectTemplate("{}").isEmpty());
+    }
+
+    @Test
+    @DisplayName("template not wrapped with braces throws IllegalArgumentException")
+    void unwrappedTemplate_throws() {
+      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> ctx.evalObjectTemplate("id: .id"),
+          "template must be wrapped in { }");
+    }
+
+    @Test
+    @DisplayName("nested path extracts from nested structure")
+    void nestedPath_extracted() {
+      final var ctx = new StateContextImpl();
+      ctx.setPath("doc.id", "doc-42");
+      final var result = ctx.evalObjectTemplate("{ docId: .doc }");
+      assertNotNull(result.get("docId"), "nested extraction should work via . path to top key");
+    }
+
+    @Test
+    @DisplayName("boolean literal value in template")
+    void booleanLiteral_included() {
+      final var ctx = new StateContextImpl();
+      final var result = ctx.evalObjectTemplate("{ flag: true }");
+      assertEquals(true, result.get("flag"));
+    }
+
+    @Test
+    @DisplayName("numeric literal value in template")
+    void numericLiteral_included() {
+      final var ctx = new StateContextImpl();
+      final var result = ctx.evalObjectTemplate("{ count: 42 }");
+      assertEquals(42, result.get("count"));
+    }
+  }
+
+  // ================================================================== //
+  //  equals / hashCode                                                  //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("equals / hashCode")
+  class EqualsHashCode {
+
+    @Test
+    @DisplayName("two contexts with same data are equal regardless of version")
+    void equalData_equalContexts() {
+      final var a = new StateContextImpl(Map.of("k", "v"), 1L);
+      final var b = new StateContextImpl(Map.of("k", "v"), 99L);
+      assertEquals(a, b, "equality is based on data, not version");
+    }
+
+    @Test
+    @DisplayName("contexts with different data are not equal")
+    void differentData_notEqual() {
+      final var a = new StateContextImpl(Map.of("k", "v1"));
+      final var b = new StateContextImpl(Map.of("k", "v2"));
+      assertFalse(a.equals(b));
+    }
+
+    @Test
+    @DisplayName("same instance equals itself")
+    void sameInstance_equal() {
+      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      assertTrue(ctx.equals(ctx));
+    }
+
+    @Test
+    @DisplayName("hashCode consistent with equals")
+    void hashCode_consistentWithEquals() {
+      final var a = new StateContextImpl(Map.of("k", "v"));
+      final var b = new StateContextImpl(Map.of("k", "v"));
+      assertEquals(a.hashCode(), b.hashCode());
+    }
+  }
+
+  // ================================================================== //
+  //  toString                                                           //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("toString")
+  class ToStringTests {
+
+    @Test
+    @DisplayName("toString returns valid JSON representation")
+    void toString_returnsJson() {
+      final var ctx = new StateContextImpl(Map.of("status", "ok"));
+      final var json = ctx.toString();
+      assertNotNull(json);
+      assertTrue(json.contains("status"), "toString should contain the key");
+      assertTrue(json.contains("ok"), "toString should contain the value");
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/jq/ValidationResultTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/jq/ValidationResultTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.jq;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for {@link ValidationResult}.
+ *
+ * <p>These focus on the {@link ValidationResult#isTrue()} contract, which is the primary decision
+ * gate used by the engine: a result is "true" only if {@code ok == true} AND the output list
+ * contains at least one boolean {@code true} node.
+ */
+@DisplayName("ValidationResult")
+class ValidationResultTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  // ------------------------------------------------------------------ //
+  //  Error results                                                       //
+  // ------------------------------------------------------------------ //
+
+  @Nested
+  @DisplayName("error results")
+  class ErrorResults {
+
+    @Test
+    @DisplayName("error result is not ok")
+    void error_notOk() {
+      final var result = ValidationResult.error("some error");
+      assertFalse(result.ok());
+    }
+
+    @Test
+    @DisplayName("error result output is null")
+    void error_outputIsNull() {
+      final var result = ValidationResult.error("some error");
+      assertNull(result.output());
+    }
+
+    @Test
+    @DisplayName("error result isTrue returns false")
+    void error_isFalse() {
+      final var result = ValidationResult.error("compilation error");
+      assertFalse(result.isTrue());
+    }
+
+    @Test
+    @DisplayName("error result with null message does not throw")
+    void error_nullMessageDoesNotThrow() {
+      final var result = ValidationResult.error(null);
+      assertFalse(result.ok());
+      assertFalse(result.isTrue());
+    }
+  }
+
+  // ------------------------------------------------------------------ //
+  //  ok results — empty output                                           //
+  // ------------------------------------------------------------------ //
+
+  @Nested
+  @DisplayName("ok results — empty output")
+  class EmptyOutput {
+
+    @Test
+    @DisplayName("empty output list isTrue returns false")
+    void emptyOutput_isFalse() {
+      final var result = ValidationResult.ok(List.of());
+      assertTrue(result.ok());
+      assertFalse(result.isTrue(), "empty output must not be considered true");
+    }
+  }
+
+  // ------------------------------------------------------------------ //
+  //  ok results — non-boolean output                                     //
+  // ------------------------------------------------------------------ //
+
+  @Nested
+  @DisplayName("ok results — non-boolean output")
+  class NonBooleanOutput {
+
+    @Test
+    @DisplayName("string node in output isTrue returns false")
+    void stringOutput_isFalse() throws Exception {
+      final var node = MAPPER.readTree("\"hello\"");
+      final var result = ValidationResult.ok(List.of(node));
+      assertFalse(result.isTrue(), "string output must not be considered true");
+    }
+
+    @Test
+    @DisplayName("numeric node (1) isTrue returns false — only boolean true counts")
+    void numberOutput_isFalse() throws Exception {
+      final var node = MAPPER.readTree("1");
+      final var result = ValidationResult.ok(List.of(node));
+      assertFalse(result.isTrue(), "numeric 1 must not be considered boolean true");
+    }
+
+    @Test
+    @DisplayName("null JSON node isTrue returns false")
+    void nullNode_isFalse() throws Exception {
+      final var node = MAPPER.readTree("null");
+      final var result = ValidationResult.ok(List.of(node));
+      assertFalse(result.isTrue(), "JSON null node must not be considered true");
+    }
+
+    @Test
+    @DisplayName("object node isTrue returns false")
+    void objectNode_isFalse() throws Exception {
+      final var node = MAPPER.readTree("{\"status\":\"ok\"}");
+      final var result = ValidationResult.ok(List.of(node));
+      assertFalse(result.isTrue(), "object node must not be considered true");
+    }
+
+    @Test
+    @DisplayName("array node isTrue returns false")
+    void arrayNode_isFalse() throws Exception {
+      final var node = MAPPER.readTree("[true, true]");
+      final var result = ValidationResult.ok(List.of(node));
+      assertFalse(
+          result.isTrue(),
+          "array node (even containing trues) must not be considered true — isTrue checks nodes"
+              + " directly");
+    }
+  }
+
+  // ------------------------------------------------------------------ //
+  //  ok results — boolean output                                         //
+  // ------------------------------------------------------------------ //
+
+  @Nested
+  @DisplayName("ok results — boolean output")
+  class BooleanOutput {
+
+    @Test
+    @DisplayName("single boolean true node isTrue returns true")
+    void singleTrue_isTrue() {
+      final var result = ValidationResult.ok(List.of(BooleanNode.TRUE));
+      assertTrue(result.isTrue());
+    }
+
+    @Test
+    @DisplayName("single boolean false node isTrue returns false")
+    void singleFalse_isFalse() {
+      final var result = ValidationResult.ok(List.of(BooleanNode.FALSE));
+      assertFalse(result.isTrue());
+    }
+
+    @Test
+    @DisplayName("multiple boolean nodes — any true means isTrue returns true")
+    void multipleMixed_anyTrueIsTrue() {
+      final var result =
+          ValidationResult.ok(List.of(BooleanNode.FALSE, BooleanNode.TRUE, BooleanNode.FALSE));
+      assertTrue(result.isTrue(), "at least one true in multiple results is sufficient");
+    }
+
+    @Test
+    @DisplayName("multiple boolean false nodes — all false means isTrue returns false")
+    void multipleAllFalse_isFalse() {
+      final var result =
+          ValidationResult.ok(List.of(BooleanNode.FALSE, BooleanNode.FALSE, BooleanNode.FALSE));
+      assertFalse(result.isTrue(), "all false means isTrue must be false");
+    }
+
+    @Test
+    @DisplayName("mixed boolean and non-boolean — true boolean presence makes isTrue true")
+    void mixedBooleanAndNonBoolean_trueBooleanWins() throws Exception {
+      final var stringNode = MAPPER.readTree("\"hello\"");
+      final var result = ValidationResult.ok(List.of(stringNode, BooleanNode.TRUE));
+      assertTrue(result.isTrue(), "boolean true among mixed nodes should still return true");
+    }
+
+    @Test
+    @DisplayName("non-boolean followed by false — isTrue returns false")
+    void nonBooleanFollowedByFalse_isFalse() throws Exception {
+      final var stringNode = MAPPER.readTree("\"hello\"");
+      final var result = ValidationResult.ok(List.of(stringNode, BooleanNode.FALSE));
+      assertFalse(result.isTrue());
+    }
+  }
+
+  // ------------------------------------------------------------------ //
+  //  error results behave correctly even with ok=false                  //
+  // ------------------------------------------------------------------ //
+
+  @Nested
+  @DisplayName("ok=false but non-null output is ignored")
+  class OkFalseWithOutput {
+
+    @Test
+    @DisplayName("if ok=false, isTrue is false regardless of output content")
+    void okFalse_outputHasTrueNode_isFalse() {
+      // Construct directly — factory methods don't allow this combination, but the record does
+      final var result = new ValidationResult(false, "error", List.of(BooleanNode.TRUE));
+      assertFalse(result.isTrue(), "ok=false must short-circuit to false");
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/model/GoalExpressionTest.java
+++ b/engine/src/test/java/io/casehub/engine/model/GoalExpressionTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.model.AllOfGoalExpression;
+import io.casehub.api.model.AnyOfGoalExpression;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for {@link AllOfGoalExpression} and {@link AnyOfGoalExpression}.
+ *
+ * <p>These drive case completion logic: the engine calls {@code expression.test(achievedGoals)}.
+ * Getting this wrong means cases that should complete don't, or cases that shouldn't complete do.
+ */
+@DisplayName("GoalExpression")
+class GoalExpressionTest {
+
+  private Goal goalA;
+  private Goal goalB;
+  private Goal goalC;
+
+  @BeforeEach
+  void setUp() {
+    goalA = Goal.builder().name("goal-a").condition(".a == true").kind(GoalKind.SUCCESS).build();
+    goalB = Goal.builder().name("goal-b").condition(".b == true").kind(GoalKind.SUCCESS).build();
+    goalC = Goal.builder().name("goal-c").condition(".c == true").kind(GoalKind.FAILURE).build();
+  }
+
+  // ================================================================== //
+  //  AllOfGoalExpression                                                //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("AllOfGoalExpression")
+  class AllOfTests {
+
+    @Test
+    @DisplayName("empty allOf requirement — vacuously true regardless of current goals")
+    void emptyAllOf_alwaysTrue() {
+      final var expr = new AllOfGoalExpression(List.of());
+      assertTrue(expr.test(List.of()), "empty allOf should be vacuously true with no goals");
+      assertTrue(expr.test(List.of(goalA)), "empty allOf should be vacuously true with any goals");
+      assertTrue(
+          expr.test(null), "empty allOf should be vacuously true even with null current goals");
+    }
+
+    @Test
+    @DisplayName("null allOf collection — vacuously true")
+    void nullAllOf_alwaysTrue() {
+      final var expr = new AllOfGoalExpression(null);
+      assertTrue(expr.test(List.of()));
+      assertTrue(expr.test(null));
+    }
+
+    @Test
+    @DisplayName("single goal in allOf — requires that goal to be present")
+    void singleGoal_requiresPresence() {
+      final var expr = GoalExpression.allOf(goalA);
+      assertTrue(expr.test(List.of(goalA)), "goal present — should be true");
+      assertFalse(expr.test(List.of(goalB)), "different goal present — should be false");
+      assertFalse(expr.test(List.of()), "no goals — should be false");
+    }
+
+    @Test
+    @DisplayName("all goals in allOf must be present — partial match is false")
+    void twoGoals_allMustBePresent() {
+      final var expr = GoalExpression.allOf(goalA, goalB);
+      assertTrue(expr.test(List.of(goalA, goalB)), "both present — true");
+      assertFalse(expr.test(List.of(goalA)), "only A present — false");
+      assertFalse(expr.test(List.of(goalB)), "only B present — false");
+      assertFalse(expr.test(List.of()), "none present — false");
+    }
+
+    @Test
+    @DisplayName("superset of required goals — still true")
+    void currentGoalsIsSupersetOfRequired_isTrue() {
+      final var expr = GoalExpression.allOf(goalA);
+      assertTrue(
+          expr.test(List.of(goalA, goalB, goalC)),
+          "having more goals than required is still a pass");
+    }
+
+    @Test
+    @DisplayName("null current goals — false when allOf has entries")
+    void nullCurrentGoals_nonEmptyAllOf_isFalse() {
+      final var expr = GoalExpression.allOf(goalA);
+      assertFalse(expr.test(null), "null current goals with non-empty requirement is false");
+    }
+
+    @Test
+    @DisplayName("getGoals returns the configured collection")
+    void getGoals_returnsConfiguredCollection() {
+      final var goals = List.of(goalA, goalB);
+      final var expr = new AllOfGoalExpression(goals);
+      assertTrue(expr.getGoals().containsAll(goals));
+    }
+
+    @Test
+    @DisplayName("GoalExpression.allOf(Collection) factory delegates correctly")
+    void factoryWithCollection_delegatesCorrectly() {
+      final var expr = GoalExpression.allOf(List.of(goalA, goalB));
+      assertTrue(expr.test(List.of(goalA, goalB)));
+      assertFalse(expr.test(List.of(goalA)));
+    }
+  }
+
+  // ================================================================== //
+  //  AnyOfGoalExpression                                                //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("AnyOfGoalExpression")
+  class AnyOfTests {
+
+    @Test
+    @DisplayName("empty anyOf requirement — vacuously true")
+    void emptyAnyOf_alwaysTrue() {
+      final var expr = new AnyOfGoalExpression(List.of());
+      assertTrue(expr.test(List.of()), "empty anyOf should be vacuously true");
+      assertTrue(expr.test(List.of(goalA)));
+      assertTrue(expr.test(null));
+    }
+
+    @Test
+    @DisplayName("null anyOf collection — vacuously true")
+    void nullAnyOf_alwaysTrue() {
+      final var expr = new AnyOfGoalExpression(null);
+      assertTrue(expr.test(List.of()));
+    }
+
+    @Test
+    @DisplayName("single goal in anyOf — true when that goal is present")
+    void singleGoal_trueWhenPresent() {
+      final var expr = GoalExpression.anyOf(goalA);
+      assertTrue(expr.test(List.of(goalA)));
+      assertFalse(expr.test(List.of(goalB)));
+      assertFalse(expr.test(List.of()));
+    }
+
+    @Test
+    @DisplayName("first of two goals present — anyOf is true")
+    void firstGoalPresent_isTrue() {
+      final var expr = GoalExpression.anyOf(goalA, goalB);
+      assertTrue(expr.test(List.of(goalA)), "first goal satisfies anyOf");
+    }
+
+    @Test
+    @DisplayName("second of two goals present — anyOf is true")
+    void secondGoalPresent_isTrue() {
+      final var expr = GoalExpression.anyOf(goalA, goalB);
+      assertTrue(expr.test(List.of(goalB)), "second goal satisfies anyOf");
+    }
+
+    @Test
+    @DisplayName("neither goal present — anyOf is false")
+    void neitherGoalPresent_isFalse() {
+      final var expr = GoalExpression.anyOf(goalA, goalB);
+      assertFalse(expr.test(List.of(goalC)));
+    }
+
+    @Test
+    @DisplayName("empty current goals — anyOf with required goals is false")
+    void emptyCurrentGoals_isFalse() {
+      final var expr = GoalExpression.anyOf(goalA, goalB);
+      assertFalse(expr.test(List.of()));
+    }
+
+    @Test
+    @DisplayName("null current goals — anyOf with required goals is false")
+    void nullCurrentGoals_isFalse() {
+      final var expr = GoalExpression.anyOf(goalA);
+      assertFalse(expr.test(null));
+    }
+
+    @Test
+    @DisplayName("all goals present — anyOf is true")
+    void allGoalsPresent_isTrue() {
+      final var expr = GoalExpression.anyOf(goalA, goalB);
+      assertTrue(expr.test(List.of(goalA, goalB)));
+    }
+
+    @Test
+    @DisplayName("getGoals returns the configured collection")
+    void getGoals_returnsConfiguredCollection() {
+      final var goals = List.of(goalA, goalC);
+      final var expr = new AnyOfGoalExpression(goals);
+      assertTrue(expr.getGoals().containsAll(goals));
+    }
+  }
+
+  // ================================================================== //
+  //  Goal equality — foundational to containsAll/contains checks        //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("Goal equality semantics (AllOfGoalExpression.test relies on this)")
+  class GoalEqualitySemantics {
+
+    @Test
+    @DisplayName("same Goal instance is equal to itself")
+    void sameInstance_equal() {
+      assertTrue(goalA.equals(goalA));
+    }
+
+    @Test
+    @DisplayName("equal by fields — same name/condition/kind — should be equal")
+    void equalByFields_equal() {
+      final var goalA2 =
+          Goal.builder().name("goal-a").condition(".a == true").kind(GoalKind.SUCCESS).build();
+      assertTrue(goalA.equals(goalA2), "goals with same fields should be equal");
+    }
+
+    @Test
+    @DisplayName("different name — not equal")
+    void differentName_notEqual() {
+      final var other =
+          Goal.builder().name("goal-x").condition(".a == true").kind(GoalKind.SUCCESS).build();
+      assertFalse(goalA.equals(other));
+    }
+
+    @Test
+    @DisplayName("different kind — not equal")
+    void differentKind_notEqual() {
+      final var other =
+          Goal.builder().name("goal-a").condition(".a == true").kind(GoalKind.FAILURE).build();
+      assertFalse(goalA.equals(other));
+    }
+
+    @Test
+    @DisplayName("allOf with equal Goal objects works correctly")
+    void allOf_worksWithEqualGoalInstances() {
+      // goalA2 is a NEW instance equal to goalA by fields
+      final var goalA2 =
+          Goal.builder().name("goal-a").condition(".a == true").kind(GoalKind.SUCCESS).build();
+
+      final var expr = GoalExpression.allOf(goalA);
+
+      // The achieved list holds goalA2 (a different instance, equal by value)
+      final Collection<Goal> achieved = new ArrayList<>();
+      achieved.add(goalA2);
+
+      assertTrue(
+          expr.test(achieved),
+          "containsAll relies on equals — equal-by-field Goal instances must satisfy allOf");
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/model/ModelBuilderTest.java
+++ b/engine/src/test/java/io/casehub/engine/model/ModelBuilderTest.java
@@ -1,0 +1,620 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.model;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalBasedCompletion;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Milestone;
+import io.casehub.api.model.PredicateBasedCompletion;
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for model builder contracts, equals/hashCode, and GoalKind.fromValue().
+ *
+ * <p>Builders use {@link java.util.Objects#requireNonNull} for mandatory fields — a NPE here
+ * indicates a programming error in the caller, not a runtime condition, so asserting that the
+ * exception is thrown is the right contract test.
+ */
+@DisplayName("Model Builders and Value Objects")
+class ModelBuilderTest {
+
+  // ================================================================== //
+  //  CaseDefinition                                                     //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("CaseDefinition builder")
+  class CaseDefinitionBuilderTests {
+
+    @Test
+    @DisplayName("null namespace throws NullPointerException")
+    void nullNamespace_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> CaseDefinition.builder().namespace(null).name("test").version("1.0").build());
+    }
+
+    @Test
+    @DisplayName("missing namespace throws NullPointerException")
+    void missingNamespace_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> CaseDefinition.builder().name("test").version("1.0").build());
+    }
+
+    @Test
+    @DisplayName("null name throws NullPointerException")
+    void nullName_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> CaseDefinition.builder().namespace("ns").name(null).version("1.0").build());
+    }
+
+    @Test
+    @DisplayName("null version throws NullPointerException")
+    void nullVersion_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> CaseDefinition.builder().namespace("ns").name("test").version(null).build());
+    }
+
+    @Test
+    @DisplayName("minimal valid build succeeds")
+    void minimal_builds() {
+      final var def =
+          assertDoesNotThrow(
+              () -> CaseDefinition.builder().namespace("ns").name("test").version("1.0").build());
+      assertEquals("ns", def.getNamespace());
+      assertEquals("test", def.getName());
+      assertEquals("1.0", def.getVersion());
+    }
+
+    @Test
+    @DisplayName("optional fields default to null/empty lists")
+    void optionalFieldsDefaults() {
+      final var def = CaseDefinition.builder().namespace("ns").name("test").version("1.0").build();
+      assertNull(def.getTitle());
+      assertNull(def.getSummary());
+      assertNull(def.getCompletion());
+      assertTrue(def.getCapabilities().isEmpty());
+      assertTrue(def.getBindings().isEmpty());
+      assertTrue(def.getMilestones().isEmpty());
+      assertTrue(def.getGoals().isEmpty());
+      assertTrue(def.getWorkers().isEmpty());
+    }
+
+    @Test
+    @DisplayName("equals: two definitions with same namespace/name/version are equal")
+    void equals_sameCoordinates_equal() {
+      final var a = CaseDefinition.builder().namespace("ns").name("case").version("1.0").build();
+      final var b = CaseDefinition.builder().namespace("ns").name("case").version("1.0").build();
+      assertEquals(a, b);
+      assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    @DisplayName("equals: different version means not equal")
+    void equals_differentVersion_notEqual() {
+      final var a = CaseDefinition.builder().namespace("ns").name("case").version("1.0").build();
+      final var b = CaseDefinition.builder().namespace("ns").name("case").version("2.0").build();
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("equals: different namespace means not equal")
+    void equals_differentNamespace_notEqual() {
+      final var a = CaseDefinition.builder().namespace("ns-a").name("case").version("1.0").build();
+      final var b = CaseDefinition.builder().namespace("ns-b").name("case").version("1.0").build();
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("equals: not equal to null")
+    void equals_null_notEqual() {
+      final var a = CaseDefinition.builder().namespace("ns").name("case").version("1.0").build();
+      assertNotEquals(a, null);
+    }
+
+    @Test
+    @DisplayName(
+        "completion(String when) creates PredicateBasedCompletion with JQExpressionEvaluator")
+    void completionStringWhen_createsPredicateBased() {
+      final var def =
+          CaseDefinition.builder()
+              .namespace("ns")
+              .name("test")
+              .version("1.0")
+              .completion(".status == \"done\"")
+              .build();
+      assertInstanceOf(PredicateBasedCompletion.class, def.getCompletion());
+      final var pbc = (PredicateBasedCompletion) def.getCompletion();
+      assertInstanceOf(JQExpressionEvaluator.class, pbc.getDoneWhen());
+      assertEquals(".status == \"done\"", ((JQExpressionEvaluator) pbc.getDoneWhen()).expression());
+    }
+
+    @Test
+    @DisplayName("completion(GoalExpression) creates GoalBasedCompletion with null failure")
+    void completionGoalExpression_createsGoalBased() {
+      final var goal =
+          Goal.builder().name("g").condition(".done == true").kind(GoalKind.SUCCESS).build();
+      final var def =
+          CaseDefinition.builder()
+              .namespace("ns")
+              .name("test")
+              .version("1.0")
+              .completion(GoalExpression.allOf(goal))
+              .build();
+      assertInstanceOf(GoalBasedCompletion.class, def.getCompletion());
+      final var gbc = (GoalBasedCompletion) def.getCompletion();
+      assertNotNull(gbc.getSuccess());
+      assertNull(gbc.getFailure());
+    }
+
+    @Test
+    @DisplayName("completion(success, failure) stores both expressions")
+    void completionSuccessFailure_storesBoth() {
+      final var successGoal =
+          Goal.builder().name("g-success").condition(".ok == true").kind(GoalKind.SUCCESS).build();
+      final var failGoal =
+          Goal.builder().name("g-fail").condition(".error == true").kind(GoalKind.FAILURE).build();
+      final var def =
+          CaseDefinition.builder()
+              .namespace("ns")
+              .name("test")
+              .version("1.0")
+              .completion(GoalExpression.allOf(successGoal), GoalExpression.anyOf(failGoal))
+              .build();
+      assertInstanceOf(GoalBasedCompletion.class, def.getCompletion());
+      final var gbc = (GoalBasedCompletion) def.getCompletion();
+      assertNotNull(gbc.getSuccess());
+      assertNotNull(gbc.getFailure());
+    }
+  }
+
+  // ================================================================== //
+  //  Binding                                                            //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("Binding builder")
+  class BindingBuilderTests {
+
+    private final Capability cap =
+        Capability.builder().name("cap1").inputSchema("{}").outputSchema("{}").build();
+    private final ContextChangeTrigger trigger = new ContextChangeTrigger(".x == true");
+
+    @Test
+    @DisplayName("null name throws NullPointerException")
+    void nullName_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Binding.builder().name(null).capability(cap).on(trigger).build());
+    }
+
+    @Test
+    @DisplayName("null capability throws NullPointerException")
+    void nullCapability_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Binding.builder().name("binding").capability(null).on(trigger).build());
+    }
+
+    @Test
+    @DisplayName("null trigger throws NullPointerException")
+    void nullTrigger_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Binding.builder().name("binding").capability(cap).on(null).build());
+    }
+
+    @Test
+    @DisplayName("minimal valid build succeeds")
+    void minimal_builds() {
+      final var binding =
+          assertDoesNotThrow(
+              () -> Binding.builder().name("on-event").capability(cap).on(trigger).build());
+      assertEquals("on-event", binding.getName());
+      assertEquals(cap, binding.getCapability());
+      assertEquals(trigger, binding.getOn());
+      assertNull(binding.getWhen(), "when is optional, should default to null");
+    }
+
+    @Test
+    @DisplayName("when(String) creates JQExpressionEvaluator")
+    void whenString_createsJQEvaluator() {
+      final var binding =
+          Binding.builder().name("b").capability(cap).on(trigger).when(".flag == true").build();
+      assertInstanceOf(JQExpressionEvaluator.class, binding.getWhen());
+      assertEquals(".flag == true", ((JQExpressionEvaluator) binding.getWhen()).expression());
+    }
+  }
+
+  // ================================================================== //
+  //  Milestone                                                          //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("Milestone builder")
+  class MilestoneBuilderTests {
+
+    @Test
+    @DisplayName("null name throws NullPointerException")
+    void nullName_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Milestone.builder().name(null).condition(".x == true").build());
+    }
+
+    @Test
+    @DisplayName("null ExpressionEvaluator condition throws NullPointerException")
+    void nullEvaluatorCondition_throws() {
+      // condition(String null) wraps null in JQExpressionEvaluator (non-null object) — that path
+      // does not throw. condition(ExpressionEvaluator) with null does hit requireNonNull at build.
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              Milestone.builder()
+                  .name("m")
+                  .condition((io.casehub.api.model.evaluator.ExpressionEvaluator) null)
+                  .build());
+    }
+
+    @Test
+    @DisplayName("condition(String) creates JQExpressionEvaluator")
+    void conditionString_createsJQEvaluator() {
+      final var m = Milestone.builder().name("m").condition(".done == true").build();
+      assertInstanceOf(JQExpressionEvaluator.class, m.getCondition());
+      assertEquals(".done == true", ((JQExpressionEvaluator) m.getCondition()).expression());
+    }
+
+    @Test
+    @DisplayName("equals: same name/condition/description are equal")
+    void equals_sameFields_equal() {
+      final var a =
+          Milestone.builder().name("m").condition(".x == true").description("desc").build();
+      final var b =
+          Milestone.builder().name("m").condition(".x == true").description("desc").build();
+      assertEquals(a, b);
+      assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    @DisplayName("equals: different name is not equal")
+    void equals_differentName_notEqual() {
+      final var a = Milestone.builder().name("m1").condition(".x == true").build();
+      final var b = Milestone.builder().name("m2").condition(".x == true").build();
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("equals: different condition is not equal")
+    void equals_differentCondition_notEqual() {
+      final var a = Milestone.builder().name("m").condition(".x == true").build();
+      final var b = Milestone.builder().name("m").condition(".y == true").build();
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("description is optional — null default")
+    void descriptionDefaultsToNull() {
+      final var m = Milestone.builder().name("m").condition(".x == true").build();
+      assertNull(m.getDescription());
+    }
+
+    @Test
+    @DisplayName("description setter works")
+    void descriptionSetter() {
+      final var m =
+          Milestone.builder().name("m").condition(".x == true").description("my milestone").build();
+      assertEquals("my milestone", m.getDescription());
+    }
+  }
+
+  // ================================================================== //
+  //  Goal                                                               //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("Goal builder")
+  class GoalBuilderTests {
+
+    @Test
+    @DisplayName("null name throws NullPointerException")
+    void nullName_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Goal.builder().name(null).condition(".x == true").kind(GoalKind.SUCCESS).build());
+    }
+
+    @Test
+    @DisplayName("null ExpressionEvaluator condition throws NullPointerException")
+    void nullEvaluatorCondition_throws() {
+      // condition(String null) wraps null in JQExpressionEvaluator (non-null object) so does not
+      // throw. Passing a null ExpressionEvaluator directly hits requireNonNull at build time.
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              Goal.builder()
+                  .name("g")
+                  .condition((io.casehub.api.model.evaluator.ExpressionEvaluator) null)
+                  .kind(GoalKind.SUCCESS)
+                  .build());
+    }
+
+    @Test
+    @DisplayName("null kind throws NullPointerException")
+    void nullKind_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Goal.builder().name("g").condition(".x == true").kind(null).build());
+    }
+
+    @Test
+    @DisplayName("condition(String) creates JQExpressionEvaluator")
+    void conditionString_createsJQEvaluator() {
+      final var g =
+          Goal.builder().name("g").condition(".done == true").kind(GoalKind.SUCCESS).build();
+      assertInstanceOf(JQExpressionEvaluator.class, g.getCondition());
+      assertEquals(".done == true", ((JQExpressionEvaluator) g.getCondition()).expression());
+    }
+
+    @Test
+    @DisplayName("equals: same name/condition/kind/terminal/description are equal")
+    void equals_sameFields_equal() {
+      final var a =
+          Goal.builder()
+              .name("g")
+              .condition(".x == true")
+              .kind(GoalKind.SUCCESS)
+              .terminal(false)
+              .description("d")
+              .build();
+      final var b =
+          Goal.builder()
+              .name("g")
+              .condition(".x == true")
+              .kind(GoalKind.SUCCESS)
+              .terminal(false)
+              .description("d")
+              .build();
+      assertEquals(a, b);
+      assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    @DisplayName("equals: different kind is not equal")
+    void equals_differentKind_notEqual() {
+      final var a = Goal.builder().name("g").condition(".x == true").kind(GoalKind.SUCCESS).build();
+      final var b = Goal.builder().name("g").condition(".x == true").kind(GoalKind.FAILURE).build();
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    @DisplayName("terminal defaults to false")
+    void terminalDefaultsFalse() {
+      final var g = Goal.builder().name("g").condition(".x == true").kind(GoalKind.SUCCESS).build();
+      assertFalse(g.getTerminal());
+    }
+
+    @Test
+    @DisplayName("terminal(true) is stored correctly")
+    void terminalTrue_stored() {
+      final var g =
+          Goal.builder()
+              .name("g")
+              .condition(".x == true")
+              .kind(GoalKind.SUCCESS)
+              .terminal(true)
+              .build();
+      assertTrue(g.getTerminal());
+    }
+
+    @Test
+    @DisplayName("SUCCESS and FAILURE goals with same name are not equal")
+    void successVsFailure_notEqual() {
+      final var success =
+          Goal.builder().name("g").condition(".x == true").kind(GoalKind.SUCCESS).build();
+      final var failure =
+          Goal.builder().name("g").condition(".x == true").kind(GoalKind.FAILURE).build();
+      assertNotEquals(success, failure);
+    }
+  }
+
+  // ================================================================== //
+  //  GoalKind                                                           //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("GoalKind.fromValue()")
+  class GoalKindFromValueTests {
+
+    @Test
+    @DisplayName("'success' maps to GoalKind.SUCCESS")
+    void successString_mapsToSuccess() {
+      assertEquals(GoalKind.SUCCESS, GoalKind.fromValue("success"));
+    }
+
+    @Test
+    @DisplayName("'failure' maps to GoalKind.FAILURE")
+    void failureString_mapsToFailure() {
+      assertEquals(GoalKind.FAILURE, GoalKind.fromValue("failure"));
+    }
+
+    @Test
+    @DisplayName("unknown value throws IllegalArgumentException")
+    void unknownValue_throws() {
+      assertThrows(IllegalArgumentException.class, () -> GoalKind.fromValue("unknown"));
+    }
+
+    @Test
+    @DisplayName("null value throws (NPE or IAE — either is acceptable)")
+    void nullValue_throws() {
+      assertThrows(Exception.class, () -> GoalKind.fromValue(null));
+    }
+
+    @Test
+    @DisplayName("upper-case 'SUCCESS' is not recognised — values are lower-case only")
+    void uppercaseSuccess_throws() {
+      assertThrows(IllegalArgumentException.class, () -> GoalKind.fromValue("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("GoalKind.value() returns the canonical lower-case string")
+    void value_returnsLowercase() {
+      assertEquals("success", GoalKind.SUCCESS.value());
+      assertEquals("failure", GoalKind.FAILURE.value());
+    }
+
+    @Test
+    @DisplayName("GoalKind.toString() matches value()")
+    void toString_matchesValue() {
+      assertEquals(GoalKind.SUCCESS.value(), GoalKind.SUCCESS.toString());
+      assertEquals(GoalKind.FAILURE.value(), GoalKind.FAILURE.toString());
+    }
+  }
+
+  // ================================================================== //
+  //  Capability                                                         //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("Capability builder")
+  class CapabilityBuilderTests {
+
+    @Test
+    @DisplayName("null name throws NullPointerException")
+    void nullName_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Capability.builder().name(null).inputSchema("{}").outputSchema("{}").build());
+    }
+
+    @Test
+    @DisplayName("null inputSchema throws NullPointerException")
+    void nullInputSchema_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Capability.builder().name("cap").inputSchema(null).outputSchema("{}").build());
+    }
+
+    @Test
+    @DisplayName("null outputSchema throws NullPointerException")
+    void nullOutputSchema_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Capability.builder().name("cap").inputSchema("{}").outputSchema(null).build());
+    }
+
+    @Test
+    @DisplayName("minimal build succeeds")
+    void minimal_builds() {
+      final var cap =
+          assertDoesNotThrow(
+              () ->
+                  Capability.builder()
+                      .name("cap")
+                      .inputSchema("{input: .x}")
+                      .outputSchema("{output: .y}")
+                      .build());
+      assertEquals("cap", cap.getName());
+      assertEquals("{input: .x}", cap.getInputSchema());
+      assertEquals("{output: .y}", cap.getOutputSchema());
+      assertNull(cap.getDescription());
+    }
+
+    @Test
+    @DisplayName("description setter works")
+    void descriptionSetter() {
+      final var cap =
+          Capability.builder()
+              .name("cap")
+              .inputSchema("{}")
+              .outputSchema("{}")
+              .description("A capability")
+              .build();
+      assertEquals("A capability", cap.getDescription());
+    }
+  }
+
+  // ================================================================== //
+  //  ContextChangeTrigger                                               //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("ContextChangeTrigger")
+  class ContextChangeTriggerTests {
+
+    @Test
+    @DisplayName("String constructor wraps expression in JQExpressionEvaluator")
+    void stringConstructor_wrapsInJQEvaluator() {
+      final var trigger = new ContextChangeTrigger(".status == \"active\"");
+      assertInstanceOf(JQExpressionEvaluator.class, trigger.getFilter());
+      assertEquals(
+          ".status == \"active\"", ((JQExpressionEvaluator) trigger.getFilter()).expression());
+    }
+
+    @Test
+    @DisplayName("ExpressionEvaluator constructor stores the evaluator directly")
+    void evaluatorConstructor_storesDirectly() {
+      final var evaluator = new JQExpressionEvaluator(".x == 1");
+      final var trigger = new ContextChangeTrigger(evaluator);
+      assertEquals(evaluator, trigger.getFilter());
+    }
+  }
+
+  // ================================================================== //
+  //  PredicateBasedCompletion                                           //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("PredicateBasedCompletion")
+  class PredicateBasedCompletionTests {
+
+    @Test
+    @DisplayName("stores the provided evaluator")
+    void storesEvaluator() {
+      final var evaluator = new JQExpressionEvaluator(".done == true");
+      final var completion = new PredicateBasedCompletion(evaluator);
+      assertEquals(evaluator, completion.getDoneWhen());
+    }
+
+    @Test
+    @DisplayName("null evaluator is stored (validation is caller's responsibility)")
+    void nullEvaluator_stored() {
+      final var completion = new PredicateBasedCompletion(null);
+      assertNull(completion.getDoneWhen());
+    }
+  }
+}

--- a/engine/src/test/resources/casehub/simple.yaml
+++ b/engine/src/test/resources/casehub/simple.yaml
@@ -21,7 +21,7 @@ spec:
                 id: ${ .documentId }
                 content: ${ "Processed content for document " + .documentId }
               status: processed
-  rules:
+  bindings:
     - name: trigger-on-processing-status
       capability: processDocument
       on:

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -41,7 +41,7 @@
                             <mainClass>io.casehub.codegen.CasehubCodegen</mainClass>
                             <includePluginDependencies>true</includePluginDependencies>
                             <arguments>
-                                <argument>${project.basedir}/src/main/resources/schema/CaseHubDefinition.yaml</argument>
+                                <argument>${project.basedir}/src/main/resources/schema/CaseDefinition.yaml</argument>
                                 <argument>${project.build.directory}/generated-sources/jsonschema2pojo</argument>
                                 <argument>io.casehub.model</argument>
                             </arguments>

--- a/schema/src/main/resources/schema/CaseDefinition.yaml
+++ b/schema/src/main/resources/schema/CaseDefinition.yaml
@@ -106,14 +106,13 @@ $defs:
           (success) or terminally failed based on Goal satisfaction and/or a
           direct JQ predicate. The Reactor evaluates completion on every
           CaseContext change and may emit CaseCompleted/CaseFailed events.
-      rules:
+      bindings:
         type: array
         description: >
-          Rules define when and how to invoke capabilities based on context
-          changes and events. They are the "glue" that connects Workers to
-          Cases and orchestrates interactions.
+          Bindings connect trigger conditions to worker capabilities. When a binding's
+          trigger condition is met, the associated capability is invoked.
         items:
-          $ref: "#/$defs/DispatchRule"
+          $ref: "#/$defs/Binding"
       workers:
         type: array
         description: >
@@ -144,7 +143,7 @@ $defs:
       outputSchema:
         { type: string, description: "JQ producing capability output" }
 
-  DispatchRule:
+  Binding:
     type: object
     required: [ on, capability ]
     unevaluatedProperties: false


### PR DESCRIPTION
Closes #37
Refs #30

## Summary

Completes the `DispatchRule`→`Binding` and `CaseHubDefinition`→`CaseDefinition` rename across all layers, adds Milestone/Goal Javadoc, and adds 181 new tests.

---

## `DispatchRule` → `Binding`

`DispatchRule` implied a rules-engine. The concept is a _binding_ between a trigger condition and a worker capability. `Binding` is the CMMN-aligned term, already used as the YAML schema field name, and standard in event-driven systems.

## `CaseHubDefinition` → `CaseDefinition`

Redundant `CaseHub` prefix in an already-namespaced package. `CaseDefinition` is more concise and now consistent with `CaseDefinitionRegistry`.

## Scope

| Layer | Change |
|---|---|
| `api/` model classes | `DispatchRule.java`→`Binding.java`, `CaseHubDefinition.java`→`CaseDefinition.java` (git mv) |
| `api/` method | `CaseDefinition.getRules()`→`getBindings()`, `.rules()`→`.bindings()` builder |
| `engine/` production | All references updated |
| `engine/` tests | All references updated |
| YAML schema | `CaseHubDefinition.yaml`→`CaseDefinition.yaml`, `DispatchRule`→`Binding` def, `rules:`→`bindings:` |
| `schema/pom.xml` | Codegen source path updated |
| Test resources | `simple.yaml` `rules:`→`bindings:` |

## Javadoc

`Milestone` and `Goal` Javadoc added explaining the distinction:
- Milestones are neutral waypoints you _pass through_ on the way to a goal
- Goals carry `GoalKind` (SUCCESS/FAILURE) and drive case completion
- `Milestone` is a unified concept: lightweight (fire event) or lifecycle-tracked (CasePlanModel)

## Test coverage (closes #39)

181 new tests across 4 files — `ValidationResultTest`, `GoalExpressionTest`, `ModelBuilderTest`, `StateContextImplTest`. Suite: 284 tests, 0 failures.

**Notable bug found:** `Milestone/Goal.builder().condition((String) null)` silently accepts null (wraps in `JQExpressionEvaluator(null)`) — NPE at runtime, not at build time.

## Testing

All 284 tests pass. `SignalTest#workerRunsOnceOnDuplicateSignal` is pre-existing flaky (#29).