### PR TITLE
refactor(api): rename DispatchRule → Binding, CaseHubDefinition → Cas…

### DIFF
--- a/api/src/main/java/io/casehub/api/engine/LoopControl.java
+++ b/api/src/main/java/io/casehub/api/engine/LoopControl.java
@@ -16,7 +16,7 @@
 package io.casehub.api.engine;
 
 import io.casehub.api.context.StateContext;
-import io.casehub.api.model.DispatchRule;
+import io.casehub.api.model.Binding;
 import java.util.List;
 
 /**
@@ -38,5 +38,5 @@ public interface LoopControl {
    * @param eligible rules whose trigger conditions matched — may be empty, never null
    * @return the subset to fire; may be empty, may be the full list, must not be null
    */
-  List<DispatchRule> select(StateContext context, List<DispatchRule> eligible);
+  List<Binding> select(StateContext context, List<Binding> eligible);
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/ChoreographyLoopControl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/ChoreographyLoopControl.java
@@ -17,7 +17,7 @@ package io.casehub.engine.internal.engine;
 
 import io.casehub.api.context.StateContext;
 import io.casehub.api.engine.LoopControl;
-import io.casehub.api.model.DispatchRule;
+import io.casehub.api.model.Binding;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
@@ -32,7 +32,7 @@ import java.util.List;
 public class ChoreographyLoopControl implements LoopControl {
 
   @Override
-  public List<DispatchRule> select(final StateContext context, final List<DispatchRule> eligible) {
+  public List<Binding> select(final StateContext context, final List<Binding> eligible) {
     return eligible;
   }
 }

--- a/engine/src/test/java/io/casehub/engine/SignalPersistenceAndDedupTest.java
+++ b/engine/src/test/java/io/casehub/engine/SignalPersistenceAndDedupTest.java
@@ -23,10 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.CaseHubDefinition;
+import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
-import io.casehub.api.model.DispatchRule;
 import io.casehub.api.model.Worker;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
@@ -279,8 +279,8 @@ public class SignalPersistenceAndDedupTest {
             .build();
 
     @Override
-    public CaseHubDefinition getDefinition() {
-      return CaseHubDefinition.builder()
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
           .namespace("test-signal-persistence")
           .name("Signal Persistence Test")
           .version("1.0.0")
@@ -298,8 +298,8 @@ public class SignalPersistenceAndDedupTest {
                             "status", "processed", "lastProcessedAmount", amount.intValue());
                       })
                   .build())
-          .rules(
-              DispatchRule.builder()
+          .bindings(
+              Binding.builder()
                   .name("on-payment-received")
                   .capability(paymentCapability)
                   .on(new ContextChangeTrigger(".payment != null"))


### PR DESCRIPTION
…eDefinition

Closes #37
Refs #30

DispatchRule → Binding

DispatchRule implied a rules-engine. The concept is a binding between a trigger condition and a worker capability — when the condition holds, execution is bound to that capability. Binding is the agreed CMMN-aligned term, consistent with the 'bindings' field name already used in the YAML schema, and standard in event-driven systems (CloudEvents subscriptions, Serverless Workflow bindings).

CaseHubDefinition → CaseDefinition

CaseHubDefinition carried a redundant CaseHub prefix in a package that is already namespaced to CaseHub. CaseDefinition is more concise, reads naturally in method signatures, and is now consistent with CaseDefinitionRegistry — the class that stores and looks up definitions. The internal engine already used the CaseDefinition name for its registry; the API type now matches.

Scope: api/ model classes + all engine/ production and test references. Schema module (io.casehub.model.*) deferred to a separate PR.