### PR TITLE
feat(engine): enrich WORKER_EXECUTION_COMPLETED with ContextDiffStrategy

### DIFF
--- a/api/src/main/java/io/casehub/api/spi/ContextDiffStrategy.java
+++ b/api/src/main/java/io/casehub/api/spi/ContextDiffStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * SPI: computes the diff between CaseContext state before and after a worker execution.
+ *
+ * <p>The result is stored as {@code contextChanges} in the {@code WORKER_EXECUTION_COMPLETED}
+ * EventLog metadata. Return {@code null} to omit {@code contextChanges} entirely.
+ *
+ * <p>Three implementations are provided in the engine module:
+ *
+ * <ul>
+ *   <li>{@code TopLevelContextDiffStrategy} — default; per-key before/after object
+ *   <li>{@code JsonPatchContextDiffStrategy} — @Alternative; RFC 6902 array
+ *   <li>{@code NoOpContextDiffStrategy} — @Alternative; returns null, no overhead
+ * </ul>
+ *
+ * Switch via {@code quarkus.arc.selected-alternatives} in {@code application.properties}.
+ */
+public interface ContextDiffStrategy {
+
+  /**
+   * Computes the diff between the CaseContext before and after a worker execution.
+   *
+   * @param before CaseContext state snapshotted before {@code setAll(output)} was called
+   * @param after CaseContext state after {@code setAll(output)} was called
+   * @return diff node to store as {@code contextChanges}, or {@code null} to omit the field
+   */
+  JsonNode compute(JsonNode before, JsonNode after);
+}

--- a/casehub-blackboard/src/test/resources/application.properties
+++ b/casehub-blackboard/src/test/resources/application.properties
@@ -2,9 +2,3 @@
 %test.quarkus.flyway.clean-at-start=true
 
 quarkus.arc.selected-alternatives=io.casehub.blackboard.strategy.PlanningStrategyLoopControl
-
-# Index engine and api modules so Quarkus discovers their CDI beans
-quarkus.index-dependency.engine.group-id=io.casehub
-quarkus.index-dependency.engine.artifact-id=engine
-quarkus.index-dependency.api.group-id=io.casehub
-quarkus.index-dependency.api.artifact-id=api

--- a/casehub-blackboard/src/test/resources/application.properties
+++ b/casehub-blackboard/src/test/resources/application.properties
@@ -1,4 +1,4 @@
 %test.quarkus.hibernate-orm.mapping.format.global=ignore
 %test.quarkus.flyway.clean-at-start=true
 
-quarkus.arc.selected-alternatives=io.casehub.blackboard.strategy.PlanningStrategyLoopControl
+quarkus.arc.selected-alternatives=io.casehub.blackboard.strategy.PlanningStrategyLoopControl)

--- a/engine/src/main/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategy.java
@@ -18,7 +18,6 @@ package io.casehub.engine.internal.diff;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.casehub.api.spi.ContextDiffStrategy;
 import io.fabric8.zjsonpatch.JsonDiff;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 
@@ -38,7 +37,6 @@ import jakarta.enterprise.inject.Alternative;
  * </pre>
  */
 @Alternative
