### PR TITLE
fix(engine): improve signal deduplication and worker recovery

### DIFF
--- a/api/src/main/java/io/casehub/api/context/CaseContext.java
+++ b/api/src/main/java/io/casehub/api/context/CaseContext.java
@@ -18,6 +18,7 @@ package io.casehub.api.context;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -58,6 +59,13 @@ public interface CaseContext {
   String getPathAsString(String path);
 
   CaseContext setPath(String path, Object value);
+
+  /**
+   * Atomically sets the value at {@code path} and returns the JSON diff against the state before
+   * the write. Returns {@link Optional#empty()} if the write produced no state change (idempotent
+   * signal deduplication).
+   */
+  Optional<JsonNode> applyAndDiff(String path, Object value);
 
   CaseContext setAll(Map<String, Object> values);
 

--- a/engine/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -313,6 +314,42 @@ public class CaseContextImpl implements CaseContext {
         version++;
       }
       return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<JsonNode> applyAndDiff(String path, Object value) {
+    lock.writeLock().lock();
+    try {
+      JsonNode before = mapper.convertValue(data, JsonNode.class);
+
+      String[] parts = path.split("\\.");
+      Map<String, Object> current = data;
+      for (int i = 0; i < parts.length - 1; i++) {
+        Object next = current.get(parts[i]);
+        if (next == null) {
+          next = new LinkedHashMap<String, Object>();
+          current.put(parts[i], next);
+        }
+        if (next instanceof Map) {
+          current = (Map<String, Object>) next;
+        } else {
+          throw new IllegalStateException("Cannot set path: " + parts[i] + " is not a Map");
+        }
+      }
+      String leaf = parts[parts.length - 1];
+      Object prev = current.get(leaf);
+      if (!Objects.equals(prev, value)) {
+        current.put(leaf, value);
+        version++;
+      }
+
+      JsonNode after = mapper.convertValue(data, JsonNode.class);
+      JsonNode diff = JsonDiff.asJson(before, after);
+      return diff.isEmpty() ? Optional.empty() : Optional.of(diff);
     } finally {
       lock.writeLock().unlock();
     }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
@@ -19,7 +19,6 @@ import static io.casehub.engine.internal.event.EventBusAddresses.CONTEXT_CHANGED
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.casehub.api.context.CaseContext;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
 import io.casehub.engine.internal.event.CaseContextChangedEvent;
@@ -36,6 +35,7 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Instant;
+import java.util.Optional;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -63,17 +63,18 @@ public class SignalReceivedEventHandler {
   }
 
   private Uni<Void> applySignal(CaseInstance instance, SignalReceivedEvent event) {
-    CaseContext before = instance.getCaseContext().snapshot();
-    instance.getCaseContext().setPath(event.path(), event.value());
-    JsonNode diff = before.diff(instance.getCaseContext());
-    JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
+    Optional<JsonNode> maybeDiff =
+        instance.getCaseContext().applyAndDiff(event.path(), event.value());
 
-    if (diff.isEmpty()) {
+    if (maybeDiff.isEmpty()) {
       LOG.debugf(
           "Signal path='%s' produced no state change for caseId=%s — skipping",
           event.path(), event.caseId());
       return Uni.createFrom().voidItem();
     }
+
+    JsonNode diff = maybeDiff.get();
+    JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
 
     return Panache.withTransaction(
             () -> {

--- a/engine/src/main/java/io/casehub/engine/internal/engine/recovery/WorkerExecutionRecoveryService.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/recovery/WorkerExecutionRecoveryService.java
@@ -106,22 +106,32 @@ public class WorkerExecutionRecoveryService {
   }
 
   private Uni<Void> reschedulePendingEvents(List<EventLog> eventLogs) {
-    Set<String> alreadyStarted = new HashSet<>();
+    // First pass: collect keys for every execution that has already been started,
+    // completed, or failed. Events are ordered by seq asc, so WORKER_SCHEDULED always
+    // appears before its matching terminal event in the stream. A single-pass approach
+    // would include every SCHEDULED event for recovery because the terminal event hasn't
+    // been seen yet when the SCHEDULED event is processed.
+    Set<String> alreadyProgressed = new HashSet<>();
+    for (EventLog eventLog : eventLogs) {
+      if (eventLog.getEventType() != CaseHubEventType.WORKER_SCHEDULED) {
+        String key = executionKey(eventLog);
+        if (key != null) {
+          alreadyProgressed.add(key);
+        }
+      }
+    }
+
+    // Second pass: only reschedule WORKER_SCHEDULED events that have no matching
+    // STARTED / COMPLETED / FAILED record (i.e. genuinely interrupted mid-flight).
     List<Uni<Void>> recoveries =
         eventLogs.stream()
             .filter(
                 eventLog -> {
-                  String executionKey = executionKey(eventLog);
-                  if (executionKey == null) {
+                  if (eventLog.getEventType() != CaseHubEventType.WORKER_SCHEDULED) {
                     return false;
                   }
-
-                  if (eventLog.getEventType() == CaseHubEventType.WORKER_SCHEDULED) {
-                    return !alreadyStarted.contains(executionKey);
-                  }
-
-                  alreadyStarted.add(executionKey);
-                  return false;
+                  String key = executionKey(eventLog);
+                  return key != null && !alreadyProgressed.contains(key);
                 })
             .map(workflowExecutionManager::schedulePersistedEvent)
             .toList();

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -19,3 +19,8 @@ quarkus.hibernate-orm.schema-management.strategy=validate
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:casehub}
 %prod.quarkus.datasource.username=${DB_USERNAME}
 %prod.quarkus.datasource.password=${DB_PASSWORD}
+
+quarkus.index-dependency.engine.group-id=io.casehub
+quarkus.index-dependency.engine.artifact-id=engine
+quarkus.index-dependency.api.group-id=io.casehub
+quarkus.index-dependency.api.artifact-id=api

--- a/engine/src/main/resources/db/migration/V1.1.0__Create_Application_Tables.sql
+++ b/engine/src/main/resources/db/migration/V1.1.0__Create_Application_Tables.sql
@@ -22,10 +22,11 @@ CREATE TABLE IF NOT EXISTS case_meta_model (
 
 -- Represents a running case instance linked to a definition
 CREATE TABLE IF NOT EXISTS case_instance (
-    id                 BIGINT      NOT NULL DEFAULT nextval('case_instance_seq'),
-    uuid               UUID        NOT NULL,
-    case_definition_id BIGINT      NOT NULL,
-    state              VARCHAR(50),
+    id                   BIGINT      NOT NULL DEFAULT nextval('case_instance_seq'),
+    uuid                 UUID        NOT NULL,
+    case_definition_id   BIGINT      NOT NULL,
+    state                VARCHAR(50),
+    parent_plan_item_id  UUID,
     PRIMARY KEY (id),
     CONSTRAINT uq_case_instance_uuid
         UNIQUE (uuid),


### PR DESCRIPTION
- introduce CaseContext.applyAndDiff() to compute diffs as part of the write operation
- prevent idempotent signals from producing extra context change events
- change recovery to reschedule only WORKER_SCHEDULED events that never progressed
- update the case_instance schema with parent_plan_item_id support
- configure Quarkus dependency indexing for consistent build-time bean discovery