### PR TITLE
feat(resilience): PoisonPill detection — sliding-window quarantine, scheduler skip

### DIFF
--- a/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillDetector.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillDetector.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Sliding-window circuit breaker that quarantines workers that fail too frequently.
+ *
+ * <p>Tracks failure timestamps per worker within a configurable time window. When the number of
+ * failures within the window reaches the threshold, the worker is quarantined for a cool-down
+ * period. Quarantined workers should be skipped by the scheduler — no further executions are
+ * attempted until the quarantine expires or is manually released.
+ *
+ * <p>Thread-safe. All state is in-memory.
+ */
+@ApplicationScoped
+public class PoisonPillDetector {
+
+  private static final Logger LOG = Logger.getLogger(PoisonPillDetector.class);
+
+  private final int failureThreshold;
+  private final Duration failureWindow;
+  private final Duration quarantineDuration;
+
+  /** Sliding window of failure timestamps per worker. */
+  private final Map<String, Deque<Instant>> failureWindows = new ConcurrentHashMap<>();
+
+  /** Quarantine expiry times per worker. Absent = not quarantined. */
+  private final Map<String, Instant> quarantinedUntil = new ConcurrentHashMap<>();
+
+  /** CDI no-arg constructor using config properties. */
+  PoisonPillDetector(
+      @ConfigProperty(name = "casehub.resilience.poison-pill.threshold", defaultValue = "5")
+          int failureThreshold,
+      @ConfigProperty(name = "casehub.resilience.poison-pill.window", defaultValue = "PT10M")
+          Duration failureWindow,
+      @ConfigProperty(name = "casehub.resilience.poison-pill.quarantine", defaultValue = "PT30M")
+          Duration quarantineDuration) {
+    this.failureThreshold = failureThreshold;
+    this.failureWindow = failureWindow;
+    this.quarantineDuration = quarantineDuration;
+  }
+
+  /**
+   * Records a failure for the given worker. If the number of failures within the sliding window
+   * reaches the threshold, the worker is quarantined.
+   *
+   * @param workerId the name of the failing worker
+   */
+  public synchronized void recordFailure(String workerId) {
+    Instant now = Instant.now();
+    Deque<Instant> window = failureWindows.computeIfAbsent(workerId, k -> new ArrayDeque<>());
+
+    window.addLast(now);
+    evictExpired(window, now);
+
+    if (window.size() >= failureThreshold) {
+      Instant until = now.plus(quarantineDuration);
+      quarantinedUntil.put(workerId, until);
+      LOG.warnf(
+          "Worker quarantined: workerId=%s, failures=%d, until=%s", workerId, window.size(), until);
+    }
+  }
+
+  /**
+   * Returns {@code true} if the worker is currently quarantined. Expired quarantines are
+   * automatically cleared.
+   *
+   * @param workerId the worker to check
+   */
+  public boolean isQuarantined(String workerId) {
+    Instant expiry = quarantinedUntil.get(workerId);
+    if (expiry == null) {
+      return false;
+    }
+    if (Instant.now().isAfter(expiry)) {
+      quarantinedUntil.remove(workerId);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Manually releases a quarantine and resets the failure window for the given worker. Useful for
+   * operator intervention after a fix is deployed.
+   *
+   * @param workerId the worker to release
+   */
+  public synchronized void release(String workerId) {
+    quarantinedUntil.remove(workerId);
+    failureWindows.remove(workerId);
+    LOG.infof("Quarantine released for workerId=%s", workerId);
+  }
+
+  /**
+   * Returns the set of currently quarantined worker IDs. Expired quarantines are excluded (lazily
+   * cleaned on read).
+   */
+  public Set<String> quarantinedWorkers() {
+    Instant now = Instant.now();
+    // Evict expired entries first
+    quarantinedUntil.entrySet().removeIf(e -> now.isAfter(e.getValue()));
+    return Collections.unmodifiableSet(quarantinedUntil.keySet());
+  }
+
+  private void evictExpired(Deque<Instant> window, Instant now) {
+    Instant cutoff = now.minus(failureWindow);
+    while (!window.isEmpty() && window.peekFirst().isBefore(cutoff)) {
+      window.pollFirst();
+    }
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillWorkerExecutionGuard.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillWorkerExecutionGuard.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import io.casehub.api.spi.WorkerExecutionGuard;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.UUID;
+
+/**
+ * {@link WorkerExecutionGuard} that blocks workers quarantined by the {@link PoisonPillDetector}.
+ *
+ * <p>Active when {@code casehub-resilience} is on the classpath and selected as the CDI alternative
+ * (via {@code quarkus.arc.selected-alternatives} in {@code application.properties}).
+ */
+@Alternative
+@Priority(10)
+@ApplicationScoped
+public class PoisonPillWorkerExecutionGuard implements WorkerExecutionGuard {
+
+  @Inject PoisonPillDetector detector;
+
+  @Override
+  public boolean isBlocked(String workerId, UUID caseId) {
+    return detector.isQuarantined(workerId);
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillDetectorTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillDetectorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests — no Quarkus, no CDI. PoisonPillDetector is a self-contained sliding-window
+ * circuit breaker that must be testable without a container.
+ */
+class PoisonPillDetectorTest {
+
+  /** Small threshold and window for fast tests. */
+  private PoisonPillDetector detector;
+
+  @BeforeEach
+  void setUp() {
+    // threshold=3, window=1 minute, quarantine=1 minute
+    detector = new PoisonPillDetector(3, Duration.ofMinutes(1), Duration.ofMinutes(1));
+  }
+
+  // ---- Below threshold — not quarantined ------------------------------------
+
+  @Test
+  void belowThreshold_workerIsNotQuarantined() {
+    detector.recordFailure("worker-a");
+    detector.recordFailure("worker-a");
+
+    assertThat(detector.isQuarantined("worker-a")).isFalse();
+  }
+
+  @Test
+  void noFailures_workerIsNotQuarantined() {
+    assertThat(detector.isQuarantined("brand-new-worker")).isFalse();
+  }
+
+  // ---- At threshold — quarantined -------------------------------------------
+
+  @Test
+  void atThreshold_workerIsQuarantined() {
+    detector.recordFailure("worker-b");
+    detector.recordFailure("worker-b");
+    detector.recordFailure("worker-b"); // 3rd failure triggers quarantine
+
+    assertThat(detector.isQuarantined("worker-b")).isTrue();
+  }
+
+  @Test
+  void beyondThreshold_workerRemainsQuarantined() {
+    for (int i = 0; i < 10; i++) {
+      detector.recordFailure("worker-c");
+    }
+    assertThat(detector.isQuarantined("worker-c")).isTrue();
+  }
+
+  // ---- Quarantine only affects the named worker -----------------------------
+
+  @Test
+  void quarantineIsPerWorker_otherWorkersUnaffected() {
+    detector.recordFailure("bad-worker");
+    detector.recordFailure("bad-worker");
+    detector.recordFailure("bad-worker");
+
+    assertThat(detector.isQuarantined("bad-worker")).isTrue();
+    assertThat(detector.isQuarantined("good-worker")).isFalse();
+  }
+
+  // ---- Manual release -------------------------------------------------------
+
+  @Test
+  void release_clearsQuarantine() {
+    detector.recordFailure("worker-d");
+    detector.recordFailure("worker-d");
+    detector.recordFailure("worker-d");
+    assertThat(detector.isQuarantined("worker-d")).isTrue();
+
+    detector.release("worker-d");
+
+    assertThat(detector.isQuarantined("worker-d")).isFalse();
+  }
+
+  @Test
+  void release_unknownWorker_doesNotThrow() {
+    detector.release("nonexistent"); // must not throw
+  }
+
+  @Test
+  void release_resetsFailureCount() {
+    // After release, two more failures should NOT re-trigger quarantine (below threshold)
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e");
+    detector.release("worker-e");
+
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e"); // only 2 new failures
+
+    assertThat(detector.isQuarantined("worker-e")).isFalse();
+  }
+
+  // ---- Failures outside window don't count ----------------------------------
+
+  @Test
+  void failuresOutsideWindow_doNotContributeToThreshold() throws InterruptedException {
+    // Use a very short window detector
+    PoisonPillDetector shortWindowDetector =
+        new PoisonPillDetector(3, Duration.ofMillis(50), Duration.ofMinutes(1));
+
+    shortWindowDetector.recordFailure("worker-f");
+    shortWindowDetector.recordFailure("worker-f");
+    Thread.sleep(100); // let the window expire
+
+    // These two are within the new window — below threshold of 3
+    shortWindowDetector.recordFailure("worker-f");
+    shortWindowDetector.recordFailure("worker-f");
+
+    assertThat(shortWindowDetector.isQuarantined("worker-f")).isFalse();
+  }
+
+  // ---- Quarantine expiry ----------------------------------------------------
+
+  @Test
+  void quarantine_expiresAfterCoolDown() throws InterruptedException {
+    PoisonPillDetector shortQuarantineDetector =
+        new PoisonPillDetector(3, Duration.ofMinutes(1), Duration.ofMillis(80));
+
+    shortQuarantineDetector.recordFailure("worker-g");
+    shortQuarantineDetector.recordFailure("worker-g");
+    shortQuarantineDetector.recordFailure("worker-g");
+    assertThat(shortQuarantineDetector.isQuarantined("worker-g")).isTrue();
+
+    Thread.sleep(150); // wait for quarantine to expire
+
+    assertThat(shortQuarantineDetector.isQuarantined("worker-g")).isFalse();
+  }
+
+  // ---- Quarantine status reporting ------------------------------------------
+
+  @Test
+  void quarantinedWorkers_listReturnsAllQuarantinedNames() {
+    detector.recordFailure("slow-worker");
+    detector.recordFailure("slow-worker");
+    detector.recordFailure("slow-worker");
+
+    assertThat(detector.quarantinedWorkers()).contains("slow-worker");
+    assertThat(detector.quarantinedWorkers()).doesNotContain("clean-worker");
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test: verifies that once a worker is quarantined by {@link PoisonPillDetector}, the
+ * engine skips scheduling it and the case transitions to FAULTED without additional execution
+ * attempts.
+ *
+ * <p>The test pre-quarantines the worker directly via {@link PoisonPillDetector} (bypassing the
+ * failure count mechanism), then starts a case and verifies the worker is never invoked.
+ */
+@QuarkusTest
+class PoisonPillIntegrationTest {
+
+  @Inject PoisonPillDetector detector;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject QuarantineSkipCaseHub quarantineSkipCase;
+
+  @BeforeEach
+  void releaseAll() {
+    detector.release("quarantine-checked-worker");
+    QuarantineSkipCaseHub.runCount.set(0);
+  }
+
+  /**
+   * When the worker is quarantined, the engine must NOT invoke it — the worker function should
+   * never run, and the case should fault due to no eligible workers.
+   */
+  @Test
+  void quarantinedWorker_isNeverInvoked_andCaseFaults() {
+    // Pre-quarantine: record enough failures to trigger quarantine (threshold=3 in test config)
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isTrue();
+
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    quarantineSkipCase
+        .startCase(Map.of("status", "run"))
+        .thenAccept(caseIdRef::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(caseIdRef.get()).isNotNull();
+            });
+
+    UUID caseId = caseIdRef.get();
+
+    // Case must reach FAULTED — quarantined worker cannot execute
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
+            });
+
+    // Worker function must have been called zero times
+    assertThat(QuarantineSkipCaseHub.runCount.get())
+        .as("quarantined worker must not execute")
+        .isZero();
+  }
+
+  /** After releasing the quarantine, the worker should execute normally and complete the case. */
+  @Test
+  void afterRelease_workerExecutesNormally() {
+    // Pre-quarantine then release
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isTrue();
+
+    detector.release("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isFalse();
+
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    quarantineSkipCase
+        .startCase(Map.of("status", "run"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseIdRef.get());
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    assertThat(QuarantineSkipCaseHub.runCount.get())
+        .as("released worker should have executed once")
+        .isEqualTo(1);
+  }
+
+  // ---- CaseHub bean ---------------------------------------------------------
+
+  @ApplicationScoped
+  public static class QuarantineSkipCaseHub extends CaseHub {
+
+    static final AtomicInteger runCount = new AtomicInteger(0);
+
+    private final Capability capability =
+        Capability.builder()
+            .name("checkedWork")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder()
+            .name("done")
+            .condition(".status == \"complete\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-poison-pill-e2e")
+          .name("Quarantine Skip Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("quarantine-checked-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        runCount.incrementAndGet();
+                        return Map.of("status", "complete");
+                      })
+                  .executionPolicy(new ExecutionPolicy(5000, new RetryPolicy(1, 100)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"run\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Part of #51 — `casehub-resilience` module (3 of 3). Builds on #53.

- **`PoisonPillDetector`** — `@ApplicationScoped` sliding-window circuit breaker; tracks failure timestamps per worker; quarantines at threshold; auto-expiry after cool-down; manual `release()` for operator intervention
- **`PoisonPillWorkerExecutionGuard`** — `@Alternative @Priority(10)` implementation of the `WorkerExecutionGuard` SPI; active when `casehub-resilience` is on the classpath and selected via `quarkus.arc.selected-alternatives`; blocked workers cause `WorkerScheduleEventHandler` to emit `WORKER_RETRIES_EXHAUSTED`, triggering the normal FAULTED lifecycle

Configuration (all optional with defaults):
```
casehub.resilience.poison-pill.threshold  (default: 5)
casehub.resilience.poison-pill.window     (default: PT10M)
casehub.resilience.poison-pill.quarantine (default: PT30M)
```

## Test plan

- [x] 11 pure unit tests (`PoisonPillDetectorTest`): threshold detection, per-worker isolation, manual release, release resets failure count, failure window expiry, quarantine expiry, `quarantinedWorkers()` listing
- [x] 2 `@QuarkusTest` E2E tests (`PoisonPillIntegrationTest`): pre-quarantined worker is never invoked and case faults with zero executions; released worker executes normally and case completes