-@Priority(10)
 @ApplicationScoped
 public class JsonPatchContextDiffStrategy implements ContextDiffStrategy {
 

--- a/engine/src/main/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.spi.ContextDiffStrategy;
+import io.fabric8.zjsonpatch.JsonDiff;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * RFC 6902 JSON Patch {@link ContextDiffStrategy} using {@code zjsonpatch}.
+ *
+ * <p>Produces a JSON array of patch operations ({@code add}, {@code replace}, {@code remove}).
+ * Records changes at every affected path, including nested keys — more precise than {@link
+ * TopLevelContextDiffStrategy} but less readable for humans.
+ *
+ * <p>Useful as a foundation for future replay support (issues #10–#13).
+ *
+ * <p>Activate via:
+ *
+ * <pre>
+ * quarkus.arc.selected-alternatives=io.casehub.engine.internal.diff.JsonPatchContextDiffStrategy
+ * </pre>
+ */
+@Alternative
+@Priority(10)
+@ApplicationScoped
+public class JsonPatchContextDiffStrategy implements ContextDiffStrategy {
+
+  @Override
+  public JsonNode compute(JsonNode before, JsonNode after) {
+    return JsonDiff.asJson(before, after);
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategy.java
@@ -17,7 +17,6 @@ package io.casehub.engine.internal.diff;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.casehub.api.spi.ContextDiffStrategy;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 
@@ -31,7 +30,6 @@ import jakarta.enterprise.inject.Alternative;
  * </pre>
  */
 @Alternative
-@Priority(10)
 @ApplicationScoped
 public class NoOpContextDiffStrategy implements ContextDiffStrategy {
 

--- a/engine/src/main/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.spi.ContextDiffStrategy;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * No-op {@link ContextDiffStrategy}: skips diff computation entirely. {@code contextChanges} is
+ * omitted from {@code WORKER_EXECUTION_COMPLETED} metadata. Use when diff overhead is unwanted.
+ *
+ * <p>Activate via:
+ *
+ * <pre>quarkus.arc.selected-alternatives=io.casehub.engine.internal.diff.NoOpContextDiffStrategy
+ * </pre>
+ */
+@Alternative
+@Priority(10)
+@ApplicationScoped
+public class NoOpContextDiffStrategy implements ContextDiffStrategy {
+
+  @Override
+  public JsonNode compute(JsonNode before, JsonNode after) {
+    return null;
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategy.java
@@ -53,14 +53,18 @@ public class TopLevelContextDiffStrategy implements ContextDiffStrategy {
             key -> {
               JsonNode afterVal = after.get(key);
               JsonNode beforeVal = before.get(key);
-              if (!afterVal.equals(beforeVal)) {
-                ObjectNode change = MAPPER.createObjectNode();
-                if (beforeVal != null && !beforeVal.isMissingNode()) {
-                  change.set("before", beforeVal);
-                }
-                change.set("after", afterVal);
-                changes.set(key, change);
+              if (afterVal.equals(beforeVal)) {
+                return; // unchanged — omit
               }
+              ObjectNode change = MAPPER.createObjectNode();
+              if (beforeVal != null && !beforeVal.isMissingNode()) {
+                change.set("before", beforeVal);
+              }
+              // null written by worker is treated as removal — no "after" field
+              if (afterVal != null && !afterVal.isNull()) {
+                change.set("after", afterVal);
+              }
+              changes.set(key, change);
             });
 
     // Removed keys — present in `before` but absent in `after`

--- a/engine/src/main/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.casehub.api.spi.ContextDiffStrategy;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Default {@link ContextDiffStrategy}: records a before/after entry per changed top-level key.
+ *
+ * <p>Output format per key:
+ *
+ * <ul>
+ *   <li>Added: {@code { "after": value }} — no {@code before} field
+ *   <li>Updated: {@code { "before": oldValue, "after": newValue }}
+ *   <li>Removed: {@code { "before": oldValue }} — no {@code after} field
+ *   <li>Unchanged: omitted entirely
+ * </ul>
+ *
+ * <p>Operates on top-level keys only. Nested changes within an object value are captured as a
+ * whole-object before/after, not path-by-path. Use {@link JsonPatchContextDiffStrategy} for full
+ * path precision.
+ */
+@ApplicationScoped
+public class TopLevelContextDiffStrategy implements ContextDiffStrategy {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Override
+  public JsonNode compute(JsonNode before, JsonNode after) {
+    ObjectNode changes = MAPPER.createObjectNode();
+
+    // Added or updated keys — present in `after`
+    after
+        .fieldNames()
+        .forEachRemaining(
+            key -> {
+              JsonNode afterVal = after.get(key);
+              JsonNode beforeVal = before.get(key);
+              if (!afterVal.equals(beforeVal)) {
+                ObjectNode change = MAPPER.createObjectNode();
+                if (beforeVal != null && !beforeVal.isMissingNode()) {
+                  change.set("before", beforeVal);
+                }
+                change.set("after", afterVal);
+                changes.set(key, change);
+              }
+            });
+
+    // Removed keys — present in `before` but absent in `after`
+    before
+        .fieldNames()
+        .forEachRemaining(
+            key -> {
+              if (!after.has(key)) {
+                ObjectNode change = MAPPER.createObjectNode();
+                change.set("before", before.get(key));
+                changes.set(key, change);
+              }
+            });
+
+    return changes;
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -53,11 +53,10 @@ public class WorkflowExecutionCompletedHandler {
     final Map<String, Object> rawOutput = event.output() == null ? Map.of() : event.output();
     final Instant now = Instant.now();
 
-    // Snapshot context BEFORE applying worker output — used for diff computation
-    final JsonNode contextBefore = caseInstance.getCaseContext().asJsonNode();
-
     return Panache.withTransaction(
             () -> {
+              // Snapshot BEFORE applying output — deep copy so setAll cannot corrupt it
+              JsonNode contextBefore = caseInstance.getCaseContext().snapshot().asJsonNode();
               caseInstance.getCaseContext().setAll(rawOutput);
               JsonNode contextAfter = caseInstance.getCaseContext().asJsonNode();
 

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -17,7 +17,9 @@ package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.casehub.api.model.Worker;
+import io.casehub.api.spi.ContextDiffStrategy;
 import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
@@ -39,10 +41,10 @@ import org.jboss.logging.Logger;
 public class WorkflowExecutionCompletedHandler {
 
   @Inject EventBus eventBus;
+  @Inject ContextDiffStrategy contextDiffStrategy;
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  private static final Logger LOG = Logger.getLogger(CaseStartedEventHandler.class);
+  private static final Logger LOG = Logger.getLogger(WorkflowExecutionCompletedHandler.class);
 
   @ConsumeEvent(value = EventBusAddresses.WORKER_EXECUTION_FINISHED)
   public Uni<Void> onWorkflowExecutionCompletedHandler(WorkflowExecutionCompleted event) {
@@ -51,13 +53,19 @@ public class WorkflowExecutionCompletedHandler {
     final Map<String, Object> rawOutput = event.output() == null ? Map.of() : event.output();
     final Instant now = Instant.now();
 
-    final EventLog eventLog =
-        buildEventLog(caseInstance, worker, rawOutput, event.idempotency(), now);
+    // Snapshot context BEFORE applying worker output — used for diff computation
+    final JsonNode contextBefore = caseInstance.getCaseContext().asJsonNode();
+
     return Panache.withTransaction(
             () -> {
               caseInstance.getCaseContext().setAll(rawOutput);
-              JsonNode contextSnapshot = caseInstance.getCaseContext().asJsonNode();
-              return eventLog.persist().replaceWith(contextSnapshot);
+              JsonNode contextAfter = caseInstance.getCaseContext().asJsonNode();
+
+              JsonNode diff = contextDiffStrategy.compute(contextBefore, contextAfter);
+              EventLog eventLog =
+                  buildEventLog(caseInstance, worker, rawOutput, event.idempotency(), now, diff);
+
+              return eventLog.persist().replaceWith(contextAfter);
             })
         .invoke(
             contextSnapshot ->
@@ -79,18 +87,25 @@ public class WorkflowExecutionCompletedHandler {
       Worker worker,
       Map<String, Object> output,
       String idempotency,
-      Instant timestamp) {
+      Instant timestamp,
+      JsonNode contextDiff) {
     final EventLog eventLog = new EventLog();
     eventLog.setCaseId(caseInstance.getUuid());
     eventLog.setWorkerId(worker.getName());
     eventLog.setStreamType(EventStreamType.CASE);
     eventLog.setTimestamp(timestamp);
     eventLog.setEventType(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
-
     eventLog.setPayload(OBJECT_MAPPER.valueToTree(output == null ? Map.of() : output));
-
-    eventLog.setMetadata(OBJECT_MAPPER.createObjectNode().put("inputDataHash", idempotency));
-
+    eventLog.setMetadata(buildMetadata(idempotency, contextDiff));
     return eventLog;
+  }
+
+  private JsonNode buildMetadata(String idempotency, JsonNode contextDiff) {
+    ObjectNode metadata = OBJECT_MAPPER.createObjectNode();
+    metadata.put("inputDataHash", idempotency);
+    if (contextDiff != null) {
+      metadata.set("contextChanges", contextDiff);
+    }
+    return metadata;
   }
 }

--- a/engine/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
+++ b/engine/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.internal.util.ReactiveUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test: verifies that WORKER_EXECUTION_COMPLETED EventLog entries contain a {@code
+ * contextChanges} field reflecting the before/after state of CaseContext keys modified by the
+ * worker.
+ */
+@QuarkusTest
+class ContextDiffEndToEndTest {
+
+  private static final Duration DB_TIMEOUT = Duration.ofSeconds(10);
+
+  @Inject DiffCaseHub diffCase;
+  @Inject UpdateCaseHub updateCase;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject Mutiny.SessionFactory sessionFactory;
+  @Inject Vertx vertx;
+
+  /**
+   * Happy path: initial context has "status"="start". Worker writes "status"="done" and adds
+   * "result"="ok". EventLog must record status as updated, result as added.
+   */
+  @Test
+  void workerOutput_isReflectedInContextChanges() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+
+    diffCase
+        .startCase(Map.of("status", "start"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    UUID caseId = caseIdRef.get();
+
+    // Wait for COMPLETED
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    // Query the WORKER_EXECUTION_COMPLETED EventLog entry
+    EventLog completedEvent = fetchCompletedEvent(caseId);
+    assertThat(completedEvent).isNotNull();
+
+    var metadata = completedEvent.getMetadata();
+    assertThat(metadata.has("contextChanges")).isTrue();
+
+    var changes = metadata.get("contextChanges");
+
+    // "status" was updated: before="start", after="done"
+    assertThat(changes.has("status")).isTrue();
+    assertThat(changes.get("status").get("before").asText()).isEqualTo("start");
+    assertThat(changes.get("status").get("after").asText()).isEqualTo("done");
+
+    // "result" was added: no before, after="ok"
+    assertThat(changes.has("result")).isTrue();
+    assertThat(changes.get("result").has("before")).isFalse();
+    assertThat(changes.get("result").get("after").asText()).isEqualTo("ok");
+  }
+
+  /**
+   * Keys present in initial context that the worker does NOT touch must be absent from
+   * contextChanges.
+   */
+  @Test
+  void unchangedKeys_areAbsentFromContextChanges() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+
+    // Start with two keys; worker only touches "status"
+    updateCase
+        .startCase(Map.of("status", "start", "unchanged", "keep-me"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    UUID caseId = caseIdRef.get();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    EventLog completedEvent = fetchCompletedEvent(caseId);
+    var changes = completedEvent.getMetadata().get("contextChanges");
+
+    assertThat(changes.has("status")).isTrue();
+    assertThat(changes.has("unchanged")).isFalse();
+  }
+
+  /** The inputDataHash must still be present alongside contextChanges. */
+  @Test
+  void inputDataHash_remainsPresentAlongsideContextChanges() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    diffCase
+        .startCase(Map.of("status", "start"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseIdRef.get());
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    EventLog completedEvent = fetchCompletedEvent(caseIdRef.get());
+    var metadata = completedEvent.getMetadata();
+
+    assertThat(metadata.has("inputDataHash")).isTrue();
+    assertThat(metadata.get("inputDataHash").asText()).isNotBlank();
+    assertThat(metadata.has("contextChanges")).isTrue();
+  }
+
+  // ---- Helper ---------------------------------------------------------------
+
+  private EventLog fetchCompletedEvent(UUID caseId) {
+    List<EventLog> events =
+        ReactiveUtils.runOnSafeVertxContext(
+                vertx,
+                () ->
+                    sessionFactory.withSession(
+                        session ->
+                            session
+                                .createSelectionQuery(
+                                    "from EventLog where caseId = :caseId and eventType = :eventType order by seq asc",
+                                    EventLog.class)
+                                .setParameter("caseId", caseId)
+                                .setParameter(
+                                    "eventType", CaseHubEventType.WORKER_EXECUTION_COMPLETED)
+                                .getResultList()))
+            .await()
+            .atMost(DB_TIMEOUT);
+    return events.isEmpty() ? null : events.get(0);
+  }
+
+  // ---- CaseHub beans --------------------------------------------------------
+
+  /** Worker writes status="done" and adds result="ok". */
+  @ApplicationScoped
+  public static class DiffCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("doWork")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status, result: .result }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-context-diff")
+          .name("Context Diff Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("diff-worker")
+                  .capabilities(capability)
+                  .function(input -> Map.of("status", "done", "result", "ok"))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+
+  /** Worker writes only status="done"; leaves "unchanged" key untouched. */
+  @ApplicationScoped
+  public static class UpdateCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("partialUpdate")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-context-diff-partial")
+          .name("Partial Update Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("partial-worker")
+                  .capabilities(capability)
+                  .function(input -> Map.of("status", "done"))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategyTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategyTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+/** Pure unit tests — no CDI, no Quarkus. */
+class JsonPatchContextDiffStrategyTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final JsonPatchContextDiffStrategy strategy = new JsonPatchContextDiffStrategy();
+
+  @Test
+  void addedKey_producesAddOperation() {
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), after);
+
+    assertThat(diff.isArray()).isTrue();
+    assertThat(findOp(diff, "add", "/status")).isNotNull();
+    assertThat(findOp(diff, "add", "/status").get("value").asText()).isEqualTo("done");
+  }
+
+  @Test
+  void updatedKey_producesReplaceOperation() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(findOp(diff, "replace", "/status")).isNotNull();
+    assertThat(findOp(diff, "replace", "/status").get("value").asText()).isEqualTo("done");
+  }
+
+  @Test
+  void removedKey_producesRemoveOperation() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("tempKey", "bye");
+
+    JsonNode diff = strategy.compute(before, MAPPER.createObjectNode());
+
+    assertThat(findOp(diff, "remove", "/tempKey")).isNotNull();
+  }
+
+  @Test
+  void noChanges_producesEmptyArray() {
+    ObjectNode both = MAPPER.createObjectNode();
+    both.put("status", "done");
+
+    JsonNode diff = strategy.compute(both, both);
+
+    assertThat(diff.isArray()).isTrue();
+    assertThat(diff.size()).isZero();
+  }
+
+  @Test
+  void bothEmpty_producesEmptyArray() {
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), MAPPER.createObjectNode());
+
+    assertThat(diff.isArray()).isTrue();
+    assertThat(diff.size()).isZero();
+  }
+
+  @Test
+  void nestedChange_producesPathWithSlashSeparator() {
+    ObjectNode beforeDoc = MAPPER.createObjectNode();
+    beforeDoc.put("status", "draft");
+    ObjectNode before = MAPPER.createObjectNode();
+    before.set("doc", beforeDoc);
+
+    ObjectNode afterDoc = MAPPER.createObjectNode();
+    afterDoc.put("status", "published");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.set("doc", afterDoc);
+
+    JsonNode diff = strategy.compute(before, after);
+
+    // JSON Patch records /doc/status as the changed path
+    assertThat(findOp(diff, "replace", "/doc/status")).isNotNull();
+  }
+
+  /** Finds the first operation matching op type and path, or null. */
+  private JsonNode findOp(JsonNode patch, String op, String path) {
+    for (JsonNode node : patch) {
+      if (op.equals(node.path("op").asText()) && path.equals(node.path("path").asText())) {
+        return node;
+      }
+    }
+    return null;
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategyTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategyTest.java
@@ -42,7 +42,16 @@ class NoOpContextDiffStrategyTest {
   }
 
   @Test
-  void alwaysReturnsNull_forNullInputs() {
-    assertThat(strategy.compute(null, null)).isNull();
+  void alwaysReturnsNull_regardlessOfContent() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    before.put("score", 10);
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+    after.put("score", 99);
+    after.put("newKey", "hello");
+
+    // NoOp returns null regardless of how much the context changed
+    assertThat(strategy.compute(before, after)).isNull();
   }
 }

--- a/engine/src/test/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategyTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class NoOpContextDiffStrategyTest {
+
+  private final NoOpContextDiffStrategy strategy = new NoOpContextDiffStrategy();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void alwaysReturnsNull_forEmptyNodes() {
+    assertThat(strategy.compute(MAPPER.createObjectNode(), MAPPER.createObjectNode())).isNull();
+  }
+
+  @Test
+  void alwaysReturnsNull_forNonEmptyNodes() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    assertThat(strategy.compute(before, after)).isNull();
+  }
+
+  @Test
+  void alwaysReturnsNull_forNullInputs() {
+    assertThat(strategy.compute(null, null)).isNull();
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategyTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategyTest.java
@@ -98,6 +98,20 @@ class TopLevelContextDiffStrategyTest {
     assertThat(diff.get("tempKey").has("after")).isFalse();
   }
 
+  @Test
+  void nullValueWritten_treatedAsRemoval_noAfterField() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("tempKey", "old-value");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.putNull("tempKey"); // worker explicitly sets null
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.has("tempKey")).isTrue();
+    assertThat(diff.get("tempKey").get("before").asText()).isEqualTo("old-value");
+    assertThat(diff.get("tempKey").has("after")).isFalse();
+  }
+
   // ---- Unchanged keys -------------------------------------------------------
 
   @Test

--- a/engine/src/test/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategyTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategyTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+/** Pure unit tests — no CDI, no Quarkus. TopLevelContextDiffStrategy is a stateless utility. */
+class TopLevelContextDiffStrategyTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final TopLevelContextDiffStrategy strategy = new TopLevelContextDiffStrategy();
+
+  // ---- Added keys -----------------------------------------------------------
+
+  @Test
+  void addedKey_hasAfterOnly_noBeforeField() {
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), after);
+
+    assertThat(diff.has("status")).isTrue();
+    assertThat(diff.get("status").get("after").asText()).isEqualTo("done");
+    assertThat(diff.get("status").has("before")).isFalse();
+  }
+
+  @Test
+  void addedObjectKey_capturesFullValue() {
+    ObjectNode afterDoc = MAPPER.createObjectNode();
+    afterDoc.put("id", "doc-1");
+    afterDoc.put("title", "Test");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.set("doc", afterDoc);
+
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), after);
+
+    assertThat(diff.get("doc").get("after").get("id").asText()).isEqualTo("doc-1");
+    assertThat(diff.get("doc").has("before")).isFalse();
+  }
+
+  // ---- Updated keys ---------------------------------------------------------
+
+  @Test
+  void updatedKey_hasBeforeAndAfter() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.get("status").get("before").asText()).isEqualTo("processing");
+    assertThat(diff.get("status").get("after").asText()).isEqualTo("done");
+  }
+
+  @Test
+  void updatedNumericKey_capturesNumericValues() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("score", 10);
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("score", 99);
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.get("score").get("before").asInt()).isEqualTo(10);
+    assertThat(diff.get("score").get("after").asInt()).isEqualTo(99);
+  }
+
+  // ---- Removed keys ---------------------------------------------------------
+
+  @Test
+  void removedKey_hasBeforeOnly_noAfterField() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("tempKey", "old-value");
+
+    JsonNode diff = strategy.compute(before, MAPPER.createObjectNode());
+
+    assertThat(diff.has("tempKey")).isTrue();
+    assertThat(diff.get("tempKey").get("before").asText()).isEqualTo("old-value");
+    assertThat(diff.get("tempKey").has("after")).isFalse();
+  }
+
+  // ---- Unchanged keys -------------------------------------------------------
+
+  @Test
+  void unchangedKey_isOmittedFromDiff() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "done");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.has("status")).isFalse();
+  }
+
+  @Test
+  void mixedContext_onlyChangedKeysAppear() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    before.put("unchanged", "same");
+
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+    after.put("unchanged", "same");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.has("status")).isTrue();
+    assertThat(diff.has("unchanged")).isFalse();
+  }
+
+  // ---- No changes -----------------------------------------------------------
+
+  @Test
+  void noChanges_returnsEmptyObject() {
+    ObjectNode both = MAPPER.createObjectNode();
+    both.put("status", "done");
+    both.put("result", "ok");
+
+    JsonNode diff = strategy.compute(both, both);
+
+    assertThat(diff.size()).isZero();
+    assertThat(diff.isObject()).isTrue();
+  }
+
+  @Test
+  void bothEmpty_returnsEmptyObject() {
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), MAPPER.createObjectNode());
+
+    assertThat(diff.size()).isZero();
+  }
+
+  // ---- Multiple simultaneous changes ----------------------------------------
+
+  @Test
+  void multipleChanges_allCaptured() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    before.put("toRemove", "bye");
+
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+    after.put("newKey", "hello");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    // updated
+    assertThat(diff.get("status").get("before").asText()).isEqualTo("processing");
+    assertThat(diff.get("status").get("after").asText()).isEqualTo("done");
+    // added
+    assertThat(diff.get("newKey").get("after").asText()).isEqualTo("hello");
+    assertThat(diff.get("newKey").has("before")).isFalse();
+    // removed
+    assertThat(diff.get("toRemove").get("before").asText()).isEqualTo("bye");
+    assertThat(diff.get("toRemove").has("after")).isFalse();
+  }
+}


### PR DESCRIPTION
Summary
Closes https://github.com/casehubio/engine/issues/55

ContextDiffStrategy SPI (api) — pluggable diff computation injected into WorkflowExecutionCompletedHandler
TopLevelContextDiffStrategy (default) — records { "before": X, "after": Y } per changed top-level key; added keys omit before, removed keys omit after, unchanged keys omitted
JsonPatchContextDiffStrategy (@Alternative) — RFC 6902 JSON Patch array via zjsonpatch; foundation for future replay
NoOpContextDiffStrategy (@Alternative) — returns null, omits contextChanges entirely
Switch strategy via quarkus.arc.selected-alternatives — same pattern as WorkerExecutionGuard. Note: @Priority is intentionally absent from @Alternative beans — CDI 4.0/Quarkus activates @Alternative @Priority globally, causing ambiguity.
