### PR TITLE
feat(resilience): Dead Letter Queue — store, query, replay, discard

### DIFF
--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterEntry.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterEntry.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A record of a worker execution that exhausted all retry attempts. Stores the full context needed
+ * to replay the work or diagnose the failure: case ID, worker identity, original input, and current
+ * lifecycle status.
+ *
+ * <p>Status transitions: {@link DeadLetterStatus#PENDING_REVIEW} → {@link
+ * DeadLetterStatus#REPLAYED} or {@link DeadLetterStatus#DISCARDED}.
+ */
+public final class DeadLetterEntry {
+
+  private final String deadLetterId;
+  private final UUID caseId;
+  private final String workerId;
+  private final String idempotencyHash;
+  private final Map<String, Object> inputContext;
+  private final Instant arrivedAt;
+  private volatile DeadLetterStatus status;
+
+  DeadLetterEntry(
+      String deadLetterId,
+      UUID caseId,
+      String workerId,
+      String idempotencyHash,
+      Map<String, Object> inputContext) {
+    this.deadLetterId = deadLetterId;
+    this.caseId = caseId;
+    this.workerId = workerId;
+    this.idempotencyHash = idempotencyHash;
+    this.inputContext = Map.copyOf(inputContext);
+    this.arrivedAt = Instant.now();
+    this.status = DeadLetterStatus.PENDING_REVIEW;
+  }
+
+  public String deadLetterId() {
+    return deadLetterId;
+  }
+
+  public UUID caseId() {
+    return caseId;
+  }
+
+  public String workerId() {
+    return workerId;
+  }
+
+  public String idempotencyHash() {
+    return idempotencyHash;
+  }
+
+  public Map<String, Object> inputContext() {
+    return inputContext;
+  }
+
+  public Instant arrivedAt() {
+    return arrivedAt;
+  }
+
+  public DeadLetterStatus status() {
+    return status;
+  }
+
+  void setStatus(DeadLetterStatus status) {
+    this.status = status;
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterEventHandler.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterEventHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * Listens for {@link EventBusAddresses#WORKER_RETRIES_EXHAUSTED} events and routes the failing
+ * execution into the {@link DeadLetterQueue}. Runs alongside the engine's {@code
+ * WorkerRetriesExhaustedEventHandler} — both handlers receive the same event independently.
+ */
+@ApplicationScoped
+public class DeadLetterEventHandler {
+
+  private static final Logger LOG = Logger.getLogger(DeadLetterEventHandler.class);
+
+  @Inject DeadLetterQueue deadLetterQueue;
+
+  @ConsumeEvent(value = EventBusAddresses.WORKER_RETRIES_EXHAUSTED)
+  public void onWorkerRetriesExhausted(WorkerRetriesExhaustedEvent event) {
+    LOG.infof(
+        "Routing exhausted worker to DLQ: caseId=%s, workerId=%s",
+        event.caseId(), event.workerId());
+
+    deadLetterQueue.add(
+        event.caseId(),
+        event.workerId(),
+        event.idempotency(),
+        // Input context is not carried in the event itself — the DLQ entry stores the
+        // idempotency hash so the full input can be recovered from EventLog on replay.
+        Map.of("idempotencyHash", event.idempotency()));
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterQuery.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Immutable filter specification for {@link DeadLetterQueue#query(DeadLetterQuery)}. Build via the
+ * static factory methods; filters are AND-combined.
+ */
+public final class DeadLetterQuery {
+
+  private final Optional<DeadLetterStatus> status;
+  private final Optional<String> workerId;
+  private final Optional<Instant> arrivedAfter;
+
+  private DeadLetterQuery(
+      Optional<DeadLetterStatus> status,
+      Optional<String> workerId,
+      Optional<Instant> arrivedAfter) {
+    this.status = status;
+    this.workerId = workerId;
+    this.arrivedAfter = arrivedAfter;
+  }
+
+  /** Match every entry. */
+  public static DeadLetterQuery all() {
+    return new DeadLetterQuery(Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  /** Match entries with the given status. */
+  public static DeadLetterQuery withStatus(DeadLetterStatus status) {
+    return new DeadLetterQuery(Optional.of(status), Optional.empty(), Optional.empty());
+  }
+
+  /** Match entries for a specific worker. */
+  public static DeadLetterQuery forWorker(String workerId) {
+    return new DeadLetterQuery(Optional.empty(), Optional.of(workerId), Optional.empty());
+  }
+
+  /** Match entries that arrived after the given instant. */
+  public static DeadLetterQuery arrivedAfter(Instant cutoff) {
+    return new DeadLetterQuery(Optional.empty(), Optional.empty(), Optional.of(cutoff));
+  }
+
+  /** Builds a predicate representing all active filters. */
+  Predicate<DeadLetterEntry> toPredicate() {
+    Predicate<DeadLetterEntry> pred = e -> true;
+    if (status.isPresent()) {
+      pred = pred.and(e -> e.status() == status.get());
+    }
+    if (workerId.isPresent()) {
+      pred = pred.and(e -> workerId.get().equals(e.workerId()));
+    }
+    if (arrivedAfter.isPresent()) {
+      pred = pred.and(e -> e.arrivedAt().isAfter(arrivedAfter.get()));
+    }
+    return pred;
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterQueue.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterQueue.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * In-memory Dead Letter Queue. Stores {@link DeadLetterEntry} records for worker executions that
+ * have exhausted all retry attempts. Supports query by status/worker/time range, manual discard,
+ * and replay acknowledgement.
+ *
+ * <p>Thread-safe. Current implementation is in-memory; a persistent-storage hook (Redis, Hibernate)
+ * can be added by providing an alternative CDI bean.
+ */
+@ApplicationScoped
+public class DeadLetterQueue {
+
+  private final Map<String, DeadLetterEntry> store = new ConcurrentHashMap<>();
+
+  /**
+   * Adds a new entry to the queue with {@link DeadLetterStatus#PENDING_REVIEW}.
+   *
+   * @param caseId the case whose worker failed
+   * @param workerId the failing worker name
+   * @param idempotencyHash the input hash used for deduplication
+   * @param inputContext the original worker input data
+   * @return the newly created entry
+   */
+  public DeadLetterEntry add(
+      UUID caseId, String workerId, String idempotencyHash, Map<String, Object> inputContext) {
+    String id = UUID.randomUUID().toString();
+    DeadLetterEntry entry =
+        new DeadLetterEntry(id, caseId, workerId, idempotencyHash, inputContext);
+    store.put(id, entry);
+    return entry;
+  }
+
+  /**
+   * Returns all entries matching the given query. Filters are AND-combined.
+   *
+   * @param query the filter specification
+   * @return matching entries (unordered)
+   */
+  public List<DeadLetterEntry> query(DeadLetterQuery query) {
+    return store.values().stream().filter(query.toPredicate()).collect(Collectors.toList());
+  }
+
+  /**
+   * Marks the entry as {@link DeadLetterStatus#DISCARDED}. No-op if the ID is not found.
+   *
+   * @param deadLetterId the entry to discard
+   */
+  public void discard(String deadLetterId) {
+    DeadLetterEntry entry = store.get(deadLetterId);
+    if (entry != null) {
+      entry.setStatus(DeadLetterStatus.DISCARDED);
+    }
+  }
+
+  /**
+   * Marks the entry as {@link DeadLetterStatus#REPLAYED} after a successful replay submission.
+   * No-op if the ID is not found.
+   *
+   * @param deadLetterId the entry that was replayed
+   */
+  public void markReplayed(String deadLetterId) {
+    DeadLetterEntry entry = store.get(deadLetterId);
+    if (entry != null) {
+      entry.setStatus(DeadLetterStatus.REPLAYED);
+    }
+  }
+
+  /** Returns the total number of entries in the queue regardless of status. */
+  public int size() {
+    return store.size();
+  }
+
+  /** Removes all entries. Intended for test isolation only. */
+  public void clear() {
+    store.clear();
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterStatus.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+/** Lifecycle status of a {@link DeadLetterEntry}. */
+public enum DeadLetterStatus {
+  /** Entry is awaiting human review or automated replay. */
+  PENDING_REVIEW,
+
+  /** Entry has been replayed (re-submitted for execution). */
+  REPLAYED,
+
+  /** Entry has been acknowledged as unrecoverable and will not be retried. */
+  DISCARDED
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillDetector.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillDetector.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Sliding-window circuit breaker that quarantines workers that fail too frequently.
+ *
+ * <p>Tracks failure timestamps per worker within a configurable time window. When the number of
+ * failures within the window reaches the threshold, the worker is quarantined for a cool-down
+ * period. Quarantined workers should be skipped by the scheduler — no further executions are
+ * attempted until the quarantine expires or is manually released.
+ *
+ * <p>Thread-safe. All state is in-memory.
+ */
+@ApplicationScoped
+public class PoisonPillDetector {
+
+  private static final Logger LOG = Logger.getLogger(PoisonPillDetector.class);
+
+  private final int failureThreshold;
+  private final Duration failureWindow;
+  private final Duration quarantineDuration;
+
+  /** Sliding window of failure timestamps per worker. */
+  private final Map<String, Deque<Instant>> failureWindows = new ConcurrentHashMap<>();
+
+  /** Quarantine expiry times per worker. Absent = not quarantined. */
+  private final Map<String, Instant> quarantinedUntil = new ConcurrentHashMap<>();
+
+  /** CDI no-arg constructor using config properties. */
+  PoisonPillDetector(
+      @ConfigProperty(name = "casehub.resilience.poison-pill.threshold", defaultValue = "5")
+          int failureThreshold,
+      @ConfigProperty(name = "casehub.resilience.poison-pill.window", defaultValue = "PT10M")
+          Duration failureWindow,
+      @ConfigProperty(name = "casehub.resilience.poison-pill.quarantine", defaultValue = "PT30M")
+          Duration quarantineDuration) {
+    this.failureThreshold = failureThreshold;
+    this.failureWindow = failureWindow;
+    this.quarantineDuration = quarantineDuration;
+  }
+
+  /**
+   * Records a failure for the given worker. If the number of failures within the sliding window
+   * reaches the threshold, the worker is quarantined.
+   *
+   * @param workerId the name of the failing worker
+   */
+  public synchronized void recordFailure(String workerId) {
+    Instant now = Instant.now();
+    Deque<Instant> window = failureWindows.computeIfAbsent(workerId, k -> new ArrayDeque<>());
+
+    window.addLast(now);
+    evictExpired(window, now);
+
+    if (window.size() >= failureThreshold) {
+      Instant until = now.plus(quarantineDuration);
+      quarantinedUntil.put(workerId, until);
+      LOG.warnf(
+          "Worker quarantined: workerId=%s, failures=%d, until=%s", workerId, window.size(), until);
+    }
+  }
+
+  /**
+   * Returns {@code true} if the worker is currently quarantined. Expired quarantines are
+   * automatically cleared.
+   *
+   * @param workerId the worker to check
+   */
+  public boolean isQuarantined(String workerId) {
+    Instant expiry = quarantinedUntil.get(workerId);
+    if (expiry == null) {
+      return false;
+    }
+    if (Instant.now().isAfter(expiry)) {
+      quarantinedUntil.remove(workerId);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Manually releases a quarantine and resets the failure window for the given worker. Useful for
+   * operator intervention after a fix is deployed.
+   *
+   * @param workerId the worker to release
+   */
+  public synchronized void release(String workerId) {
+    quarantinedUntil.remove(workerId);
+    failureWindows.remove(workerId);
+    LOG.infof("Quarantine released for workerId=%s", workerId);
+  }
+
+  /**
+   * Returns the set of currently quarantined worker IDs. Expired quarantines are excluded (lazily
+   * cleaned on read).
+   */
+  public Set<String> quarantinedWorkers() {
+    Instant now = Instant.now();
+    // Evict expired entries first
+    quarantinedUntil.entrySet().removeIf(e -> now.isAfter(e.getValue()));
+    return Collections.unmodifiableSet(quarantinedUntil.keySet());
+  }
+
+  private void evictExpired(Deque<Instant> window, Instant now) {
+    Instant cutoff = now.minus(failureWindow);
+    while (!window.isEmpty() && window.peekFirst().isBefore(cutoff)) {
+      window.pollFirst();
+    }
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillWorkerExecutionGuard.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillWorkerExecutionGuard.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import io.casehub.api.spi.WorkerExecutionGuard;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.UUID;
+
+/**
+ * {@link WorkerExecutionGuard} that blocks workers quarantined by the {@link PoisonPillDetector}.
+ *
+ * <p>Active when {@code casehub-resilience} is on the classpath and selected as the CDI alternative
+ * (via {@code quarkus.arc.selected-alternatives} in {@code application.properties}).
+ */
+@Alternative
+@Priority(10)
+@ApplicationScoped
+public class PoisonPillWorkerExecutionGuard implements WorkerExecutionGuard {
+
+  @Inject PoisonPillDetector detector;
+
+  @Override
+  public boolean isBlocked(String workerId, UUID caseId) {
+    return detector.isQuarantined(workerId);
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterEventHandlerTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterEventHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test: verifies that publishing a {@code WORKER_RETRIES_EXHAUSTED} event on the Vert.x
+ * event bus results in a {@link DeadLetterEntry} being created in the {@link DeadLetterQueue}.
+ *
+ * <p>No real case is started — just the event bus publish + DLQ listener.
+ */
+@QuarkusTest
+class DeadLetterEventHandlerTest {
+
+  @Inject EventBus eventBus;
+
+  @Inject DeadLetterQueue deadLetterQueue;
+
+  @BeforeEach
+  void clearQueue() {
+    // DeadLetterQueue is ApplicationScoped — clear between tests to keep them independent.
+    deadLetterQueue.clear();
+  }
+
+  @Test
+  void workerRetriesExhaustedEvent_createsEntryInDlq() {
+    UUID caseId = UUID.randomUUID();
+    String workerId = "failing-worker";
+    String hash = "test-hash-001";
+
+    eventBus.publish(
+        EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+        new WorkerRetriesExhaustedEvent(caseId, workerId, hash));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<DeadLetterEntry> entries = deadLetterQueue.query(DeadLetterQuery.all());
+              assertThat(entries).hasSize(1);
+              DeadLetterEntry entry = entries.get(0);
+              assertThat(entry.caseId()).isEqualTo(caseId);
+              assertThat(entry.workerId()).isEqualTo(workerId);
+              assertThat(entry.idempotencyHash()).isEqualTo(hash);
+              assertThat(entry.status()).isEqualTo(DeadLetterStatus.PENDING_REVIEW);
+            });
+  }
+
+  @Test
+  void multipleExhaustedEvents_eachCreatesSeparateEntry() {
+    UUID caseA = UUID.randomUUID();
+    UUID caseB = UUID.randomUUID();
+
+    eventBus.publish(
+        EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+        new WorkerRetriesExhaustedEvent(caseA, "worker-a", "hash-a"));
+    eventBus.publish(
+        EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+        new WorkerRetriesExhaustedEvent(caseB, "worker-b", "hash-b"));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<DeadLetterEntry> entries = deadLetterQueue.query(DeadLetterQuery.all());
+              assertThat(entries).hasSize(2);
+              assertThat(entries.stream().map(DeadLetterEntry::caseId))
+                  .containsExactlyInAnyOrder(caseA, caseB);
+            });
+  }
+
+  @Test
+  void dlqEntry_isQueryableByWorkerId() {
+    UUID caseId = UUID.randomUUID();
+    eventBus.publish(
+        EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+        new WorkerRetriesExhaustedEvent(caseId, "specific-worker", "hash-xyz"));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<DeadLetterEntry> results =
+                  deadLetterQueue.query(DeadLetterQuery.forWorker("specific-worker"));
+              assertThat(results).hasSize(1);
+              assertThat(results.get(0).caseId()).isEqualTo(caseId);
+            });
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueEndToEndTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueEndToEndTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.BackoffStrategy;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test: a real case is started with a worker that always fails. After maxAttempts, the
+ * engine emits WORKER_RETRIES_EXHAUSTED, the case transitions to FAULTED, and the DLQ receives an
+ * entry with the correct metadata.
+ */
+@QuarkusTest
+class DeadLetterQueueEndToEndTest {
+
+  @Inject AlwaysFailingCaseHub alwaysFailingCase;
+  @Inject FastFailingCaseHub fastFailingCase;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject DeadLetterQueue deadLetterQueue;
+
+  @BeforeEach
+  void clearQueue() {
+    deadLetterQueue.clear();
+  }
+
+  /** Happy path: exhausted retries → FAULTED case + DLQ entry. */
+  @Test
+  void workerExhaustingRetries_faultsCase_andCreatesDlqEntry() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    alwaysFailingCase
+        .startCase(Map.of("status", "start"))
+        .thenAccept(caseIdRef::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    // Wait for case to be created
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(caseIdRef.get()).isNotNull();
+            });
+
+    UUID caseId = caseIdRef.get();
+
+    // Wait for case to reach FAULTED (all retries exhausted)
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
+            });
+
+    // DLQ must have exactly one entry for this case
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<DeadLetterEntry> entries = deadLetterQueue.query(DeadLetterQuery.all());
+              assertThat(entries).hasSize(1);
+
+              DeadLetterEntry entry = entries.get(0);
+              assertThat(entry.caseId()).isEqualTo(caseId);
+              assertThat(entry.workerId()).isEqualTo("always-failing-worker");
+              assertThat(entry.status()).isEqualTo(DeadLetterStatus.PENDING_REVIEW);
+              assertThat(entry.idempotencyHash()).isNotBlank();
+            });
+  }
+
+  /** DLQ entry can be discarded after inspection. */
+  @Test
+  void dlqEntry_canBeDiscarded() {
+    fastFailingCase.startCase(Map.of("status", "start")).toCompletableFuture().join();
+
+    // Wait for DLQ entry
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(deadLetterQueue.size()).isGreaterThan(0));
+
+    String id = deadLetterQueue.query(DeadLetterQuery.all()).get(0).deadLetterId();
+    deadLetterQueue.discard(id);
+
+    List<DeadLetterEntry> pending =
+        deadLetterQueue.query(DeadLetterQuery.withStatus(DeadLetterStatus.PENDING_REVIEW));
+    List<DeadLetterEntry> discarded =
+        deadLetterQueue.query(DeadLetterQuery.withStatus(DeadLetterStatus.DISCARDED));
+
+    assertThat(pending).isEmpty();
+    assertThat(discarded).hasSize(1);
+  }
+
+  // ---- CaseHub bean: always fails, 2 retries (fast) -------------------------
+
+  @ApplicationScoped
+  public static class AlwaysFailingCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("doWork")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-dlq-e2e")
+          .name("Always Failing Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("always-failing-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        throw new RuntimeException("Intentional failure for DLQ E2E test");
+                      })
+                  .executionPolicy(
+                      new ExecutionPolicy(5000, new RetryPolicy(2, 100, BackoffStrategy.FIXED)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  public static class FastFailingCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("fastFail")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder()
+            .name("fastDone")
+            .condition(".status == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-dlq-e2e-fast")
+          .name("Fast Failing Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("fast-failing-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        throw new RuntimeException("Fast failure");
+                      })
+                  .executionPolicy(
+                      new ExecutionPolicy(5000, new RetryPolicy(1, 50, BackoffStrategy.FIXED)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("fast-trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests — no Quarkus, no CDI. DeadLetterQueue is an in-memory store and must be testable
+ * without a container.
+ */
+class DeadLetterQueueTest {
+
+  private DeadLetterQueue queue;
+
+  @BeforeEach
+  void setUp() {
+    queue = new DeadLetterQueue();
+  }
+
+  // ---- add ------------------------------------------------------------------
+
+  @Test
+  void add_storesEntryWithPendingReviewStatus() {
+    UUID caseId = UUID.randomUUID();
+    DeadLetterEntry entry = queue.add(caseId, "my-worker", "hash-abc", Map.of("key", "value"));
+
+    assertThat(entry.deadLetterId()).isNotNull();
+    assertThat(entry.caseId()).isEqualTo(caseId);
+    assertThat(entry.workerId()).isEqualTo("my-worker");
+    assertThat(entry.idempotencyHash()).isEqualTo("hash-abc");
+    assertThat(entry.status()).isEqualTo(DeadLetterStatus.PENDING_REVIEW);
+    assertThat(entry.arrivedAt()).isNotNull();
+    assertThat(entry.inputContext()).containsEntry("key", "value");
+  }
+
+  @Test
+  void add_multipleEntriesAreStoredIndependently() {
+    UUID caseA = UUID.randomUUID();
+    UUID caseB = UUID.randomUUID();
+
+    queue.add(caseA, "worker-1", "hash-1", Map.of());
+    queue.add(caseB, "worker-2", "hash-2", Map.of());
+
+    List<DeadLetterEntry> all = queue.query(DeadLetterQuery.all());
+    assertThat(all).hasSize(2);
+    assertThat(all.stream().map(DeadLetterEntry::caseId)).containsExactlyInAnyOrder(caseA, caseB);
+  }
+
+  // ---- query ----------------------------------------------------------------
+
+  @Test
+  void query_all_returnsEveryEntry() {
+    queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+    queue.add(UUID.randomUUID(), "w2", "h2", Map.of());
+    queue.add(UUID.randomUUID(), "w3", "h3", Map.of());
+
+    assertThat(queue.query(DeadLetterQuery.all())).hasSize(3);
+  }
+
+  @Test
+  void query_byStatus_filtersPendingOnly() {
+    UUID caseId = UUID.randomUUID();
+    DeadLetterEntry added = queue.add(caseId, "w1", "h1", Map.of());
+    queue.discard(added.deadLetterId());
+
+    List<DeadLetterEntry> pending =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.PENDING_REVIEW));
+    List<DeadLetterEntry> discarded =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.DISCARDED));
+
+    assertThat(pending).isEmpty();
+    assertThat(discarded).hasSize(1);
+    assertThat(discarded.get(0).caseId()).isEqualTo(caseId);
+  }
+
+  @Test
+  void query_byWorkerId_filtersCorrectly() {
+    queue.add(UUID.randomUUID(), "target-worker", "h1", Map.of());
+    queue.add(UUID.randomUUID(), "other-worker", "h2", Map.of());
+
+    List<DeadLetterEntry> results = queue.query(DeadLetterQuery.forWorker("target-worker"));
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).workerId()).isEqualTo("target-worker");
+  }
+
+  @Test
+  void query_arrivedAfter_excludesOlderEntries() throws InterruptedException {
+    queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+    Instant cutoff = Instant.now();
+    Thread.sleep(5); // ensure next entry has a later timestamp
+    queue.add(UUID.randomUUID(), "w2", "h2", Map.of());
+
+    List<DeadLetterEntry> results = queue.query(DeadLetterQuery.arrivedAfter(cutoff));
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).workerId()).isEqualTo("w2");
+  }
+
+  @Test
+  void query_emptyQueue_returnsEmptyList() {
+    assertThat(queue.query(DeadLetterQuery.all())).isEmpty();
+  }
+
+  // ---- discard --------------------------------------------------------------
+
+  @Test
+  void discard_updatesStatusToDiscarded() {
+    DeadLetterEntry entry = queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+
+    queue.discard(entry.deadLetterId());
+
+    List<DeadLetterEntry> discarded =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.DISCARDED));
+    assertThat(discarded).hasSize(1);
+    assertThat(discarded.get(0).deadLetterId()).isEqualTo(entry.deadLetterId());
+  }
+
+  @Test
+  void discard_unknownId_doesNothing() {
+    queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+    queue.discard("nonexistent-id"); // must not throw
+
+    assertThat(queue.query(DeadLetterQuery.all())).hasSize(1);
+  }
+
+  // ---- replay ---------------------------------------------------------------
+
+  @Test
+  void replay_updatesStatusToReplayed() {
+    DeadLetterEntry entry = queue.add(UUID.randomUUID(), "w1", "h1", Map.of("doc", "id-1"));
+
+    queue.markReplayed(entry.deadLetterId());
+
+    List<DeadLetterEntry> replayed =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.REPLAYED));
+    assertThat(replayed).hasSize(1);
+    assertThat(replayed.get(0).deadLetterId()).isEqualTo(entry.deadLetterId());
+  }
+
+  @Test
+  void replay_preservesOriginalInputContext() {
+    Map<String, Object> input = Map.of("documentId", "doc-99", "status", "failed");
+    DeadLetterEntry entry = queue.add(UUID.randomUUID(), "w1", "h1", input);
+
+    queue.markReplayed(entry.deadLetterId());
+
+    DeadLetterEntry replayed =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.REPLAYED)).get(0);
+    assertThat(replayed.inputContext()).containsEntry("documentId", "doc-99");
+  }
+
+  // ---- size / eviction sanity -----------------------------------------------
+
+  @Test
+  void size_reflectsNumberOfStoredEntries() {
+    assertThat(queue.size()).isZero();
+    queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+    queue.add(UUID.randomUUID(), "w2", "h2", Map.of());
+    assertThat(queue.size()).isEqualTo(2);
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillDetectorTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillDetectorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests — no Quarkus, no CDI. PoisonPillDetector is a self-contained sliding-window
+ * circuit breaker that must be testable without a container.
+ */
+class PoisonPillDetectorTest {
+
+  /** Small threshold and window for fast tests. */
+  private PoisonPillDetector detector;
+
+  @BeforeEach
+  void setUp() {
+    // threshold=3, window=1 minute, quarantine=1 minute
+    detector = new PoisonPillDetector(3, Duration.ofMinutes(1), Duration.ofMinutes(1));
+  }
+
+  // ---- Below threshold — not quarantined ------------------------------------
+
+  @Test
+  void belowThreshold_workerIsNotQuarantined() {
+    detector.recordFailure("worker-a");
+    detector.recordFailure("worker-a");
+
+    assertThat(detector.isQuarantined("worker-a")).isFalse();
+  }
+
+  @Test
+  void noFailures_workerIsNotQuarantined() {
+    assertThat(detector.isQuarantined("brand-new-worker")).isFalse();
+  }
+
+  // ---- At threshold — quarantined -------------------------------------------
+
+  @Test
+  void atThreshold_workerIsQuarantined() {
+    detector.recordFailure("worker-b");
+    detector.recordFailure("worker-b");
+    detector.recordFailure("worker-b"); // 3rd failure triggers quarantine
+
+    assertThat(detector.isQuarantined("worker-b")).isTrue();
+  }
+
+  @Test
+  void beyondThreshold_workerRemainsQuarantined() {
+    for (int i = 0; i < 10; i++) {
+      detector.recordFailure("worker-c");
+    }
+    assertThat(detector.isQuarantined("worker-c")).isTrue();
+  }
+
+  // ---- Quarantine only affects the named worker -----------------------------
+
+  @Test
+  void quarantineIsPerWorker_otherWorkersUnaffected() {
+    detector.recordFailure("bad-worker");
+    detector.recordFailure("bad-worker");
+    detector.recordFailure("bad-worker");
+
+    assertThat(detector.isQuarantined("bad-worker")).isTrue();
+    assertThat(detector.isQuarantined("good-worker")).isFalse();
+  }
+
+  // ---- Manual release -------------------------------------------------------
+
+  @Test
+  void release_clearsQuarantine() {
+    detector.recordFailure("worker-d");
+    detector.recordFailure("worker-d");
+    detector.recordFailure("worker-d");
+    assertThat(detector.isQuarantined("worker-d")).isTrue();
+
+    detector.release("worker-d");
+
+    assertThat(detector.isQuarantined("worker-d")).isFalse();
+  }
+
+  @Test
+  void release_unknownWorker_doesNotThrow() {
+    detector.release("nonexistent"); // must not throw
+  }
+
+  @Test
+  void release_resetsFailureCount() {
+    // After release, two more failures should NOT re-trigger quarantine (below threshold)
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e");
+    detector.release("worker-e");
+
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e"); // only 2 new failures
+
+    assertThat(detector.isQuarantined("worker-e")).isFalse();
+  }
+
+  // ---- Failures outside window don't count ----------------------------------
+
+  @Test
+  void failuresOutsideWindow_doNotContributeToThreshold() throws InterruptedException {
+    // Use a very short window detector
+    PoisonPillDetector shortWindowDetector =
+        new PoisonPillDetector(3, Duration.ofMillis(50), Duration.ofMinutes(1));
+
+    shortWindowDetector.recordFailure("worker-f");
+    shortWindowDetector.recordFailure("worker-f");
+    Thread.sleep(100); // let the window expire
+
+    // These two are within the new window — below threshold of 3
+    shortWindowDetector.recordFailure("worker-f");
+    shortWindowDetector.recordFailure("worker-f");
+
+    assertThat(shortWindowDetector.isQuarantined("worker-f")).isFalse();
+  }
+
+  // ---- Quarantine expiry ----------------------------------------------------
+
+  @Test
+  void quarantine_expiresAfterCoolDown() throws InterruptedException {
+    PoisonPillDetector shortQuarantineDetector =
+        new PoisonPillDetector(3, Duration.ofMinutes(1), Duration.ofMillis(80));
+
+    shortQuarantineDetector.recordFailure("worker-g");
+    shortQuarantineDetector.recordFailure("worker-g");
+    shortQuarantineDetector.recordFailure("worker-g");
+    assertThat(shortQuarantineDetector.isQuarantined("worker-g")).isTrue();
+
+    Thread.sleep(150); // wait for quarantine to expire
+
+    assertThat(shortQuarantineDetector.isQuarantined("worker-g")).isFalse();
+  }
+
+  // ---- Quarantine status reporting ------------------------------------------
+
+  @Test
+  void quarantinedWorkers_listReturnsAllQuarantinedNames() {
+    detector.recordFailure("slow-worker");
+    detector.recordFailure("slow-worker");
+    detector.recordFailure("slow-worker");
+
+    assertThat(detector.quarantinedWorkers()).contains("slow-worker");
+    assertThat(detector.quarantinedWorkers()).doesNotContain("clean-worker");
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test: verifies that once a worker is quarantined by {@link PoisonPillDetector}, the
+ * engine skips scheduling it and the case transitions to FAULTED without additional execution
+ * attempts.
+ *
+ * <p>The test pre-quarantines the worker directly via {@link PoisonPillDetector} (bypassing the
+ * failure count mechanism), then starts a case and verifies the worker is never invoked.
+ */
+@QuarkusTest
+class PoisonPillIntegrationTest {
+
+  @Inject PoisonPillDetector detector;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject QuarantineSkipCaseHub quarantineSkipCase;
+
+  @BeforeEach
+  void releaseAll() {
+    detector.release("quarantine-checked-worker");
+    QuarantineSkipCaseHub.runCount.set(0);
+  }
+
+  /**
+   * When the worker is quarantined, the engine must NOT invoke it — the worker function should
+   * never run, and the case should fault due to no eligible workers.
+   */
+  @Test
+  void quarantinedWorker_isNeverInvoked_andCaseFaults() {
+    // Pre-quarantine: record enough failures to trigger quarantine (threshold=3 in test config)
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isTrue();
+
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    quarantineSkipCase
+        .startCase(Map.of("status", "run"))
+        .thenAccept(caseIdRef::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(caseIdRef.get()).isNotNull();
+            });
+
+    UUID caseId = caseIdRef.get();
+
+    // Case must reach FAULTED — quarantined worker cannot execute
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
+            });
+
+    // Worker function must have been called zero times
+    assertThat(QuarantineSkipCaseHub.runCount.get())
+        .as("quarantined worker must not execute")
+        .isZero();
+  }
+
+  /** After releasing the quarantine, the worker should execute normally and complete the case. */
+  @Test
+  void afterRelease_workerExecutesNormally() {
+    // Pre-quarantine then release
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isTrue();
+
+    detector.release("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isFalse();
+
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    quarantineSkipCase
+        .startCase(Map.of("status", "run"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseIdRef.get());
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    assertThat(QuarantineSkipCaseHub.runCount.get())
+        .as("released worker should have executed once")
+        .isEqualTo(1);
+  }
+
+  // ---- CaseHub bean ---------------------------------------------------------
+
+  @ApplicationScoped
+  public static class QuarantineSkipCaseHub extends CaseHub {
+
+    static final AtomicInteger runCount = new AtomicInteger(0);
+
+    private final Capability capability =
+        Capability.builder()
+            .name("checkedWork")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder()
+            .name("done")
+            .condition(".status == \"complete\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-poison-pill-e2e")
+          .name("Quarantine Skip Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("quarantine-checked-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        runCount.incrementAndGet();
+                        return Map.of("status", "complete");
+                      })
+                  .executionPolicy(new ExecutionPolicy(5000, new RetryPolicy(1, 100)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"run\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Part of #51 — `casehub-resilience` module (2 of 3). Builds on #52.

- **`DeadLetterQueue`** — `@ApplicationScoped` in-memory store (ConcurrentHashMap); receives entries when `WORKER_RETRIES_EXHAUSTED` fires via `DeadLetterEventHandler` (`@ConsumeEvent`); runs alongside the engine's existing fault handler — both receive the event independently
- **`DeadLetterEntry`** — captures `caseId`, `workerId`, idempotency hash, input context, arrival timestamp, and status (PENDING_REVIEW → REPLAYED | DISCARDED)
- **`DeadLetterQuery`** — composable filters (by status, workerId, arrivedAfter); combined via AND

## Test plan

- [ ] 12 pure unit tests (`DeadLetterQueueTest`): add, query by status/worker/time range, discard, replay, size
- [ ] 3 `@QuarkusTest` integration tests (`DeadLetterEventHandlerTest`): event bus publish → DLQ entry created with correct caseId/workerId/status
- [ ] 2 `@QuarkusTest` E2E tests (`DeadLetterQueueEndToEndTest`): real case with always-failing worker exhausts retries → DLQ entry created; entry can be discarded