### PR TITLE
feat(engine): add CaseMetaModelRepository, CaseInstanceRepository, EventLogRepository SPI interfaces

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git pull:*)",
+      "Bash(git remote:*)"
+    ]
+  }
+}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -31,7 +31,7 @@ jobs:
         run: mvn -B package --file pom.xml
 
       - name: Upload Surefire reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: surefire-reports-${{ matrix.os }}
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -70,7 +70,7 @@ jobs:
         shell: bash
 
       - name: Upload Surefire reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: surefire-reports-mvn-${{ matrix.mvn }}-java-${{ matrix.java }}

--- a/api/src/main/java/io/casehub/api/context/CaseContext.java
+++ b/api/src/main/java/io/casehub/api/context/CaseContext.java
@@ -18,6 +18,7 @@ package io.casehub.api.context;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -58,6 +59,13 @@ public interface CaseContext {
   String getPathAsString(String path);
 
   CaseContext setPath(String path, Object value);
+
+  /**
+   * Atomically sets the value at {@code path} and returns the JSON diff against the state before
+   * the write. Returns {@link Optional#empty()} if the write produced no state change (idempotent
+   * signal deduplication).
+   */
+  Optional<JsonNode> applyAndDiff(String path, Object value);
 
   CaseContext setAll(Map<String, Object> values);
 

--- a/api/src/main/java/io/casehub/api/context/CaseContext.java
+++ b/api/src/main/java/io/casehub/api/context/CaseContext.java
@@ -21,11 +21,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-public interface StateContext {
+public interface CaseContext {
 
   Map<String, Object> getData();
 
-  StateContext set(String key, Object value);
+  CaseContext set(String key, Object value);
 
   Object get(String key);
 
@@ -39,7 +39,7 @@ public interface StateContext {
 
   boolean compareAndSet(String key, Object expected, Object newValue);
 
-  StateContext update(String key, Function<Object, Object> updateFunction);
+  CaseContext update(String key, Function<Object, Object> updateFunction);
 
   String getString(String key);
 
@@ -57,17 +57,17 @@ public interface StateContext {
 
   String getPathAsString(String path);
 
-  StateContext setPath(String path, Object value);
+  CaseContext setPath(String path, Object value);
 
-  StateContext setAll(Map<String, Object> values);
+  CaseContext setAll(Map<String, Object> values);
 
   Map<String, Object> getAll(String... keys);
 
   boolean contains(String key);
 
-  StateContext remove(String key);
+  CaseContext remove(String key);
 
-  StateContext clear();
+  CaseContext clear();
 
   Set<String> getKeys();
 
@@ -77,11 +77,11 @@ public interface StateContext {
 
   JsonNode asJsonNode();
 
-  StateContext merge(StateContext other);
+  CaseContext merge(CaseContext other);
 
-  StateContext snapshot();
+  CaseContext snapshot();
 
-  JsonNode diff(StateContext other);
+  JsonNode diff(CaseContext other);
 
   void applyDiff(JsonNode diff);
 

--- a/api/src/main/java/io/casehub/api/engine/ExpressionEngine.java
+++ b/api/src/main/java/io/casehub/api/engine/ExpressionEngine.java
@@ -15,14 +15,14 @@
  */
 package io.casehub.api.engine;
 
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
 
 /**
  * SPI for pluggable expression evaluation engines.
  *
  * <p>Each engine declares the {@link ExpressionEvaluator#type()} it handles and evaluates
- * expressions of that type against a {@link StateContext}. Register additional engines as CDI beans
+ * expressions of that type against a {@link CaseContext}. Register additional engines as CDI beans
  * to support new expression languages (e.g. Drools, SpEL) without modifying the runtime.
  *
  * @see io.casehub.api.model.evaluator.JQExpressionEvaluator
@@ -42,7 +42,7 @@ public interface ExpressionEngine {
    * @param context the current case state
    * @return {@code true} if the expression matches, {@code false} otherwise
    */
-  boolean evaluate(ExpressionEvaluator evaluator, StateContext context);
+  boolean evaluate(ExpressionEvaluator evaluator, CaseContext context);
 
   /**
    * Validates the expression syntax without evaluating it against any context.

--- a/api/src/main/java/io/casehub/api/engine/LoopControl.java
+++ b/api/src/main/java/io/casehub/api/engine/LoopControl.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.api.engine;
 
-import io.casehub.api.context.StateContext;
 import io.casehub.api.model.Binding;
 import java.util.List;
 
@@ -34,9 +33,10 @@ public interface LoopControl {
    * Select the dispatch rules to fire from the set of rules whose trigger conditions have already
    * been evaluated and matched.
    *
-   * @param context the current case state context
+   * @param context case identity, definition, and current case state — enables implementations to
+   *     look up plan models without requiring access to internal engine structures
    * @param eligible rules whose trigger conditions matched — may be empty, never null
    * @return the subset to fire; may be empty, may be the full list, must not be null
    */
-  List<Binding> select(StateContext context, List<Binding> eligible);
+  List<Binding> select(PlanExecutionContext context, List<Binding> eligible);
 }

--- a/api/src/main/java/io/casehub/api/engine/PlanExecutionContext.java
+++ b/api/src/main/java/io/casehub/api/engine/PlanExecutionContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.engine;
+
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.model.CaseDefinition;
+import java.util.UUID;
+
+/**
+ * Context passed to {@link LoopControl#select} — carries case identity alongside {@link
+ * CaseContext}, enabling implementations to look up plan models and stage hierarchies without
+ * requiring access to internal engine structures.
+ */
+public record PlanExecutionContext(
+    UUID caseId, CaseDefinition definition, CaseContext caseContext) {}

--- a/api/src/main/java/io/casehub/api/model/BackoffStrategy.java
+++ b/api/src/main/java/io/casehub/api/model/BackoffStrategy.java
@@ -15,15 +15,21 @@
  */
 package io.casehub.api.model;
 
-public record RetryPolicy(Integer maxAttempts, Integer delayMs, BackoffStrategy backoffStrategy) {
+/** Backoff strategy applied between retry attempts. */
+public enum BackoffStrategy {
 
-  /** Default: 3 attempts, 10s fixed delay. */
-  public RetryPolicy() {
-    this(3, 10000, BackoffStrategy.FIXED);
-  }
+  /** Constant delay of {@code delayMs} between every attempt. */
+  FIXED,
 
-  /** Backwards-compatible 2-arg constructor — defaults to FIXED backoff. */
-  public RetryPolicy(Integer maxAttempts, Integer delayMs) {
-    this(maxAttempts, delayMs, BackoffStrategy.FIXED);
-  }
+  /**
+   * Delay doubles with each attempt ({@code delayMs * 2^(attempt-1)}), capped at 30 seconds.
+   * Prevents thundering-herd when many workers fail simultaneously.
+   */
+  EXPONENTIAL,
+
+  /**
+   * Exponential backoff with random jitter in {@code [0, exponentialDelay]}, capped at 30 seconds.
+   * Spreads retry load across time when many workers share the same backoff schedule.
+   */
+  EXPONENTIAL_WITH_JITTER
 }

--- a/api/src/main/java/io/casehub/api/model/CaseStatus.java
+++ b/api/src/main/java/io/casehub/api/model/CaseStatus.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+/**
+ * Lifecycle states for a {@code CaseInstance}.
+ *
+ * <p>Aligned with {@code io.serverlessworkflow.impl.WorkflowStatus} as used by Quarkus Flow and the
+ * CNCF Serverless Workflow specification.
+ *
+ * <p>{@code PENDING} is intentionally absent: the async event cycle transitions a case directly to
+ * {@code RUNNING} on creation. PENDING semantics for plan items and stages are managed by the
+ * {@code casehub-blackboard} module, not by {@code CaseInstance}.
+ */
+public enum CaseStatus {
+  /** Case is actively executing. */
+  RUNNING,
+  /** Case is blocked waiting for an external event or signal. */
+  WAITING,
+  /** Case has been paused by an administrative action. */
+  SUSPENDED,
+  /** Case completed successfully. */
+  COMPLETED,
+  /** Case terminated due to an error. */
+  FAULTED,
+  /** Case was stopped before completion. */
+  CANCELLED
+}

--- a/api/src/main/java/io/casehub/api/model/Goal.java
+++ b/api/src/main/java/io/casehub/api/model/Goal.java
@@ -15,9 +15,12 @@
  */
 package io.casehub.api.model;
 
+import io.casehub.api.context.CaseContext;
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * A named outcome that a case is trying to achieve, with success or failure polarity.
@@ -120,7 +123,16 @@ public class Goal {
     }
 
     public Builder condition(String condition) {
-      this.condition = new JQExpressionEvaluator(condition);
+      this.condition =
+          new JQExpressionEvaluator(
+              Objects.requireNonNull(condition, "condition must not be null"));
+      return this;
+    }
+
+    public Builder condition(Predicate<CaseContext> predicate) {
+      this.condition =
+          new LambdaExpressionEvaluator(
+              Objects.requireNonNull(predicate, "condition must not be null"));
       return this;
     }
 

--- a/api/src/main/java/io/casehub/api/model/Milestone.java
+++ b/api/src/main/java/io/casehub/api/model/Milestone.java
@@ -15,9 +15,12 @@
  */
 package io.casehub.api.model;
 
+import io.casehub.api.context.CaseContext;
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * A named waypoint that a case passes through on its way to a {@link Goal}.
@@ -110,7 +113,16 @@ public class Milestone {
     }
 
     public Builder condition(String condition) {
-      this.condition = new JQExpressionEvaluator(condition);
+      this.condition =
+          new JQExpressionEvaluator(
+              Objects.requireNonNull(condition, "condition must not be null"));
+      return this;
+    }
+
+    public Builder condition(Predicate<CaseContext> predicate) {
+      this.condition =
+          new LambdaExpressionEvaluator(
+              Objects.requireNonNull(predicate, "condition must not be null"));
       return this;
     }
 

--- a/api/src/main/java/io/casehub/api/model/Worker.java
+++ b/api/src/main/java/io/casehub/api/model/Worker.java
@@ -15,8 +15,9 @@
  */
 package io.casehub.api.model;
 
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import io.casehub.api.model.holder.WorkerFunctionHolder;
+import io.casehub.api.plan.PlanElement;
 import io.serverlessworkflow.api.types.Workflow;
 import java.io.File;
 import java.util.Arrays;
@@ -25,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-public class Worker {
+public class Worker implements PlanElement {
 
   private final String name;
   private final List<Capability> capabilities;
@@ -36,7 +37,7 @@ public class Worker {
   public Worker(
       String name,
       List<Capability> capabilities,
-      Function<StateContext, Map<String, Object>> function) {
+      Function<CaseContext, Map<String, Object>> function) {
     this(name, capabilities, new WorkerFunctionHolder<>(function));
   }
 

--- a/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/LambdaExpressionEvaluator.java
@@ -15,7 +15,7 @@
  */
 package io.casehub.api.model.evaluator;
 
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import java.util.function.Predicate;
 
 /**
@@ -28,9 +28,9 @@ public final class LambdaExpressionEvaluator implements ExpressionEvaluator {
 
   public static final String TYPE = "lambda";
 
-  private final Predicate<StateContext> predicate;
+  private final Predicate<CaseContext> predicate;
 
-  public LambdaExpressionEvaluator(final Predicate<StateContext> predicate) {
+  public LambdaExpressionEvaluator(final Predicate<CaseContext> predicate) {
     this.predicate = predicate;
   }
 
@@ -39,7 +39,7 @@ public final class LambdaExpressionEvaluator implements ExpressionEvaluator {
     return TYPE;
   }
 
-  public boolean test(final StateContext context) {
+  public boolean test(final CaseContext context) {
     return predicate.test(context);
   }
 }

--- a/api/src/main/java/io/casehub/api/plan/PlanElement.java
+++ b/api/src/main/java/io/casehub/api/plan/PlanElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.plan;
+
+/**
+ * Marker interface for elements that can be wrapped in a {@code PlanItem} and tracked through a
+ * CMMN lifecycle.
+ *
+ * <p>Permitted implementations: {@link io.casehub.api.model.Worker}, {@code
+ * io.casehub.blackboard.stage.Stage}, {@code io.casehub.blackboard.stage.SubCase}.
+ *
+ * <p>Not sealed — implementations span Maven module boundaries.
+ */
+public interface PlanElement {}

--- a/api/src/main/java/io/casehub/api/spi/ContextDiffStrategy.java
+++ b/api/src/main/java/io/casehub/api/spi/ContextDiffStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * SPI: computes the diff between CaseContext state before and after a worker execution.
+ *
+ * <p>The result is stored as {@code contextChanges} in the {@code WORKER_EXECUTION_COMPLETED}
+ * EventLog metadata. Return {@code null} to omit {@code contextChanges} entirely.
+ *
+ * <p>Three implementations are provided in the engine module:
+ *
+ * <ul>
+ *   <li>{@code TopLevelContextDiffStrategy} — default; per-key before/after object
+ *   <li>{@code JsonPatchContextDiffStrategy} — @Alternative; RFC 6902 array
+ *   <li>{@code NoOpContextDiffStrategy} — @Alternative; returns null, no overhead
+ * </ul>
+ *
+ * Switch via {@code quarkus.arc.selected-alternatives} in {@code application.properties}.
+ */
+public interface ContextDiffStrategy {
+
+  /**
+   * Computes the diff between the CaseContext before and after a worker execution.
+   *
+   * @param before CaseContext state snapshotted before {@code setAll(output)} was called
+   * @param after CaseContext state after {@code setAll(output)} was called
+   * @return diff node to store as {@code contextChanges}, or {@code null} to omit the field
+   */
+  JsonNode compute(JsonNode before, JsonNode after);
+}

--- a/api/src/main/java/io/casehub/api/spi/WorkerExecutionGuard.java
+++ b/api/src/main/java/io/casehub/api/spi/WorkerExecutionGuard.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+import java.util.UUID;
+
+/**
+ * SPI: determines whether a worker is allowed to execute for a given case.
+ *
+ * <p>The engine's default implementation ({@code AllowAllWorkerExecutionGuard}) always permits
+ * execution. The {@code casehub-resilience} module provides an {@code @Alternative} implementation
+ * that blocks quarantined workers (PoisonPill detection).
+ *
+ * <p>Implementations are CDI beans. Override via {@code @Alternative @Priority}.
+ */
+public interface WorkerExecutionGuard {
+
+  /**
+   * Returns {@code true} if the worker is blocked and must NOT be scheduled.
+   *
+   * @param workerId the worker name
+   * @param caseId the case instance ID
+   */
+  boolean isBlocked(String workerId, UUID caseId);
+}

--- a/casehub-blackboard/pom.xml
+++ b/casehub-blackboard/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.casehub</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>casehub-blackboard</artifactId>
+    <name>Case Hub :: Blackboard</name>
+    <description>Optional CMMN/Blackboard orchestration layer — Stages, PlanItems, PlanningStrategy</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/CasePlanModel.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/CasePlanModel.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.plan;
+
+import io.casehub.blackboard.stage.Stage;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Authored orchestration definition — a named list of root Stages. Separate from CaseDefinition.
+ */
+public class CasePlanModel {
+
+  private final String name;
+  private final List<Stage> stages;
+
+  private CasePlanModel(Builder b) {
+    this.name = b.name;
+    this.stages = List.copyOf(b.stages);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<Stage> getStages() {
+    return stages;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private String name;
+    private final List<Stage> stages = new ArrayList<>();
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder stages(Stage... stages) {
+      this.stages.addAll(Arrays.asList(stages));
+      return this;
+    }
+
+    public CasePlanModel build() {
+      Objects.requireNonNull(name, "name must not be null");
+      return new CasePlanModel(this);
+    }
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/CasePlanModelRegistry.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/CasePlanModelRegistry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.plan;
+
+import io.casehub.api.model.CaseDefinition;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * CDI singleton registry mapping CaseDefinition identity (namespace+name+version) to CasePlanModel.
+ * Register plans at application startup via {@code @PostConstruct}.
+ */
+@ApplicationScoped
+public class CasePlanModelRegistry {
+
+  private final Map<String, CasePlanModel> registry = new ConcurrentHashMap<>();
+
+  public void register(CaseDefinition definition, CasePlanModel model) {
+    registry.put(key(definition), model);
+  }
+
+  public Optional<CasePlanModel> find(CaseDefinition definition) {
+    return Optional.ofNullable(registry.get(key(definition)));
+  }
+
+  public Optional<CasePlanModel> findByKey(String namespace, String name, String version) {
+    return Optional.ofNullable(registry.get(namespace + ":" + name + ":" + version));
+  }
+
+  private static String key(CaseDefinition definition) {
+    return definition.getNamespace() + ":" + definition.getName() + ":" + definition.getVersion();
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.plan;
+
+import io.casehub.api.plan.PlanElement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Runtime lifecycle container for a {@link PlanElement}. Hierarchical — knows its parent and
+ * children. Each instance starts PENDING; transitions follow PlanItemStatus rules.
+ */
+public class PlanItem<T extends PlanElement> {
+
+  private final T element;
+  private PlanItemStatus status;
+  private PlanItem<?> parent;
+  private final List<PlanItem<?>> children = new ArrayList<>();
+  private Instant activatedAt;
+  private Instant completedAt;
+
+  private PlanItem(T element) {
+    this.element = element;
+    this.status = PlanItemStatus.PENDING;
+  }
+
+  public static <T extends PlanElement> PlanItem<T> of(T element) {
+    return new PlanItem<>(element);
+  }
+
+  public T getElement() {
+    return element;
+  }
+
+  public PlanItemStatus getStatus() {
+    return status;
+  }
+
+  public PlanItem<?> getParent() {
+    return parent;
+  }
+
+  public List<PlanItem<?>> getChildren() {
+    return Collections.unmodifiableList(children);
+  }
+
+  public Instant getActivatedAt() {
+    return activatedAt;
+  }
+
+  public Instant getCompletedAt() {
+    return completedAt;
+  }
+
+  public void addChild(PlanItem<?> child) {
+    child.parent = this;
+    children.add(child);
+  }
+
+  public void activate() {
+    requireStatus(PlanItemStatus.PENDING, "activate");
+    this.status = PlanItemStatus.ACTIVE;
+    this.activatedAt = Instant.now();
+  }
+
+  public void complete() {
+    requireStatus(PlanItemStatus.ACTIVE, "complete");
+    this.status = PlanItemStatus.COMPLETED;
+    this.completedAt = Instant.now();
+  }
+
+  public void terminate() {
+    if (status.isTerminal()) return; // idempotent for terminal states
+    this.status = PlanItemStatus.TERMINATED;
+    this.completedAt = Instant.now();
+    for (PlanItem<?> child : children) {
+      child.terminate();
+    }
+  }
+
+  public void fault() {
+    requireStatus(PlanItemStatus.ACTIVE, "fault");
+    this.status = PlanItemStatus.FAULTED;
+    this.completedAt = Instant.now();
+  }
+
+  private void requireStatus(PlanItemStatus required, String operation) {
+    if (status != required) {
+      throw new IllegalStateException(
+          "Cannot " + operation + " PlanItem in status " + status + " (requires " + required + ")");
+    }
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/PlanItemStatus.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/PlanItemStatus.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.plan;
+
+/** Lifecycle states for a {@link PlanItem}. */
+public enum PlanItemStatus {
+  /** Created — waiting for entry criteria to be met. */
+  PENDING,
+  /** Entry criteria met — element is executing. */
+  ACTIVE,
+  /** Completed successfully or exit criteria met. */
+  COMPLETED,
+  /** Stopped by design — parent terminated, or externally cancelled. */
+  TERMINATED,
+  /** Stopped by failure — worker exhausted retries, or sub-case faulted. */
+  FAULTED;
+
+  public boolean isTerminal() {
+    return this == COMPLETED || this == TERMINATED || this == FAULTED;
+  }
+
+  public boolean isActive() {
+    return this == ACTIVE;
+  }
+
+  public boolean isFaulted() {
+    return this == FAULTED;
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.stage;
+
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import io.casehub.api.plan.PlanElement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/** CMMN Stage — a named logical grouping of Workers with entry/exit criteria. */
+public class Stage implements PlanElement {
+
+  private final String name;
+  private final ExpressionEvaluator entryCondition;
+  private final ExpressionEvaluator exitCondition;
+  private final List<Worker> workers;
+  private final List<Stage> nestedStages;
+  private final List<SubCase> subCases;
+
+  private Stage(Builder b) {
+    this.name = b.name;
+    this.entryCondition = b.entryCondition;
+    this.exitCondition = b.exitCondition;
+    this.workers = List.copyOf(b.workers);
+    this.nestedStages = List.copyOf(b.nestedStages);
+    this.subCases = List.copyOf(b.subCases);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ExpressionEvaluator getEntryCondition() {
+    return entryCondition;
+  }
+
+  public ExpressionEvaluator getExitCondition() {
+    return exitCondition;
+  }
+
+  public List<Worker> getWorkers() {
+    return workers;
+  }
+
+  public List<Stage> getNestedStages() {
+    return nestedStages;
+  }
+
+  public List<SubCase> getSubCases() {
+    return subCases;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private String name;
+    private ExpressionEvaluator entryCondition;
+    private ExpressionEvaluator exitCondition;
+    private final List<Worker> workers = new ArrayList<>();
+    private final List<Stage> nestedStages = new ArrayList<>();
+    private final List<SubCase> subCases = new ArrayList<>();
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder entry(String jq) {
+      this.entryCondition =
+          new JQExpressionEvaluator(Objects.requireNonNull(jq, "entry condition must not be null"));
+      return this;
+    }
+
+    public Builder entry(Predicate<CaseContext> predicate) {
+      this.entryCondition =
+          new LambdaExpressionEvaluator(
+              Objects.requireNonNull(predicate, "entry condition must not be null"));
+      return this;
+    }
+
+    public Builder entry(ExpressionEvaluator evaluator) {
+      this.entryCondition = evaluator;
+      return this;
+    }
+
+    public Builder exit(String jq) {
+      this.exitCondition =
+          new JQExpressionEvaluator(Objects.requireNonNull(jq, "exit condition must not be null"));
+      return this;
+    }
+
+    public Builder exit(Predicate<CaseContext> predicate) {
+      this.exitCondition =
+          new LambdaExpressionEvaluator(
+              Objects.requireNonNull(predicate, "exit condition must not be null"));
+      return this;
+    }
+
+    public Builder exit(ExpressionEvaluator evaluator) {
+      this.exitCondition = evaluator;
+      return this;
+    }
+
+    public Builder workers(Worker... workers) {
+      this.workers.addAll(Arrays.asList(workers));
+      return this;
+    }
+
+    public Builder nestedStage(Stage stage) {
+      this.nestedStages.add(stage);
+      return this;
+    }
+
+    public Builder subCase(SubCase subCase) {
+      this.subCases.add(subCase);
+      return this;
+    }
+
+    public Stage build() {
+      Objects.requireNonNull(name, "name must not be null");
+      Objects.requireNonNull(entryCondition, "entry condition must not be null");
+      return new Stage(this);
+    }
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/SubCase.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/SubCase.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.stage;
+
+import io.casehub.api.plan.PlanElement;
+import io.casehub.blackboard.strategy.DefaultSubCaseCompletionStrategy;
+import io.casehub.blackboard.strategy.SubCaseCompletionStrategy;
+import java.util.Objects;
+
+/** Reference to a child case to spawn as a sub-case PlanItem. */
+public class SubCase implements PlanElement {
+
+  private final String namespace;
+  private final String name;
+  private final String version;
+  private final SubCaseCompletionStrategy completionStrategy;
+
+  private SubCase(Builder b) {
+    this.namespace = b.namespace;
+    this.name = b.name;
+    this.version = b.version;
+    this.completionStrategy = b.completionStrategy;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public SubCaseCompletionStrategy getCompletionStrategy() {
+    return completionStrategy;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private String namespace;
+    private String name;
+    private String version;
+    private SubCaseCompletionStrategy completionStrategy = new DefaultSubCaseCompletionStrategy();
+
+    public Builder namespace(String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+
+    public Builder completionStrategy(SubCaseCompletionStrategy strategy) {
+      this.completionStrategy = strategy;
+      return this;
+    }
+
+    public SubCase build() {
+      Objects.requireNonNull(namespace, "namespace must not be null");
+      Objects.requireNonNull(name, "name must not be null");
+      Objects.requireNonNull(version, "version must not be null");
+      return new SubCase(this);
+    }
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/DefaultPlanningStrategy.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/DefaultPlanningStrategy.java
@@ -13,13 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.casehub.engine.internal.model;
+package io.casehub.blackboard.strategy;
 
-public enum CaseState {
-  ACTIVE,
-  COMPLETED,
-  FAILED,
-  SUSPENDED,
-  TERMINATED,
-  WAITING
+import io.casehub.api.context.CaseContext;
+import io.casehub.blackboard.plan.PlanItem;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+/**
+ * Default: fires all eligible PlanItems — orchestration at Stage level, choreography within Stage.
+ */
+@ApplicationScoped
+public class DefaultPlanningStrategy implements PlanningStrategy {
+
+  @Override
+  public List<PlanItem<?>> select(CaseContext context, List<PlanItem<?>> eligible) {
+    return eligible;
+  }
 }

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/DefaultSubCaseCompletionStrategy.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/DefaultSubCaseCompletionStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.strategy;
+
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.blackboard.plan.PlanItemStatus;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/** Default: COMPLETED→COMPLETED, FAULTED→FAULTED, everything else→TERMINATED. */
+@ApplicationScoped
+public class DefaultSubCaseCompletionStrategy implements SubCaseCompletionStrategy {
+
+  @Override
+  public PlanItemStatus resolve(CaseStatus subCaseStatus, CaseContext subCaseContext) {
+    return switch (subCaseStatus) {
+      case COMPLETED -> PlanItemStatus.COMPLETED;
+      case FAULTED -> PlanItemStatus.FAULTED;
+      default -> PlanItemStatus.TERMINATED;
+    };
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/PlanningStrategy.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/PlanningStrategy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.strategy;
+
+import io.casehub.api.context.CaseContext;
+import io.casehub.blackboard.plan.PlanItem;
+import java.util.List;
+
+/**
+ * SPI for selecting which eligible {@link PlanItem}s to activate.
+ *
+ * <p>{@code eligible} contains PlanItem&lt;Worker&gt; and PlanItem&lt;SubCase&gt; whose containing
+ * Stage is ACTIVE and whose Binding trigger conditions have been evaluated as true by the engine.
+ */
+public interface PlanningStrategy {
+  List<PlanItem<?>> select(CaseContext context, List<PlanItem<?>> eligible);
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/PlanningStrategyLoopControl.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/PlanningStrategyLoopControl.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.strategy;
+
+import io.casehub.api.engine.LoopControl;
+import io.casehub.api.engine.PlanExecutionContext;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Worker;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.CasePlanModelRegistry;
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.plan.PlanItemStatus;
+import io.casehub.blackboard.stage.Stage;
+import io.casehub.engine.internal.engine.ExpressionEngineRegistry;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jboss.logging.Logger;
+
+/**
+ * Blackboard-aware {@link LoopControl} that layers Stage orchestration on top of the engine's
+ * choreography loop.
+ *
+ * <p>When a {@link CasePlanModel} is registered for the current case definition, this control gates
+ * eligible Bindings through the Stage lifecycle: only Bindings whose Worker belongs to an ACTIVE
+ * Stage are permitted. Bindings for Workers not assigned to any Stage pass through unchanged (pure
+ * choreography).
+ *
+ * <p>When no plan model is registered, all eligible Bindings are returned — identical to {@link
+ * io.casehub.engine.internal.engine.ChoreographyLoopControl}.
+ */
+@Alternative
+@Priority(10)
+@ApplicationScoped
+public class PlanningStrategyLoopControl implements LoopControl {
+
+  private static final Logger LOG = Logger.getLogger(PlanningStrategyLoopControl.class);
+
+  private final Map<UUID, List<PlanItem<Stage>>> planInstances = new ConcurrentHashMap<>();
+
+  @Inject CasePlanModelRegistry registry;
+  @Inject PlanningStrategy planningStrategy;
+  @Inject ExpressionEngineRegistry expressionEngineRegistry;
+
+  @Override
+  public List<Binding> select(PlanExecutionContext context, List<Binding> eligible) {
+    Optional<CasePlanModel> planModel = registry.find(context.definition());
+    if (planModel.isEmpty()) {
+      return eligible; // no plan model — pure choreography
+    }
+
+    UUID caseId = context.caseId();
+    List<PlanItem<Stage>> stageItems =
+        planInstances.computeIfAbsent(caseId, id -> buildPlanInstance(planModel.get()));
+
+    // 1. Evaluate entry criteria — activate PENDING stages
+    for (PlanItem<Stage> item : stageItems) {
+      evaluateEntry(item, context);
+    }
+
+    // 2. Evaluate exit criteria — complete ACTIVE stages with explicit exit condition
+    for (PlanItem<Stage> item : stageItems) {
+      evaluateExit(item, context);
+    }
+
+    // 3. Collect workers in ACTIVE stages
+    Map<String, Worker> activeStageWorkers = new HashMap<>();
+    for (PlanItem<Stage> item : stageItems) {
+      collectActiveWorkers(item, activeStageWorkers);
+    }
+
+    // 4. Split eligible bindings: staged vs free-floating
+    List<Binding> stagedBindings = new ArrayList<>();
+    List<Binding> freeFloatingBindings = new ArrayList<>();
+
+    for (Binding binding : eligible) {
+      if (binding.getCapability() == null) {
+        freeFloatingBindings.add(binding);
+        continue;
+      }
+      String cap = binding.getCapability().getName();
+      boolean inActiveStage =
+          activeStageWorkers.values().stream().anyMatch(w -> workerHasCapability(w, cap));
+      boolean inAnyStage = isCapabilityInAnyStage(cap, planModel.get());
+
+      if (!inAnyStage) {
+        freeFloatingBindings.add(binding); // choreographic — not in any stage
+      } else if (inActiveStage) {
+        stagedBindings.add(binding); // orchestrated and stage is active
+      }
+      // else: in a non-active stage — filtered out
+    }
+
+    // 5. Resolve staged bindings to PlanItems, delegate to PlanningStrategy
+    List<PlanItem<?>> eligibleItems = new ArrayList<>();
+    for (Binding binding : stagedBindings) {
+      String cap = binding.getCapability().getName();
+      activeStageWorkers.values().stream()
+          .filter(w -> workerHasCapability(w, cap))
+          .findFirst()
+          .ifPresent(
+              w -> {
+                PlanItem<Worker> workerItem = findWorkerItem(w, stageItems);
+                if (workerItem != null && !eligibleItems.contains(workerItem)) {
+                  eligibleItems.add(workerItem);
+                }
+              });
+    }
+
+    List<PlanItem<?>> selected = planningStrategy.select(context.caseContext(), eligibleItems);
+
+    // 6. Translate selected PlanItems back to Bindings
+    List<Binding> result = new ArrayList<>(freeFloatingBindings);
+    for (PlanItem<?> selectedItem : selected) {
+      if (!(selectedItem.getElement() instanceof Worker selectedWorker)) continue;
+      for (Binding binding : stagedBindings) {
+        if (binding.getCapability() != null
+            && workerHasCapability(selectedWorker, binding.getCapability().getName())) {
+          result.add(binding);
+          break;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  // ---- plan instance construction ----
+
+  private List<PlanItem<Stage>> buildPlanInstance(CasePlanModel model) {
+    List<PlanItem<Stage>> rootItems = new ArrayList<>();
+    for (Stage stage : model.getStages()) {
+      rootItems.add(buildStageItem(stage, null));
+    }
+    return rootItems;
+  }
+
+  private PlanItem<Stage> buildStageItem(Stage stage, PlanItem<?> parent) {
+    PlanItem<Stage> item = PlanItem.of(stage);
+    if (parent != null) {
+      parent.addChild(item);
+    }
+    for (Worker worker : stage.getWorkers()) {
+      item.addChild(PlanItem.of(worker));
+    }
+    for (Stage nested : stage.getNestedStages()) {
+      buildStageItem(nested, item);
+    }
+    return item;
+  }
+
+  // ---- entry/exit condition evaluation ----
+
+  private void evaluateEntry(PlanItem<Stage> item, PlanExecutionContext context) {
+    if (item.getStatus() == PlanItemStatus.PENDING) {
+      Stage stage = item.getElement();
+      if (expressionEngineRegistry.evaluate(stage.getEntryCondition(), context.caseContext())) {
+        LOG.infof("Stage '%s' entry condition met — activating", stage.getName());
+        item.activate();
+        // activate worker children
+        for (PlanItem<?> child : item.getChildren()) {
+          if (child.getElement() instanceof Worker && child.getStatus() == PlanItemStatus.PENDING) {
+            child.activate();
+          }
+        }
+      }
+    }
+    // recurse into nested stages only when parent is ACTIVE
+    if (item.getStatus() == PlanItemStatus.ACTIVE) {
+      for (PlanItem<?> child : item.getChildren()) {
+        if (child.getElement() instanceof Stage) {
+          @SuppressWarnings("unchecked")
+          PlanItem<Stage> nestedStage = (PlanItem<Stage>) child;
+          evaluateEntry(nestedStage, context);
+        }
+      }
+    }
+  }
+
+  private void evaluateExit(PlanItem<Stage> item, PlanExecutionContext context) {
+    if (item.getStatus() != PlanItemStatus.ACTIVE) return;
+    Stage stage = item.getElement();
+    if (stage.getExitCondition() != null
+        && expressionEngineRegistry.evaluate(stage.getExitCondition(), context.caseContext())) {
+      LOG.infof("Stage '%s' exit condition met — completing", stage.getName());
+      item.complete();
+    }
+    // recurse into active nested stages
+    for (PlanItem<?> child : item.getChildren()) {
+      if (child.getElement() instanceof Stage) {
+        @SuppressWarnings("unchecked")
+        PlanItem<Stage> nestedStage = (PlanItem<Stage>) child;
+        evaluateExit(nestedStage, context);
+      }
+    }
+  }
+
+  // ---- worker collection and matching ----
+
+  private void collectActiveWorkers(PlanItem<Stage> item, Map<String, Worker> result) {
+    if (item.getStatus() != PlanItemStatus.ACTIVE) return;
+    for (PlanItem<?> child : item.getChildren()) {
+      if (child.getElement() instanceof Worker w && child.getStatus() == PlanItemStatus.ACTIVE) {
+        result.put(w.getName(), w);
+      } else if (child.getElement() instanceof Stage) {
+        @SuppressWarnings("unchecked")
+        PlanItem<Stage> nestedStage = (PlanItem<Stage>) child;
+        collectActiveWorkers(nestedStage, result);
+      }
+    }
+  }
+
+  private boolean workerHasCapability(Worker worker, String capabilityName) {
+    return worker.getCapabilities().stream().anyMatch(c -> c.getName().equals(capabilityName));
+  }
+
+  private boolean isCapabilityInAnyStage(String capabilityName, CasePlanModel model) {
+    return model.getStages().stream().anyMatch(s -> stageContainsCapability(s, capabilityName));
+  }
+
+  private boolean stageContainsCapability(Stage stage, String capabilityName) {
+    for (Worker w : stage.getWorkers()) {
+      if (workerHasCapability(w, capabilityName)) return true;
+    }
+    for (Stage nested : stage.getNestedStages()) {
+      if (stageContainsCapability(nested, capabilityName)) return true;
+    }
+    return false;
+  }
+
+  private PlanItem<Worker> findWorkerItem(Worker worker, List<PlanItem<Stage>> stageItems) {
+    for (PlanItem<Stage> stageItem : stageItems) {
+      PlanItem<Worker> found = findWorkerItemInStage(worker, stageItem);
+      if (found != null) return found;
+    }
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private PlanItem<Worker> findWorkerItemInStage(Worker worker, PlanItem<Stage> stageItem) {
+    for (PlanItem<?> child : stageItem.getChildren()) {
+      if (child.getElement() instanceof Worker w && w.getName().equals(worker.getName())) {
+        return (PlanItem<Worker>) child;
+      } else if (child.getElement() instanceof Stage) {
+        PlanItem<Worker> found = findWorkerItemInStage(worker, (PlanItem<Stage>) child);
+        if (found != null) return found;
+      }
+    }
+    return null;
+  }
+
+  /** Evict cached plan instance for a completed or terminated case. */
+  public void evictCase(UUID caseId) {
+    planInstances.remove(caseId);
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/SubCaseCompletionStrategy.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/SubCaseCompletionStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.strategy;
+
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.blackboard.plan.PlanItemStatus;
+
+/**
+ * Maps a completed sub-case's {@link CaseStatus} to a {@link PlanItemStatus} for the parent {@link
+ * io.casehub.blackboard.plan.PlanItem}.
+ */
+@FunctionalInterface
+public interface SubCaseCompletionStrategy {
+  PlanItemStatus resolve(CaseStatus subCaseStatus, CaseContext subCaseContext);
+}

--- a/casehub-blackboard/src/main/resources/META-INF/beans.xml
+++ b/casehub-blackboard/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/BlackboardIntegrationTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/BlackboardIntegrationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class BlackboardIntegrationTest {
+
+  @Inject SingleStageCaseHub singleStageCase;
+  @Inject ExitConditionCaseHub exitConditionCase;
+  @Inject MixedCaseHub mixedCase;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  /** Test 1 — Single stage activates on entry, worker writes status, goal completes the case. */
+  @Test
+  public void singleStageActivatesAndCompletesViaGoal() {
+    AtomicReference<UUID> ref = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    singleStageCase
+        .startCase(Map.of("status", "processing"))
+        .thenAccept(ref::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertNotNull(ref.get());
+            });
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(ref.get());
+              assertNotNull(instance);
+              assertEquals(CaseStatus.COMPLETED, instance.getState());
+            });
+  }
+
+  /** Test 2 — Stage with explicit exit condition. Worker writes status that triggers exit. */
+  @Test
+  public void stageExitConditionCompletesCase() {
+    AtomicReference<UUID> ref = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    exitConditionCase
+        .startCase(Map.of("status", "start"))
+        .thenAccept(ref::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertNotNull(ref.get());
+            });
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(ref.get());
+              assertNotNull(instance);
+              assertEquals(CaseStatus.COMPLETED, instance.getState());
+            });
+  }
+
+  /** Test 3 — Free-floating worker alongside staged worker. Both run. */
+  @Test
+  public void freeFloatingAndStagedWorkersBothExecute() {
+    AtomicReference<UUID> ref = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    MixedCaseHub.stagedWorkerRan.set(false);
+    MixedCaseHub.freeWorkerRan.set(false);
+
+    mixedCase
+        .startCase(Map.of("status", "go"))
+        .thenAccept(ref::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertNotNull(ref.get());
+            });
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertTrue(MixedCaseHub.stagedWorkerRan.get(), "staged worker should have run");
+              assertTrue(MixedCaseHub.freeWorkerRan.get(), "free-floating worker should have run");
+            });
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/ExitConditionCaseHub.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/ExitConditionCaseHub.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.CasePlanModelRegistry;
+import io.casehub.blackboard.stage.Stage;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+
+/**
+ * Test bean: stage with explicit exit condition. Worker writes status that triggers both exit and
+ * goal.
+ */
+@ApplicationScoped
+public class ExitConditionCaseHub extends CaseHub {
+
+  @Inject CasePlanModelRegistry planModelRegistry;
+
+  private final CaseDefinition definition;
+
+  public ExitConditionCaseHub() {
+    Capability cap =
+        Capability.builder()
+            .name("exit-cond-cap")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    Goal goal =
+        Goal.builder()
+            .name("exited-goal")
+            .condition(".status == \"exited\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    Worker worker =
+        Worker.builder()
+            .name("exit-cond-worker")
+            .capabilities(cap)
+            .function(input -> Map.of("status", "exited"))
+            .build();
+
+    definition =
+        CaseDefinition.builder()
+            .namespace("blackboard-test")
+            .name("exit-condition-test")
+            .version("1.0.0")
+            .capabilities(cap)
+            .workers(worker)
+            .bindings(
+                Binding.builder()
+                    .name("trigger-exit")
+                    .capability(cap)
+                    .on(new ContextChangeTrigger(".status == \"start\""))
+                    .build())
+            .goals(goal)
+            .completion(GoalExpression.allOf(goal))
+            .build();
+  }
+
+  @PostConstruct
+  void registerPlanModel() {
+    Worker worker = definition.getWorkers().get(0);
+
+    CasePlanModel planModel =
+        CasePlanModel.builder()
+            .name("exit-condition-plan")
+            .stages(
+                Stage.builder()
+                    .name("start-stage")
+                    .entry(".status == \"start\"")
+                    .exit(".status == \"exited\"")
+                    .workers(worker)
+                    .build())
+            .build();
+
+    planModelRegistry.register(definition, planModel);
+  }
+
+  @Override
+  public CaseDefinition getDefinition() {
+    return definition;
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/MixedCaseHub.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/MixedCaseHub.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.CasePlanModelRegistry;
+import io.casehub.blackboard.stage.Stage;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Test bean: free-floating worker (not in any Stage) alongside a staged worker. Both must run. */
+@ApplicationScoped
+public class MixedCaseHub extends CaseHub {
+
+  static final AtomicBoolean stagedWorkerRan = new AtomicBoolean(false);
+  static final AtomicBoolean freeWorkerRan = new AtomicBoolean(false);
+
+  @Inject CasePlanModelRegistry planModelRegistry;
+
+  private final CaseDefinition definition;
+
+  public MixedCaseHub() {
+    Capability stagedCap =
+        Capability.builder()
+            .name("staged-cap")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ stagedDone: .stagedDone }")
+            .build();
+
+    Capability freeCap =
+        Capability.builder()
+            .name("free-cap")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ freeDone: .freeDone }")
+            .build();
+
+    Goal goal =
+        Goal.builder()
+            .name("mixed-goal")
+            .condition(".stagedDone == true and .freeDone == true")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    Worker stagedWorker =
+        Worker.builder()
+            .name("staged-worker")
+            .capabilities(stagedCap)
+            .function(
+                input -> {
+                  stagedWorkerRan.set(true);
+                  return Map.of("stagedDone", true);
+                })
+            .build();
+
+    Worker freeWorker =
+        Worker.builder()
+            .name("free-worker")
+            .capabilities(freeCap)
+            .function(
+                input -> {
+                  freeWorkerRan.set(true);
+                  return Map.of("freeDone", true);
+                })
+            .build();
+
+    definition =
+        CaseDefinition.builder()
+            .namespace("blackboard-test")
+            .name("mixed-test")
+            .version("1.0.0")
+            .capabilities(stagedCap, freeCap)
+            .workers(stagedWorker, freeWorker)
+            .bindings(
+                Binding.builder()
+                    .name("trigger-staged")
+                    .capability(stagedCap)
+                    .on(new ContextChangeTrigger(".status == \"go\""))
+                    .build(),
+                Binding.builder()
+                    .name("trigger-free")
+                    .capability(freeCap)
+                    .on(new ContextChangeTrigger(".status == \"go\""))
+                    .build())
+            .goals(goal)
+            .completion(GoalExpression.allOf(goal))
+            .build();
+  }
+
+  @PostConstruct
+  void registerPlanModel() {
+    Worker stagedWorker = definition.getWorkers().get(0);
+
+    CasePlanModel planModel =
+        CasePlanModel.builder()
+            .name("mixed-plan")
+            .stages(
+                Stage.builder()
+                    .name("staged-section")
+                    .entry(".status == \"go\"")
+                    .workers(stagedWorker)
+                    .build())
+            .build();
+
+    // Only the staged worker is in the plan model; freeWorker is not — so it's free-floating
+    planModelRegistry.register(definition, planModel);
+  }
+
+  @Override
+  public CaseDefinition getDefinition() {
+    return definition;
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/NestedStageIntegrationTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/NestedStageIntegrationTest.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.CasePlanModelRegistry;
+import io.casehub.blackboard.stage.Stage;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class NestedStageIntegrationTest {
+
+  @Inject TwoSequentialStagesCaseHub sequentialBean;
+  @Inject NestedStageCaseHub nestedBean;
+  @Inject LambdaConditionCaseHub lambdaBean;
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @BeforeEach
+  void reset() {
+    TwoSequentialStagesCaseHub.stage1Ran.set(0);
+    TwoSequentialStagesCaseHub.stage2Ran.set(0);
+    NestedStageCaseHub.outerRan.set(false);
+    NestedStageCaseHub.innerRan.set(false);
+    LambdaConditionCaseHub.workerRan.set(false);
+  }
+
+  /** Test 1 — Two sequential stages: stage1 fires on phase=one, stage2 fires on phase=two. */
+  @Test
+  void twoSequentialStagesActivateInOrder() {
+    AtomicReference<UUID> ref = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    sequentialBean
+        .startCase(Map.of("phase", "one"))
+        .thenAccept(ref::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(ref.get()).isNotNull();
+            });
+
+    await()
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(ref.get());
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+              assertThat(TwoSequentialStagesCaseHub.stage1Ran.get()).isGreaterThan(0);
+              assertThat(TwoSequentialStagesCaseHub.stage2Ran.get()).isGreaterThan(0);
+            });
+  }
+
+  /**
+   * Test 2 — Nested stage: outer stage fires, outerWorker enables inner stage, innerWorker runs.
+   */
+  @Test
+  void nestedStageActivatesAfterOuterWorker() {
+    AtomicReference<UUID> ref = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    nestedBean
+        .startCase(Map.of("status", "outer-ready"))
+        .thenAccept(ref::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(ref.get()).isNotNull();
+            });
+
+    await()
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(ref.get());
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+              assertThat(NestedStageCaseHub.outerRan.get()).isTrue();
+              assertThat(NestedStageCaseHub.innerRan.get()).isTrue();
+            });
+  }
+
+  /** Test 3 — Lambda entry condition: stage fires when value == 42. */
+  @Test
+  void lambdaEntryConditionActivatesStage() {
+    AtomicReference<UUID> ref = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    lambdaBean
+        .startCase(Map.of("value", 42))
+        .thenAccept(ref::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(ref.get()).isNotNull();
+            });
+
+    await()
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(ref.get());
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+              assertThat(LambdaConditionCaseHub.workerRan.get()).isTrue();
+            });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bean: TwoSequentialStagesCaseHub
+  // ---------------------------------------------------------------------------
+
+  @ApplicationScoped
+  static class TwoSequentialStagesCaseHub extends CaseHub {
+
+    static final AtomicInteger stage1Ran = new AtomicInteger(0);
+    static final AtomicInteger stage2Ran = new AtomicInteger(0);
+
+    @Inject CasePlanModelRegistry planRegistry;
+
+    private final CaseDefinition definition;
+
+    public TwoSequentialStagesCaseHub() {
+      Capability cap1 =
+          Capability.builder()
+              .name("seq-cap-stage1")
+              .inputSchema("{ phase: .phase }")
+              .outputSchema("{ phase: .phase }")
+              .build();
+
+      Capability cap2 =
+          Capability.builder()
+              .name("seq-cap-stage2")
+              .inputSchema("{ phase: .phase }")
+              .outputSchema("{ status: .status }")
+              .build();
+
+      Goal goal =
+          Goal.builder()
+              .name("seq-done-goal")
+              .condition(".status == \"done\"")
+              .kind(GoalKind.SUCCESS)
+              .build();
+
+      Worker worker1 =
+          Worker.builder()
+              .name("seq-worker-stage1")
+              .capabilities(cap1)
+              .function(
+                  input -> {
+                    stage1Ran.incrementAndGet();
+                    return Map.of("phase", "two");
+                  })
+              .build();
+
+      Worker worker2 =
+          Worker.builder()
+              .name("seq-worker-stage2")
+              .capabilities(cap2)
+              .function(
+                  input -> {
+                    stage2Ran.incrementAndGet();
+                    return Map.of("status", "done");
+                  })
+              .build();
+
+      definition =
+          CaseDefinition.builder()
+              .namespace("blackboard-nested-test")
+              .name("two-sequential-stages")
+              .version("1.0.0")
+              .capabilities(cap1, cap2)
+              .workers(worker1, worker2)
+              .bindings(
+                  Binding.builder()
+                      .name("seq-trigger-stage1")
+                      .capability(cap1)
+                      .on(new ContextChangeTrigger(".phase == \"one\""))
+                      .build(),
+                  Binding.builder()
+                      .name("seq-trigger-stage2")
+                      .capability(cap2)
+                      .on(new ContextChangeTrigger(".phase == \"two\""))
+                      .build())
+              .goals(goal)
+              .completion(GoalExpression.allOf(goal))
+              .build();
+    }
+
+    @PostConstruct
+    void registerPlan() {
+      Worker worker1 = definition.getWorkers().get(0);
+      Worker worker2 = definition.getWorkers().get(1);
+
+      CasePlanModel planModel =
+          CasePlanModel.builder()
+              .name("two-sequential-stages-plan")
+              .stages(
+                  Stage.builder()
+                      .name("seq-stage-one")
+                      .entry(".phase == \"one\"")
+                      .workers(worker1)
+                      .build(),
+                  Stage.builder()
+                      .name("seq-stage-two")
+                      .entry(".phase == \"two\"")
+                      .workers(worker2)
+                      .build())
+              .build();
+
+      planRegistry.register(definition, planModel);
+    }
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return definition;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bean: NestedStageCaseHub
+  // ---------------------------------------------------------------------------
+
+  @ApplicationScoped
+  static class NestedStageCaseHub extends CaseHub {
+
+    static final AtomicBoolean outerRan = new AtomicBoolean(false);
+    static final AtomicBoolean innerRan = new AtomicBoolean(false);
+
+    @Inject CasePlanModelRegistry planRegistry;
+
+    private final CaseDefinition definition;
+
+    public NestedStageCaseHub() {
+      Capability outerCap =
+          Capability.builder()
+              .name("nested-cap-outer")
+              .inputSchema("{ status: .status }")
+              .outputSchema("{ innerReady: .innerReady }")
+              .build();
+
+      Capability innerCap =
+          Capability.builder()
+              .name("nested-cap-inner")
+              .inputSchema("{ innerReady: .innerReady }")
+              .outputSchema("{ status: .status }")
+              .build();
+
+      Goal goal =
+          Goal.builder()
+              .name("nested-done-goal")
+              .condition(".status == \"nested-done\"")
+              .kind(GoalKind.SUCCESS)
+              .build();
+
+      Worker outerWorker =
+          Worker.builder()
+              .name("nested-outer-worker")
+              .capabilities(outerCap)
+              .function(
+                  input -> {
+                    outerRan.set(true);
+                    return Map.of("innerReady", true);
+                  })
+              .build();
+
+      Worker innerWorker =
+          Worker.builder()
+              .name("nested-inner-worker")
+              .capabilities(innerCap)
+              .function(
+                  input -> {
+                    innerRan.set(true);
+                    return Map.of("status", "nested-done");
+                  })
+              .build();
+
+      definition =
+          CaseDefinition.builder()
+              .namespace("blackboard-nested-test")
+              .name("nested-stage-case")
+              .version("1.0.0")
+              .capabilities(outerCap, innerCap)
+              .workers(outerWorker, innerWorker)
+              .bindings(
+                  Binding.builder()
+                      .name("nested-trigger-outer")
+                      .capability(outerCap)
+                      .on(new ContextChangeTrigger(".status == \"outer-ready\""))
+                      .build(),
+                  Binding.builder()
+                      .name("nested-trigger-inner")
+                      .capability(innerCap)
+                      .on(new ContextChangeTrigger(".innerReady == true"))
+                      .build())
+              .goals(goal)
+              .completion(GoalExpression.allOf(goal))
+              .build();
+    }
+
+    @PostConstruct
+    void registerPlan() {
+      Worker outerWorker = definition.getWorkers().get(0);
+      Worker innerWorker = definition.getWorkers().get(1);
+
+      Stage innerStage =
+          Stage.builder()
+              .name("nested-inner-stage")
+              .entry(".innerReady == true")
+              .workers(innerWorker)
+              .build();
+
+      CasePlanModel planModel =
+          CasePlanModel.builder()
+              .name("nested-stage-plan")
+              .stages(
+                  Stage.builder()
+                      .name("nested-outer-stage")
+                      .entry(".status == \"outer-ready\"")
+                      .workers(outerWorker)
+                      .nestedStage(innerStage)
+                      .build())
+              .build();
+
+      planRegistry.register(definition, planModel);
+    }
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return definition;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bean: LambdaConditionCaseHub
+  // ---------------------------------------------------------------------------
+
+  @ApplicationScoped
+  static class LambdaConditionCaseHub extends CaseHub {
+
+    static final AtomicBoolean workerRan = new AtomicBoolean(false);
+
+    @Inject CasePlanModelRegistry planRegistry;
+
+    private final CaseDefinition definition;
+
+    public LambdaConditionCaseHub() {
+      Capability cap =
+          Capability.builder()
+              .name("lambda-cap")
+              .inputSchema("{ value: .value }")
+              .outputSchema("{ status: .status }")
+              .build();
+
+      Goal goal =
+          Goal.builder()
+              .name("lambda-done-goal")
+              .condition(".status == \"lambda-done\"")
+              .kind(GoalKind.SUCCESS)
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("lambda-worker")
+              .capabilities(cap)
+              .function(
+                  input -> {
+                    workerRan.set(true);
+                    return Map.of("status", "lambda-done");
+                  })
+              .build();
+
+      definition =
+          CaseDefinition.builder()
+              .namespace("blackboard-nested-test")
+              .name("lambda-condition-case")
+              .version("1.0.0")
+              .capabilities(cap)
+              .workers(worker)
+              .bindings(
+                  Binding.builder()
+                      .name("lambda-trigger")
+                      .capability(cap)
+                      .on(new ContextChangeTrigger(".value == 42"))
+                      .build())
+              .goals(goal)
+              .completion(GoalExpression.allOf(goal))
+              .build();
+    }
+
+    @PostConstruct
+    void registerPlan() {
+      Worker worker = definition.getWorkers().get(0);
+
+      CasePlanModel planModel =
+          CasePlanModel.builder()
+              .name("lambda-condition-plan")
+              .stages(
+                  Stage.builder()
+                      .name("lambda-stage")
+                      .entry(
+                          (CaseContext ctx) -> {
+                            Object val = ctx.getPath("value");
+                            return val instanceof Number n && n.intValue() == 42;
+                          })
+                      .workers(worker)
+                      .build())
+              .build();
+
+      planRegistry.register(definition, planModel);
+    }
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return definition;
+    }
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/SingleStageCaseHub.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/SingleStageCaseHub.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.CasePlanModelRegistry;
+import io.casehub.blackboard.stage.Stage;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+
+/**
+ * Test bean: single stage activates on entry condition, worker writes status, goal completes case.
+ */
+@ApplicationScoped
+public class SingleStageCaseHub extends CaseHub {
+
+  @Inject CasePlanModelRegistry planModelRegistry;
+
+  private final CaseDefinition definition;
+
+  public SingleStageCaseHub() {
+    Capability cap =
+        Capability.builder()
+            .name("single-stage-cap")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    Goal goal =
+        Goal.builder()
+            .name("done-goal")
+            .condition(".status == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    Worker worker =
+        Worker.builder()
+            .name("single-stage-worker")
+            .capabilities(cap)
+            .function(input -> Map.of("status", "done"))
+            .build();
+
+    definition =
+        CaseDefinition.builder()
+            .namespace("blackboard-test")
+            .name("single-stage-test")
+            .version("1.0.0")
+            .capabilities(cap)
+            .workers(worker)
+            .bindings(
+                Binding.builder()
+                    .name("trigger-single")
+                    .capability(cap)
+                    .on(new ContextChangeTrigger(".status == \"processing\""))
+                    .build())
+            .goals(goal)
+            .completion(GoalExpression.allOf(goal))
+            .build();
+  }
+
+  @PostConstruct
+  void registerPlanModel() {
+    Worker worker = definition.getWorkers().get(0);
+
+    CasePlanModel planModel =
+        CasePlanModel.builder()
+            .name("single-stage-plan")
+            .stages(
+                Stage.builder()
+                    .name("processing-stage")
+                    .entry(".status == \"processing\"")
+                    .workers(worker)
+                    .build())
+            .build();
+
+    planModelRegistry.register(definition, planModel);
+  }
+
+  @Override
+  public CaseDefinition getDefinition() {
+    return definition;
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/CasePlanModelTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/CasePlanModelTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.blackboard.stage.Stage;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CasePlanModelTest {
+
+  private static CaseDefinition def(String name) {
+    return CaseDefinition.builder().namespace("test").name(name).version("1.0").build();
+  }
+
+  private static Stage stage(String name) {
+    return Stage.builder().name(name).entry(".x == true").build();
+  }
+
+  @Test
+  void nameRequired() {
+    assertThatThrownBy(() -> CasePlanModel.builder().build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void stagesAreRetained() {
+    Stage s1 = stage("s1");
+    Stage s2 = stage("s2");
+    CasePlanModel model = CasePlanModel.builder().name("m").stages(s1, s2).build();
+    assertThat(model.getStages()).containsExactly(s1, s2);
+  }
+
+  @Test
+  void stagesDefaultToEmpty() {
+    CasePlanModel model = CasePlanModel.builder().name("m").build();
+    assertThat(model.getStages()).isEmpty();
+  }
+
+  @Test
+  void registryReturnsEmptyForUnknownDefinition() {
+    CasePlanModelRegistry registry = new CasePlanModelRegistry();
+    Optional<CasePlanModel> result = registry.find(def("unknown"));
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void registryReturnsPlanForRegisteredDefinition() {
+    CasePlanModelRegistry registry = new CasePlanModelRegistry();
+    CaseDefinition definition = def("my-case");
+    CasePlanModel model = CasePlanModel.builder().name("m").stages(stage("s1")).build();
+    registry.register(definition, model);
+    assertThat(registry.find(definition)).contains(model);
+  }
+
+  @Test
+  void registryMatchesByNamespaceNameVersion() {
+    CasePlanModelRegistry registry = new CasePlanModelRegistry();
+    CaseDefinition def1 = def("case-a");
+    CaseDefinition def2 = def("case-b");
+    CasePlanModel model1 = CasePlanModel.builder().name("m1").build();
+    CasePlanModel model2 = CasePlanModel.builder().name("m2").build();
+    registry.register(def1, model1);
+    registry.register(def2, model2);
+    assertThat(registry.find(def1)).contains(model1);
+    assertThat(registry.find(def2)).contains(model2);
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanElementTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanElementTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.Worker;
+import io.casehub.api.plan.PlanElement;
+import org.junit.jupiter.api.Test;
+
+class PlanElementTest {
+
+  @Test
+  void workerImplementsPlanElement() {
+    Worker worker =
+        Worker.builder()
+            .name("w")
+            .capabilities(
+                Capability.builder().name("c").inputSchema("{}").outputSchema("{}").build())
+            .function(input -> input)
+            .build();
+    assertThat(worker).isInstanceOf(PlanElement.class);
+  }
+
+  @Test
+  void planElementIsAnInterface() {
+    assertThat(PlanElement.class).isInterface();
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemStatusTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemStatusTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumSet;
+import org.junit.jupiter.api.Test;
+
+class PlanItemStatusTest {
+
+  @Test
+  void containsExactlyExpectedValues() {
+    assertThat(EnumSet.allOf(PlanItemStatus.class))
+        .containsExactlyInAnyOrder(
+            PlanItemStatus.PENDING,
+            PlanItemStatus.ACTIVE,
+            PlanItemStatus.COMPLETED,
+            PlanItemStatus.TERMINATED,
+            PlanItemStatus.FAULTED);
+  }
+
+  @Test
+  void pendingIsNotTerminalAndNotActive() {
+    assertThat(PlanItemStatus.PENDING.isTerminal()).isFalse();
+    assertThat(PlanItemStatus.PENDING.isActive()).isFalse();
+  }
+
+  @Test
+  void activeIsNotTerminal() {
+    assertThat(PlanItemStatus.ACTIVE.isTerminal()).isFalse();
+    assertThat(PlanItemStatus.ACTIVE.isActive()).isTrue();
+  }
+
+  @Test
+  void completedTerminatedAndFaultedAreTerminal() {
+    assertThat(PlanItemStatus.COMPLETED.isTerminal()).isTrue();
+    assertThat(PlanItemStatus.TERMINATED.isTerminal()).isTrue();
+    assertThat(PlanItemStatus.FAULTED.isTerminal()).isTrue();
+  }
+
+  @Test
+  void faultedIsDistinctFromTerminated() {
+    assertThat(PlanItemStatus.FAULTED).isNotEqualTo(PlanItemStatus.TERMINATED);
+    assertThat(PlanItemStatus.FAULTED.isFaulted()).isTrue();
+    assertThat(PlanItemStatus.TERMINATED.isFaulted()).isFalse();
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.casehub.api.plan.PlanElement;
+import org.junit.jupiter.api.Test;
+
+class PlanItemTest {
+
+  static class TestElement implements PlanElement {}
+
+  @Test
+  void newPlanItemStartsInPending() {
+    PlanItem<TestElement> item = PlanItem.of(new TestElement());
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.PENDING);
+  }
+
+  @Test
+  void activateTransitionsPendingToActive() {
+    PlanItem<TestElement> item = PlanItem.of(new TestElement());
+    item.activate();
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.ACTIVE);
+    assertThat(item.getActivatedAt()).isNotNull();
+  }
+
+  @Test
+  void completeTransitionsActiveToCompleted() {
+    PlanItem<TestElement> item = PlanItem.of(new TestElement());
+    item.activate();
+    item.complete();
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.COMPLETED);
+    assertThat(item.getCompletedAt()).isNotNull();
+  }
+
+  @Test
+  void terminateTransitionsToTerminated() {
+    PlanItem<TestElement> item = PlanItem.of(new TestElement());
+    item.activate();
+    item.terminate();
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.TERMINATED);
+  }
+
+  @Test
+  void faultTransitionsActiveToFaulted() {
+    PlanItem<TestElement> item = PlanItem.of(new TestElement());
+    item.activate();
+    item.fault();
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED);
+  }
+
+  @Test
+  void activatingAlreadyActiveItemThrows() {
+    PlanItem<TestElement> item = PlanItem.of(new TestElement());
+    item.activate();
+    assertThatThrownBy(item::activate).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void completingPendingItemThrows() {
+    PlanItem<TestElement> item = PlanItem.of(new TestElement());
+    assertThatThrownBy(item::complete).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void parentReferenceIsNullForRootItem() {
+    PlanItem<TestElement> item = PlanItem.of(new TestElement());
+    assertThat(item.getParent()).isNull();
+  }
+
+  @Test
+  void addChildSetsParentOnChild() {
+    PlanItem<TestElement> parent = PlanItem.of(new TestElement());
+    PlanItem<TestElement> child = PlanItem.of(new TestElement());
+    parent.addChild(child);
+    assertThat(child.getParent()).isSameAs(parent);
+    assertThat(parent.getChildren()).containsExactly(child);
+  }
+
+  @Test
+  void terminatingParentTerminatesAllChildren() {
+    PlanItem<TestElement> parent = PlanItem.of(new TestElement());
+    PlanItem<TestElement> child1 = PlanItem.of(new TestElement());
+    PlanItem<TestElement> child2 = PlanItem.of(new TestElement());
+    parent.addChild(child1);
+    parent.addChild(child2);
+    parent.activate();
+    child1.activate();
+    parent.terminate();
+    assertThat(parent.getStatus()).isEqualTo(PlanItemStatus.TERMINATED);
+    assertThat(child1.getStatus()).isEqualTo(PlanItemStatus.TERMINATED);
+    assertThat(child2.getStatus()).isEqualTo(PlanItemStatus.TERMINATED);
+  }
+
+  @Test
+  void elementIsRetained() {
+    TestElement element = new TestElement();
+    PlanItem<TestElement> item = PlanItem.of(element);
+    assertThat(item.getElement()).isSameAs(element);
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.stage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
+import io.casehub.api.plan.PlanElement;
+import org.junit.jupiter.api.Test;
+
+class StageTest {
+
+  private static Worker worker(String name) {
+    return Worker.builder()
+        .name(name)
+        .capabilities(
+            Capability.builder().name("cap-" + name).inputSchema("{}").outputSchema("{}").build())
+        .function(input -> input)
+        .build();
+  }
+
+  @Test
+  void stageImplementsPlanElement() {
+    Stage stage = Stage.builder().name("s").entry(".x == true").build();
+    assertThat(stage).isInstanceOf(PlanElement.class);
+  }
+
+  @Test
+  void nameIsRequired() {
+    assertThatThrownBy(() -> Stage.builder().entry(".x == true").build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void entryConditionIsRequired() {
+    assertThatThrownBy(() -> Stage.builder().name("s").build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void entryStringCreatesJQEvaluator() {
+    Stage stage = Stage.builder().name("s").entry(".x == true").build();
+    assertInstanceOf(JQExpressionEvaluator.class, stage.getEntryCondition());
+  }
+
+  @Test
+  void entryLambdaCreatesLambdaEvaluator() {
+    Stage stage = Stage.builder().name("s").entry(ctx -> true).build();
+    assertInstanceOf(LambdaExpressionEvaluator.class, stage.getEntryCondition());
+  }
+
+  @Test
+  void nullEntryStringThrows() {
+    assertThatThrownBy(() -> Stage.builder().name("s").entry((String) null).build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void nullEntryLambdaThrows() {
+    assertThatThrownBy(
+            () ->
+                Stage.builder()
+                    .name("s")
+                    .entry((java.util.function.Predicate<io.casehub.api.context.CaseContext>) null)
+                    .build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void exitConditionIsOptional() {
+    Stage stage = Stage.builder().name("s").entry(".x == true").build();
+    assertThat(stage.getExitCondition()).isNull();
+  }
+
+  @Test
+  void exitStringCreatesJQEvaluator() {
+    Stage stage = Stage.builder().name("s").entry(".x == true").exit(".y == true").build();
+    assertInstanceOf(JQExpressionEvaluator.class, stage.getExitCondition());
+  }
+
+  @Test
+  void exitLambdaCreatesLambdaEvaluator() {
+    Stage stage = Stage.builder().name("s").entry(".x == true").exit(ctx -> false).build();
+    assertInstanceOf(LambdaExpressionEvaluator.class, stage.getExitCondition());
+  }
+
+  @Test
+  void workersDefaultToEmpty() {
+    Stage stage = Stage.builder().name("s").entry(".x == true").build();
+    assertThat(stage.getWorkers()).isEmpty();
+  }
+
+  @Test
+  void nestedStagesDefaultToEmpty() {
+    Stage stage = Stage.builder().name("s").entry(".x == true").build();
+    assertThat(stage.getNestedStages()).isEmpty();
+  }
+
+  @Test
+  void workersAreRetained() {
+    Worker w = worker("w1");
+    Stage stage = Stage.builder().name("s").entry(".x == true").workers(w).build();
+    assertThat(stage.getWorkers()).containsExactly(w);
+  }
+
+  @Test
+  void nestedStageIsRetained() {
+    Stage nested = Stage.builder().name("inner").entry(".y == true").build();
+    Stage outer = Stage.builder().name("outer").entry(".x == true").nestedStage(nested).build();
+    assertThat(outer.getNestedStages()).containsExactly(nested);
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/SubCaseTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/SubCaseTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.stage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.casehub.api.plan.PlanElement;
+import io.casehub.blackboard.strategy.DefaultSubCaseCompletionStrategy;
+import org.junit.jupiter.api.Test;
+
+class SubCaseTest {
+
+  @Test
+  void subCaseImplementsPlanElement() {
+    SubCase sc = SubCase.builder().namespace("ns").name("n").version("1.0").build();
+    assertThat(sc).isInstanceOf(PlanElement.class);
+  }
+
+  @Test
+  void namespaceRequired() {
+    assertThatThrownBy(() -> SubCase.builder().name("n").version("1.0").build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void nameRequired() {
+    assertThatThrownBy(() -> SubCase.builder().namespace("ns").version("1.0").build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void versionRequired() {
+    assertThatThrownBy(() -> SubCase.builder().namespace("ns").name("n").build())
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void defaultCompletionStrategyIsUsedWhenNotSpecified() {
+    SubCase sc = SubCase.builder().namespace("ns").name("n").version("1.0").build();
+    assertThat(sc.getCompletionStrategy()).isInstanceOf(DefaultSubCaseCompletionStrategy.class);
+  }
+
+  @Test
+  void customCompletionStrategyIsRetained() {
+    io.casehub.blackboard.strategy.SubCaseCompletionStrategy strategy =
+        (status, ctx) -> io.casehub.blackboard.plan.PlanItemStatus.TERMINATED;
+    SubCase sc =
+        SubCase.builder()
+            .namespace("ns")
+            .name("n")
+            .version("1.0")
+            .completionStrategy(strategy)
+            .build();
+    assertThat(sc.getCompletionStrategy()).isSameAs(strategy);
+  }
+
+  @Test
+  void fieldsAreRetained() {
+    SubCase sc = SubCase.builder().namespace("ns").name("my-case").version("2.0").build();
+    assertThat(sc.getNamespace()).isEqualTo("ns");
+    assertThat(sc.getName()).isEqualTo("my-case");
+    assertThat(sc.getVersion()).isEqualTo("2.0");
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/strategy/DefaultPlanningStrategyTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/strategy/DefaultPlanningStrategyTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.Worker;
+import io.casehub.blackboard.plan.PlanItem;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DefaultPlanningStrategyTest {
+
+  private final DefaultPlanningStrategy strategy = new DefaultPlanningStrategy();
+
+  private static Worker worker(String name) {
+    return Worker.builder()
+        .name(name)
+        .capabilities(
+            Capability.builder().name("cap-" + name).inputSchema("{}").outputSchema("{}").build())
+        .function(input -> input)
+        .build();
+  }
+
+  @Test
+  void returnsAllEligibleItems() {
+    PlanItem<Worker> w1 = PlanItem.of(worker("a"));
+    PlanItem<Worker> w2 = PlanItem.of(worker("b"));
+    List<PlanItem<?>> result = strategy.select(null, List.of(w1, w2));
+    assertThat(result).containsExactly(w1, w2);
+  }
+
+  @Test
+  void returnsEmptyForEmptyEligible() {
+    List<PlanItem<?>> result = strategy.select(null, List.of());
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void preservesOrder() {
+    PlanItem<Worker> w1 = PlanItem.of(worker("a"));
+    PlanItem<Worker> w2 = PlanItem.of(worker("b"));
+    PlanItem<Worker> w3 = PlanItem.of(worker("c"));
+    List<PlanItem<?>> result = strategy.select(null, List.of(w1, w2, w3));
+    assertThat(result).containsExactly(w1, w2, w3);
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/strategy/DefaultSubCaseCompletionStrategyTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/strategy/DefaultSubCaseCompletionStrategyTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.blackboard.plan.PlanItemStatus;
+import org.junit.jupiter.api.Test;
+
+class DefaultSubCaseCompletionStrategyTest {
+
+  private final DefaultSubCaseCompletionStrategy strategy = new DefaultSubCaseCompletionStrategy();
+
+  @Test
+  void completedMapsToCompleted() {
+    assertThat(strategy.resolve(CaseStatus.COMPLETED, null)).isEqualTo(PlanItemStatus.COMPLETED);
+  }
+
+  @Test
+  void faultedMapsToFaulted() {
+    assertThat(strategy.resolve(CaseStatus.FAULTED, null)).isEqualTo(PlanItemStatus.FAULTED);
+  }
+
+  @Test
+  void cancelledMapsToTerminated() {
+    assertThat(strategy.resolve(CaseStatus.CANCELLED, null)).isEqualTo(PlanItemStatus.TERMINATED);
+  }
+
+  @Test
+  void waitingMapsToTerminated() {
+    assertThat(strategy.resolve(CaseStatus.WAITING, null)).isEqualTo(PlanItemStatus.TERMINATED);
+  }
+
+  @Test
+  void suspendedMapsToTerminated() {
+    assertThat(strategy.resolve(CaseStatus.SUSPENDED, null)).isEqualTo(PlanItemStatus.TERMINATED);
+  }
+}

--- a/casehub-blackboard/src/test/resources/application.properties
+++ b/casehub-blackboard/src/test/resources/application.properties
@@ -2,9 +2,3 @@
 %test.quarkus.flyway.clean-at-start=true
 
 quarkus.arc.selected-alternatives=io.casehub.blackboard.strategy.PlanningStrategyLoopControl
-
-# Index engine and api modules so Quarkus discovers their CDI beans
-quarkus.index-dependency.engine.group-id=io.casehub
-quarkus.index-dependency.engine.artifact-id=engine
-quarkus.index-dependency.api.group-id=io.casehub
-quarkus.index-dependency.api.artifact-id=api

--- a/casehub-blackboard/src/test/resources/application.properties
+++ b/casehub-blackboard/src/test/resources/application.properties
@@ -1,0 +1,10 @@
+%test.quarkus.hibernate-orm.mapping.format.global=ignore
+%test.quarkus.flyway.clean-at-start=true
+
+quarkus.arc.selected-alternatives=io.casehub.blackboard.strategy.PlanningStrategyLoopControl
+
+# Index engine and api modules so Quarkus discovers their CDI beans
+quarkus.index-dependency.engine.group-id=io.casehub
+quarkus.index-dependency.engine.artifact-id=engine
+quarkus.index-dependency.api.group-id=io.casehub
+quarkus.index-dependency.api.artifact-id=api

--- a/casehub-resilience/pom.xml
+++ b/casehub-resilience/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.casehub</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>casehub-resilience</artifactId>
+    <name>Case Hub :: Resilience</name>
+    <description>Optional resilience layer — Dead Letter Queue, PoisonPill detection, backoff strategies</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/casehub-resilience/src/main/java/io/casehub/resilience/backoff/BackoffDelayCalculator.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/backoff/BackoffDelayCalculator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.backoff;
+
+import io.casehub.api.model.BackoffStrategy;
+import io.casehub.api.model.RetryPolicy;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Stateless utility that computes the retry delay in milliseconds for a given {@link RetryPolicy}
+ * and attempt number (1-based). Exponential variants are capped at {@link #MAX_DELAY_MS} (30s) to
+ * prevent unbounded growth.
+ */
+public final class BackoffDelayCalculator {
+
+  static final long MAX_DELAY_MS = 30_000L;
+
+  private BackoffDelayCalculator() {}
+
+  /**
+   * Returns the delay in milliseconds before attempt {@code attemptNumber} (1-based).
+   *
+   * <p>A {@code null} or missing {@link BackoffStrategy} is treated as {@link
+   * BackoffStrategy#FIXED}.
+   */
+  public static long calculate(RetryPolicy policy, int attemptNumber) {
+    long baseDelayMs = policy.delayMs() != null ? policy.delayMs() : 0L;
+    BackoffStrategy strategy =
+        policy.backoffStrategy() != null ? policy.backoffStrategy() : BackoffStrategy.FIXED;
+
+    return switch (strategy) {
+      case FIXED -> baseDelayMs;
+      case EXPONENTIAL -> exponential(baseDelayMs, attemptNumber);
+      case EXPONENTIAL_WITH_JITTER -> jitter(baseDelayMs, attemptNumber);
+    };
+  }
+
+  private static long exponential(long baseDelayMs, int attempt) {
+    // baseDelayMs * 2^(attempt-1), capped at MAX_DELAY_MS
+    long shift = Math.min(attempt - 1, 30); // guard against overflow on very large attempt counts
+    return Math.min(baseDelayMs * (1L << shift), MAX_DELAY_MS);
+  }
+
+  private static long jitter(long baseDelayMs, int attempt) {
+    long cap = exponential(baseDelayMs, attempt);
+    return cap == 0 ? 0 : ThreadLocalRandom.current().nextLong(cap + 1);
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterEntry.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterEntry.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A record of a worker execution that exhausted all retry attempts. Stores the full context needed
+ * to replay the work or diagnose the failure: case ID, worker identity, original input, and current
+ * lifecycle status.
+ *
+ * <p>Status transitions: {@link DeadLetterStatus#PENDING_REVIEW} → {@link
+ * DeadLetterStatus#REPLAYED} or {@link DeadLetterStatus#DISCARDED}.
+ */
+public final class DeadLetterEntry {
+
+  private final String deadLetterId;
+  private final UUID caseId;
+  private final String workerId;
+  private final String idempotencyHash;
+  private final Map<String, Object> inputContext;
+  private final Instant arrivedAt;
+  private volatile DeadLetterStatus status;
+
+  DeadLetterEntry(
+      String deadLetterId,
+      UUID caseId,
+      String workerId,
+      String idempotencyHash,
+      Map<String, Object> inputContext) {
+    this.deadLetterId = deadLetterId;
+    this.caseId = caseId;
+    this.workerId = workerId;
+    this.idempotencyHash = idempotencyHash;
+    this.inputContext = Map.copyOf(inputContext);
+    this.arrivedAt = Instant.now();
+    this.status = DeadLetterStatus.PENDING_REVIEW;
+  }
+
+  public String deadLetterId() {
+    return deadLetterId;
+  }
+
+  public UUID caseId() {
+    return caseId;
+  }
+
+  public String workerId() {
+    return workerId;
+  }
+
+  public String idempotencyHash() {
+    return idempotencyHash;
+  }
+
+  public Map<String, Object> inputContext() {
+    return inputContext;
+  }
+
+  public Instant arrivedAt() {
+    return arrivedAt;
+  }
+
+  public DeadLetterStatus status() {
+    return status;
+  }
+
+  void setStatus(DeadLetterStatus status) {
+    this.status = status;
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterEventHandler.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterEventHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * Listens for {@link EventBusAddresses#WORKER_RETRIES_EXHAUSTED} events and routes the failing
+ * execution into the {@link DeadLetterQueue}. Runs alongside the engine's {@code
+ * WorkerRetriesExhaustedEventHandler} — both handlers receive the same event independently.
+ */
+@ApplicationScoped
+public class DeadLetterEventHandler {
+
+  private static final Logger LOG = Logger.getLogger(DeadLetterEventHandler.class);
+
+  @Inject DeadLetterQueue deadLetterQueue;
+
+  @ConsumeEvent(value = EventBusAddresses.WORKER_RETRIES_EXHAUSTED)
+  public void onWorkerRetriesExhausted(WorkerRetriesExhaustedEvent event) {
+    LOG.infof(
+        "Routing exhausted worker to DLQ: caseId=%s, workerId=%s",
+        event.caseId(), event.workerId());
+
+    deadLetterQueue.add(
+        event.caseId(),
+        event.workerId(),
+        event.idempotency(),
+        // Input context is not carried in the event itself — the DLQ entry stores the
+        // idempotency hash so the full input can be recovered from EventLog on replay.
+        Map.of("idempotencyHash", event.idempotency()));
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterQuery.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Immutable filter specification for {@link DeadLetterQueue#query(DeadLetterQuery)}. Build via the
+ * static factory methods; filters are AND-combined.
+ */
+public final class DeadLetterQuery {
+
+  private final Optional<DeadLetterStatus> status;
+  private final Optional<String> workerId;
+  private final Optional<Instant> arrivedAfter;
+
+  private DeadLetterQuery(
+      Optional<DeadLetterStatus> status,
+      Optional<String> workerId,
+      Optional<Instant> arrivedAfter) {
+    this.status = status;
+    this.workerId = workerId;
+    this.arrivedAfter = arrivedAfter;
+  }
+
+  /** Match every entry. */
+  public static DeadLetterQuery all() {
+    return new DeadLetterQuery(Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  /** Match entries with the given status. */
+  public static DeadLetterQuery withStatus(DeadLetterStatus status) {
+    return new DeadLetterQuery(Optional.of(status), Optional.empty(), Optional.empty());
+  }
+
+  /** Match entries for a specific worker. */
+  public static DeadLetterQuery forWorker(String workerId) {
+    return new DeadLetterQuery(Optional.empty(), Optional.of(workerId), Optional.empty());
+  }
+
+  /** Match entries that arrived after the given instant. */
+  public static DeadLetterQuery arrivedAfter(Instant cutoff) {
+    return new DeadLetterQuery(Optional.empty(), Optional.empty(), Optional.of(cutoff));
+  }
+
+  /** Builds a predicate representing all active filters. */
+  Predicate<DeadLetterEntry> toPredicate() {
+    Predicate<DeadLetterEntry> pred = e -> true;
+    if (status.isPresent()) {
+      pred = pred.and(e -> e.status() == status.get());
+    }
+    if (workerId.isPresent()) {
+      pred = pred.and(e -> workerId.get().equals(e.workerId()));
+    }
+    if (arrivedAfter.isPresent()) {
+      pred = pred.and(e -> e.arrivedAt().isAfter(arrivedAfter.get()));
+    }
+    return pred;
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterQueue.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterQueue.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * In-memory Dead Letter Queue. Stores {@link DeadLetterEntry} records for worker executions that
+ * have exhausted all retry attempts. Supports query by status/worker/time range, manual discard,
+ * and replay acknowledgement.
+ *
+ * <p>Thread-safe. Current implementation is in-memory; a persistent-storage hook (Redis, Hibernate)
+ * can be added by providing an alternative CDI bean.
+ */
+@ApplicationScoped
+public class DeadLetterQueue {
+
+  private final Map<String, DeadLetterEntry> store = new ConcurrentHashMap<>();
+
+  /**
+   * Adds a new entry to the queue with {@link DeadLetterStatus#PENDING_REVIEW}.
+   *
+   * @param caseId the case whose worker failed
+   * @param workerId the failing worker name
+   * @param idempotencyHash the input hash used for deduplication
+   * @param inputContext the original worker input data
+   * @return the newly created entry
+   */
+  public DeadLetterEntry add(
+      UUID caseId, String workerId, String idempotencyHash, Map<String, Object> inputContext) {
+    String id = UUID.randomUUID().toString();
+    DeadLetterEntry entry =
+        new DeadLetterEntry(id, caseId, workerId, idempotencyHash, inputContext);
+    store.put(id, entry);
+    return entry;
+  }
+
+  /**
+   * Returns all entries matching the given query. Filters are AND-combined.
+   *
+   * @param query the filter specification
+   * @return matching entries (unordered)
+   */
+  public List<DeadLetterEntry> query(DeadLetterQuery query) {
+    return store.values().stream().filter(query.toPredicate()).collect(Collectors.toList());
+  }
+
+  /**
+   * Marks the entry as {@link DeadLetterStatus#DISCARDED}. No-op if the ID is not found.
+   *
+   * @param deadLetterId the entry to discard
+   */
+  public void discard(String deadLetterId) {
+    DeadLetterEntry entry = store.get(deadLetterId);
+    if (entry != null) {
+      entry.setStatus(DeadLetterStatus.DISCARDED);
+    }
+  }
+
+  /**
+   * Marks the entry as {@link DeadLetterStatus#REPLAYED} after a successful replay submission.
+   * No-op if the ID is not found.
+   *
+   * @param deadLetterId the entry that was replayed
+   */
+  public void markReplayed(String deadLetterId) {
+    DeadLetterEntry entry = store.get(deadLetterId);
+    if (entry != null) {
+      entry.setStatus(DeadLetterStatus.REPLAYED);
+    }
+  }
+
+  /** Returns the total number of entries in the queue regardless of status. */
+  public int size() {
+    return store.size();
+  }
+
+  /** Removes all entries. Intended for test isolation only. */
+  public void clear() {
+    store.clear();
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterStatus.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/deadletter/DeadLetterStatus.java
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.casehub.api.model;
+package io.casehub.resilience.deadletter;
 
-public record RetryPolicy(Integer maxAttempts, Integer delayMs, BackoffStrategy backoffStrategy) {
+/** Lifecycle status of a {@link DeadLetterEntry}. */
+public enum DeadLetterStatus {
+  /** Entry is awaiting human review or automated replay. */
+  PENDING_REVIEW,
 
-  /** Default: 3 attempts, 10s fixed delay. */
-  public RetryPolicy() {
-    this(3, 10000, BackoffStrategy.FIXED);
-  }
+  /** Entry has been replayed (re-submitted for execution). */
+  REPLAYED,
 
-  /** Backwards-compatible 2-arg constructor — defaults to FIXED backoff. */
-  public RetryPolicy(Integer maxAttempts, Integer delayMs) {
-    this(maxAttempts, delayMs, BackoffStrategy.FIXED);
-  }
+  /** Entry has been acknowledged as unrecoverable and will not be retried. */
+  DISCARDED
 }

--- a/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillDetector.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillDetector.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Sliding-window circuit breaker that quarantines workers that fail too frequently.
+ *
+ * <p>Tracks failure timestamps per worker within a configurable time window. When the number of
+ * failures within the window reaches the threshold, the worker is quarantined for a cool-down
+ * period. Quarantined workers should be skipped by the scheduler — no further executions are
+ * attempted until the quarantine expires or is manually released.
+ *
+ * <p>Thread-safe. All state is in-memory.
+ */
+@ApplicationScoped
+public class PoisonPillDetector {
+
+  private static final Logger LOG = Logger.getLogger(PoisonPillDetector.class);
+
+  private final int failureThreshold;
+  private final Duration failureWindow;
+  private final Duration quarantineDuration;
+
+  /** Sliding window of failure timestamps per worker. */
+  private final Map<String, Deque<Instant>> failureWindows = new ConcurrentHashMap<>();
+
+  /** Quarantine expiry times per worker. Absent = not quarantined. */
+  private final Map<String, Instant> quarantinedUntil = new ConcurrentHashMap<>();
+
+  /** CDI no-arg constructor using config properties. */
+  PoisonPillDetector(
+      @ConfigProperty(name = "casehub.resilience.poison-pill.threshold", defaultValue = "5")
+          int failureThreshold,
+      @ConfigProperty(name = "casehub.resilience.poison-pill.window", defaultValue = "PT10M")
+          Duration failureWindow,
+      @ConfigProperty(name = "casehub.resilience.poison-pill.quarantine", defaultValue = "PT30M")
+          Duration quarantineDuration) {
+    this.failureThreshold = failureThreshold;
+    this.failureWindow = failureWindow;
+    this.quarantineDuration = quarantineDuration;
+  }
+
+  /**
+   * Records a failure for the given worker. If the number of failures within the sliding window
+   * reaches the threshold, the worker is quarantined.
+   *
+   * @param workerId the name of the failing worker
+   */
+  public synchronized void recordFailure(String workerId) {
+    Instant now = Instant.now();
+    Deque<Instant> window = failureWindows.computeIfAbsent(workerId, k -> new ArrayDeque<>());
+
+    window.addLast(now);
+    evictExpired(window, now);
+
+    if (window.size() >= failureThreshold) {
+      Instant until = now.plus(quarantineDuration);
+      quarantinedUntil.put(workerId, until);
+      LOG.warnf(
+          "Worker quarantined: workerId=%s, failures=%d, until=%s", workerId, window.size(), until);
+    }
+  }
+
+  /**
+   * Returns {@code true} if the worker is currently quarantined. Expired quarantines are
+   * automatically cleared.
+   *
+   * @param workerId the worker to check
+   */
+  public boolean isQuarantined(String workerId) {
+    Instant expiry = quarantinedUntil.get(workerId);
+    if (expiry == null) {
+      return false;
+    }
+    if (Instant.now().isAfter(expiry)) {
+      quarantinedUntil.remove(workerId);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Manually releases a quarantine and resets the failure window for the given worker. Useful for
+   * operator intervention after a fix is deployed.
+   *
+   * @param workerId the worker to release
+   */
+  public synchronized void release(String workerId) {
+    quarantinedUntil.remove(workerId);
+    failureWindows.remove(workerId);
+    LOG.infof("Quarantine released for workerId=%s", workerId);
+  }
+
+  /**
+   * Returns the set of currently quarantined worker IDs. Expired quarantines are excluded (lazily
+   * cleaned on read).
+   */
+  public Set<String> quarantinedWorkers() {
+    Instant now = Instant.now();
+    // Evict expired entries first
+    quarantinedUntil.entrySet().removeIf(e -> now.isAfter(e.getValue()));
+    return Collections.unmodifiableSet(quarantinedUntil.keySet());
+  }
+
+  private void evictExpired(Deque<Instant> window, Instant now) {
+    Instant cutoff = now.minus(failureWindow);
+    while (!window.isEmpty() && window.peekFirst().isBefore(cutoff)) {
+      window.pollFirst();
+    }
+  }
+}

--- a/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillWorkerExecutionGuard.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/poison/PoisonPillWorkerExecutionGuard.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import io.casehub.api.spi.WorkerExecutionGuard;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.UUID;
+
+/**
+ * {@link WorkerExecutionGuard} that blocks workers quarantined by the {@link PoisonPillDetector}.
+ *
+ * <p>Active when {@code casehub-resilience} is on the classpath and selected as the CDI alternative
+ * (via {@code quarkus.arc.selected-alternatives} in {@code application.properties}).
+ */
+@Alternative
+@Priority(10)
+@ApplicationScoped
+public class PoisonPillWorkerExecutionGuard implements WorkerExecutionGuard {
+
+  @Inject PoisonPillDetector detector;
+
+  @Override
+  public boolean isBlocked(String workerId, UUID caseId) {
+    return detector.isQuarantined(workerId);
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/backoff/BackoffDelayCalculatorTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/backoff/BackoffDelayCalculatorTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.backoff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.model.BackoffStrategy;
+import io.casehub.api.model.RetryPolicy;
+import org.junit.jupiter.api.Test;
+
+/** Pure unit tests — no Quarkus, no CDI. BackoffDelayCalculator is a stateless utility. */
+class BackoffDelayCalculatorTest {
+
+  // ---- FIXED strategy -------------------------------------------------------
+
+  @Test
+  void fixed_alwaysReturnsConfiguredDelay() {
+    RetryPolicy policy = new RetryPolicy(3, 1000, BackoffStrategy.FIXED);
+
+    assertThat(BackoffDelayCalculator.calculate(policy, 1)).isEqualTo(1000);
+    assertThat(BackoffDelayCalculator.calculate(policy, 2)).isEqualTo(1000);
+    assertThat(BackoffDelayCalculator.calculate(policy, 3)).isEqualTo(1000);
+  }
+
+  @Test
+  void fixed_zeroDelayStaysZero() {
+    RetryPolicy policy = new RetryPolicy(3, 0, BackoffStrategy.FIXED);
+    assertThat(BackoffDelayCalculator.calculate(policy, 1)).isEqualTo(0);
+  }
+
+  // ---- EXPONENTIAL strategy -------------------------------------------------
+
+  @Test
+  void exponential_doublesDelayEachAttempt() {
+    RetryPolicy policy = new RetryPolicy(5, 1000, BackoffStrategy.EXPONENTIAL);
+
+    assertThat(BackoffDelayCalculator.calculate(policy, 1)).isEqualTo(1000); // 1000 * 2^0
+    assertThat(BackoffDelayCalculator.calculate(policy, 2)).isEqualTo(2000); // 1000 * 2^1
+    assertThat(BackoffDelayCalculator.calculate(policy, 3)).isEqualTo(4000); // 1000 * 2^2
+    assertThat(BackoffDelayCalculator.calculate(policy, 4)).isEqualTo(8000); // 1000 * 2^3
+  }
+
+  @Test
+  void exponential_cappedAt30Seconds() {
+    RetryPolicy policy = new RetryPolicy(20, 1000, BackoffStrategy.EXPONENTIAL);
+
+    // 1000 * 2^15 = 32_768_000 → should be capped at 30_000
+    assertThat(BackoffDelayCalculator.calculate(policy, 16)).isEqualTo(30_000);
+    assertThat(BackoffDelayCalculator.calculate(policy, 20)).isEqualTo(30_000);
+  }
+
+  // ---- EXPONENTIAL_WITH_JITTER strategy -------------------------------------
+
+  @Test
+  void jitter_delayIsWithinExponentialBound() {
+    RetryPolicy policy = new RetryPolicy(5, 1000, BackoffStrategy.EXPONENTIAL_WITH_JITTER);
+
+    for (int attempt = 1; attempt <= 5; attempt++) {
+      long delay = BackoffDelayCalculator.calculate(policy, attempt);
+      long exponentialBound = Math.min(1000L * (1L << (attempt - 1)), 30_000L);
+      assertThat(delay)
+          .as("attempt %d delay should be in [0, %d]", attempt, exponentialBound)
+          .isBetween(0L, exponentialBound);
+    }
+  }
+
+  @Test
+  void jitter_delayIsNonDeterministicAcrossMultipleCalls() {
+    RetryPolicy policy = new RetryPolicy(5, 2000, BackoffStrategy.EXPONENTIAL_WITH_JITTER);
+
+    // With a range of [0, 2000], the probability of getting the same value 10 times in a row
+    // is astronomically small. This proves jitter is actually being applied.
+    long first = BackoffDelayCalculator.calculate(policy, 2);
+    boolean sawVariation = false;
+    for (int i = 0; i < 20; i++) {
+      if (BackoffDelayCalculator.calculate(policy, 2) != first) {
+        sawVariation = true;
+        break;
+      }
+    }
+    assertThat(sawVariation).as("jitter should produce different values across calls").isTrue();
+  }
+
+  @Test
+  void jitter_cappedAt30Seconds() {
+    RetryPolicy policy = new RetryPolicy(20, 1000, BackoffStrategy.EXPONENTIAL_WITH_JITTER);
+
+    for (int i = 0; i < 50; i++) {
+      assertThat(BackoffDelayCalculator.calculate(policy, 20)).isLessThanOrEqualTo(30_000);
+    }
+  }
+
+  // ---- Null/default safety --------------------------------------------------
+
+  @Test
+  void nullStrategy_treatedAsFixed() {
+    // RetryPolicy constructed without strategy should behave like FIXED
+    RetryPolicy policy = new RetryPolicy(3, 500);
+    assertThat(BackoffDelayCalculator.calculate(policy, 1)).isEqualTo(500);
+    assertThat(BackoffDelayCalculator.calculate(policy, 3)).isEqualTo(500);
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterEventHandlerTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterEventHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test: verifies that publishing a {@code WORKER_RETRIES_EXHAUSTED} event on the Vert.x
+ * event bus results in a {@link DeadLetterEntry} being created in the {@link DeadLetterQueue}.
+ *
+ * <p>No real case is started — just the event bus publish + DLQ listener.
+ */
+@QuarkusTest
+class DeadLetterEventHandlerTest {
+
+  @Inject EventBus eventBus;
+
+  @Inject DeadLetterQueue deadLetterQueue;
+
+  @BeforeEach
+  void clearQueue() {
+    // DeadLetterQueue is ApplicationScoped — clear between tests to keep them independent.
+    deadLetterQueue.clear();
+  }
+
+  @Test
+  void workerRetriesExhaustedEvent_createsEntryInDlq() {
+    UUID caseId = UUID.randomUUID();
+    String workerId = "failing-worker";
+    String hash = "test-hash-001";
+
+    eventBus.publish(
+        EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+        new WorkerRetriesExhaustedEvent(caseId, workerId, hash));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<DeadLetterEntry> entries = deadLetterQueue.query(DeadLetterQuery.all());
+              assertThat(entries).hasSize(1);
+              DeadLetterEntry entry = entries.get(0);
+              assertThat(entry.caseId()).isEqualTo(caseId);
+              assertThat(entry.workerId()).isEqualTo(workerId);
+              assertThat(entry.idempotencyHash()).isEqualTo(hash);
+              assertThat(entry.status()).isEqualTo(DeadLetterStatus.PENDING_REVIEW);
+            });
+  }
+
+  @Test
+  void multipleExhaustedEvents_eachCreatesSeparateEntry() {
+    UUID caseA = UUID.randomUUID();
+    UUID caseB = UUID.randomUUID();
+
+    eventBus.publish(
+        EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+        new WorkerRetriesExhaustedEvent(caseA, "worker-a", "hash-a"));
+    eventBus.publish(
+        EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+        new WorkerRetriesExhaustedEvent(caseB, "worker-b", "hash-b"));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<DeadLetterEntry> entries = deadLetterQueue.query(DeadLetterQuery.all());
+              assertThat(entries).hasSize(2);
+              assertThat(entries.stream().map(DeadLetterEntry::caseId))
+                  .containsExactlyInAnyOrder(caseA, caseB);
+            });
+  }
+
+  @Test
+  void dlqEntry_isQueryableByWorkerId() {
+    UUID caseId = UUID.randomUUID();
+    eventBus.publish(
+        EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+        new WorkerRetriesExhaustedEvent(caseId, "specific-worker", "hash-xyz"));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<DeadLetterEntry> results =
+                  deadLetterQueue.query(DeadLetterQuery.forWorker("specific-worker"));
+              assertThat(results).hasSize(1);
+              assertThat(results.get(0).caseId()).isEqualTo(caseId);
+            });
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueEndToEndTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueEndToEndTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.BackoffStrategy;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test: a real case is started with a worker that always fails. After maxAttempts, the
+ * engine emits WORKER_RETRIES_EXHAUSTED, the case transitions to FAULTED, and the DLQ receives an
+ * entry with the correct metadata.
+ */
+@QuarkusTest
+class DeadLetterQueueEndToEndTest {
+
+  @Inject AlwaysFailingCaseHub alwaysFailingCase;
+  @Inject FastFailingCaseHub fastFailingCase;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject DeadLetterQueue deadLetterQueue;
+
+  @BeforeEach
+  void clearQueue() {
+    deadLetterQueue.clear();
+  }
+
+  /** Happy path: exhausted retries → FAULTED case + DLQ entry. */
+  @Test
+  void workerExhaustingRetries_faultsCase_andCreatesDlqEntry() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    alwaysFailingCase
+        .startCase(Map.of("status", "start"))
+        .thenAccept(caseIdRef::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    // Wait for case to be created
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(caseIdRef.get()).isNotNull();
+            });
+
+    UUID caseId = caseIdRef.get();
+
+    // Wait for case to reach FAULTED (all retries exhausted)
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
+            });
+
+    // DLQ must have exactly one entry for this case
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<DeadLetterEntry> entries = deadLetterQueue.query(DeadLetterQuery.all());
+              assertThat(entries).hasSize(1);
+
+              DeadLetterEntry entry = entries.get(0);
+              assertThat(entry.caseId()).isEqualTo(caseId);
+              assertThat(entry.workerId()).isEqualTo("always-failing-worker");
+              assertThat(entry.status()).isEqualTo(DeadLetterStatus.PENDING_REVIEW);
+              assertThat(entry.idempotencyHash()).isNotBlank();
+            });
+  }
+
+  /** DLQ entry can be discarded after inspection. */
+  @Test
+  void dlqEntry_canBeDiscarded() {
+    fastFailingCase.startCase(Map.of("status", "start")).toCompletableFuture().join();
+
+    // Wait for DLQ entry
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(deadLetterQueue.size()).isGreaterThan(0));
+
+    String id = deadLetterQueue.query(DeadLetterQuery.all()).get(0).deadLetterId();
+    deadLetterQueue.discard(id);
+
+    List<DeadLetterEntry> pending =
+        deadLetterQueue.query(DeadLetterQuery.withStatus(DeadLetterStatus.PENDING_REVIEW));
+    List<DeadLetterEntry> discarded =
+        deadLetterQueue.query(DeadLetterQuery.withStatus(DeadLetterStatus.DISCARDED));
+
+    assertThat(pending).isEmpty();
+    assertThat(discarded).hasSize(1);
+  }
+
+  // ---- CaseHub bean: always fails, 2 retries (fast) -------------------------
+
+  @ApplicationScoped
+  public static class AlwaysFailingCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("doWork")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-dlq-e2e")
+          .name("Always Failing Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("always-failing-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        throw new RuntimeException("Intentional failure for DLQ E2E test");
+                      })
+                  .executionPolicy(
+                      new ExecutionPolicy(5000, new RetryPolicy(2, 100, BackoffStrategy.FIXED)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  public static class FastFailingCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("fastFail")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder()
+            .name("fastDone")
+            .condition(".status == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-dlq-e2e-fast")
+          .name("Fast Failing Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("fast-failing-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        throw new RuntimeException("Fast failure");
+                      })
+                  .executionPolicy(
+                      new ExecutionPolicy(5000, new RetryPolicy(1, 50, BackoffStrategy.FIXED)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("fast-trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.deadletter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests — no Quarkus, no CDI. DeadLetterQueue is an in-memory store and must be testable
+ * without a container.
+ */
+class DeadLetterQueueTest {
+
+  private DeadLetterQueue queue;
+
+  @BeforeEach
+  void setUp() {
+    queue = new DeadLetterQueue();
+  }
+
+  // ---- add ------------------------------------------------------------------
+
+  @Test
+  void add_storesEntryWithPendingReviewStatus() {
+    UUID caseId = UUID.randomUUID();
+    DeadLetterEntry entry = queue.add(caseId, "my-worker", "hash-abc", Map.of("key", "value"));
+
+    assertThat(entry.deadLetterId()).isNotNull();
+    assertThat(entry.caseId()).isEqualTo(caseId);
+    assertThat(entry.workerId()).isEqualTo("my-worker");
+    assertThat(entry.idempotencyHash()).isEqualTo("hash-abc");
+    assertThat(entry.status()).isEqualTo(DeadLetterStatus.PENDING_REVIEW);
+    assertThat(entry.arrivedAt()).isNotNull();
+    assertThat(entry.inputContext()).containsEntry("key", "value");
+  }
+
+  @Test
+  void add_multipleEntriesAreStoredIndependently() {
+    UUID caseA = UUID.randomUUID();
+    UUID caseB = UUID.randomUUID();
+
+    queue.add(caseA, "worker-1", "hash-1", Map.of());
+    queue.add(caseB, "worker-2", "hash-2", Map.of());
+
+    List<DeadLetterEntry> all = queue.query(DeadLetterQuery.all());
+    assertThat(all).hasSize(2);
+    assertThat(all.stream().map(DeadLetterEntry::caseId)).containsExactlyInAnyOrder(caseA, caseB);
+  }
+
+  // ---- query ----------------------------------------------------------------
+
+  @Test
+  void query_all_returnsEveryEntry() {
+    queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+    queue.add(UUID.randomUUID(), "w2", "h2", Map.of());
+    queue.add(UUID.randomUUID(), "w3", "h3", Map.of());
+
+    assertThat(queue.query(DeadLetterQuery.all())).hasSize(3);
+  }
+
+  @Test
+  void query_byStatus_filtersPendingOnly() {
+    UUID caseId = UUID.randomUUID();
+    DeadLetterEntry added = queue.add(caseId, "w1", "h1", Map.of());
+    queue.discard(added.deadLetterId());
+
+    List<DeadLetterEntry> pending =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.PENDING_REVIEW));
+    List<DeadLetterEntry> discarded =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.DISCARDED));
+
+    assertThat(pending).isEmpty();
+    assertThat(discarded).hasSize(1);
+    assertThat(discarded.get(0).caseId()).isEqualTo(caseId);
+  }
+
+  @Test
+  void query_byWorkerId_filtersCorrectly() {
+    queue.add(UUID.randomUUID(), "target-worker", "h1", Map.of());
+    queue.add(UUID.randomUUID(), "other-worker", "h2", Map.of());
+
+    List<DeadLetterEntry> results = queue.query(DeadLetterQuery.forWorker("target-worker"));
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).workerId()).isEqualTo("target-worker");
+  }
+
+  @Test
+  void query_arrivedAfter_excludesOlderEntries() throws InterruptedException {
+    queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+    Instant cutoff = Instant.now();
+    Thread.sleep(5); // ensure next entry has a later timestamp
+    queue.add(UUID.randomUUID(), "w2", "h2", Map.of());
+
+    List<DeadLetterEntry> results = queue.query(DeadLetterQuery.arrivedAfter(cutoff));
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).workerId()).isEqualTo("w2");
+  }
+
+  @Test
+  void query_emptyQueue_returnsEmptyList() {
+    assertThat(queue.query(DeadLetterQuery.all())).isEmpty();
+  }
+
+  // ---- discard --------------------------------------------------------------
+
+  @Test
+  void discard_updatesStatusToDiscarded() {
+    DeadLetterEntry entry = queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+
+    queue.discard(entry.deadLetterId());
+
+    List<DeadLetterEntry> discarded =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.DISCARDED));
+    assertThat(discarded).hasSize(1);
+    assertThat(discarded.get(0).deadLetterId()).isEqualTo(entry.deadLetterId());
+  }
+
+  @Test
+  void discard_unknownId_doesNothing() {
+    queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+    queue.discard("nonexistent-id"); // must not throw
+
+    assertThat(queue.query(DeadLetterQuery.all())).hasSize(1);
+  }
+
+  // ---- replay ---------------------------------------------------------------
+
+  @Test
+  void replay_updatesStatusToReplayed() {
+    DeadLetterEntry entry = queue.add(UUID.randomUUID(), "w1", "h1", Map.of("doc", "id-1"));
+
+    queue.markReplayed(entry.deadLetterId());
+
+    List<DeadLetterEntry> replayed =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.REPLAYED));
+    assertThat(replayed).hasSize(1);
+    assertThat(replayed.get(0).deadLetterId()).isEqualTo(entry.deadLetterId());
+  }
+
+  @Test
+  void replay_preservesOriginalInputContext() {
+    Map<String, Object> input = Map.of("documentId", "doc-99", "status", "failed");
+    DeadLetterEntry entry = queue.add(UUID.randomUUID(), "w1", "h1", input);
+
+    queue.markReplayed(entry.deadLetterId());
+
+    DeadLetterEntry replayed =
+        queue.query(DeadLetterQuery.withStatus(DeadLetterStatus.REPLAYED)).get(0);
+    assertThat(replayed.inputContext()).containsEntry("documentId", "doc-99");
+  }
+
+  // ---- size / eviction sanity -----------------------------------------------
+
+  @Test
+  void size_reflectsNumberOfStoredEntries() {
+    assertThat(queue.size()).isZero();
+    queue.add(UUID.randomUUID(), "w1", "h1", Map.of());
+    queue.add(UUID.randomUUID(), "w2", "h2", Map.of());
+    assertThat(queue.size()).isEqualTo(2);
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillDetectorTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillDetectorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests — no Quarkus, no CDI. PoisonPillDetector is a self-contained sliding-window
+ * circuit breaker that must be testable without a container.
+ */
+class PoisonPillDetectorTest {
+
+  /** Small threshold and window for fast tests. */
+  private PoisonPillDetector detector;
+
+  @BeforeEach
+  void setUp() {
+    // threshold=3, window=1 minute, quarantine=1 minute
+    detector = new PoisonPillDetector(3, Duration.ofMinutes(1), Duration.ofMinutes(1));
+  }
+
+  // ---- Below threshold — not quarantined ------------------------------------
+
+  @Test
+  void belowThreshold_workerIsNotQuarantined() {
+    detector.recordFailure("worker-a");
+    detector.recordFailure("worker-a");
+
+    assertThat(detector.isQuarantined("worker-a")).isFalse();
+  }
+
+  @Test
+  void noFailures_workerIsNotQuarantined() {
+    assertThat(detector.isQuarantined("brand-new-worker")).isFalse();
+  }
+
+  // ---- At threshold — quarantined -------------------------------------------
+
+  @Test
+  void atThreshold_workerIsQuarantined() {
+    detector.recordFailure("worker-b");
+    detector.recordFailure("worker-b");
+    detector.recordFailure("worker-b"); // 3rd failure triggers quarantine
+
+    assertThat(detector.isQuarantined("worker-b")).isTrue();
+  }
+
+  @Test
+  void beyondThreshold_workerRemainsQuarantined() {
+    for (int i = 0; i < 10; i++) {
+      detector.recordFailure("worker-c");
+    }
+    assertThat(detector.isQuarantined("worker-c")).isTrue();
+  }
+
+  // ---- Quarantine only affects the named worker -----------------------------
+
+  @Test
+  void quarantineIsPerWorker_otherWorkersUnaffected() {
+    detector.recordFailure("bad-worker");
+    detector.recordFailure("bad-worker");
+    detector.recordFailure("bad-worker");
+
+    assertThat(detector.isQuarantined("bad-worker")).isTrue();
+    assertThat(detector.isQuarantined("good-worker")).isFalse();
+  }
+
+  // ---- Manual release -------------------------------------------------------
+
+  @Test
+  void release_clearsQuarantine() {
+    detector.recordFailure("worker-d");
+    detector.recordFailure("worker-d");
+    detector.recordFailure("worker-d");
+    assertThat(detector.isQuarantined("worker-d")).isTrue();
+
+    detector.release("worker-d");
+
+    assertThat(detector.isQuarantined("worker-d")).isFalse();
+  }
+
+  @Test
+  void release_unknownWorker_doesNotThrow() {
+    detector.release("nonexistent"); // must not throw
+  }
+
+  @Test
+  void release_resetsFailureCount() {
+    // After release, two more failures should NOT re-trigger quarantine (below threshold)
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e");
+    detector.release("worker-e");
+
+    detector.recordFailure("worker-e");
+    detector.recordFailure("worker-e"); // only 2 new failures
+
+    assertThat(detector.isQuarantined("worker-e")).isFalse();
+  }
+
+  // ---- Failures outside window don't count ----------------------------------
+
+  @Test
+  void failuresOutsideWindow_doNotContributeToThreshold() throws InterruptedException {
+    // Use a very short window detector
+    PoisonPillDetector shortWindowDetector =
+        new PoisonPillDetector(3, Duration.ofMillis(50), Duration.ofMinutes(1));
+
+    shortWindowDetector.recordFailure("worker-f");
+    shortWindowDetector.recordFailure("worker-f");
+    Thread.sleep(100); // let the window expire
+
+    // These two are within the new window — below threshold of 3
+    shortWindowDetector.recordFailure("worker-f");
+    shortWindowDetector.recordFailure("worker-f");
+
+    assertThat(shortWindowDetector.isQuarantined("worker-f")).isFalse();
+  }
+
+  // ---- Quarantine expiry ----------------------------------------------------
+
+  @Test
+  void quarantine_expiresAfterCoolDown() throws InterruptedException {
+    PoisonPillDetector shortQuarantineDetector =
+        new PoisonPillDetector(3, Duration.ofMinutes(1), Duration.ofMillis(80));
+
+    shortQuarantineDetector.recordFailure("worker-g");
+    shortQuarantineDetector.recordFailure("worker-g");
+    shortQuarantineDetector.recordFailure("worker-g");
+    assertThat(shortQuarantineDetector.isQuarantined("worker-g")).isTrue();
+
+    Thread.sleep(150); // wait for quarantine to expire
+
+    assertThat(shortQuarantineDetector.isQuarantined("worker-g")).isFalse();
+  }
+
+  // ---- Quarantine status reporting ------------------------------------------
+
+  @Test
+  void quarantinedWorkers_listReturnsAllQuarantinedNames() {
+    detector.recordFailure("slow-worker");
+    detector.recordFailure("slow-worker");
+    detector.recordFailure("slow-worker");
+
+    assertThat(detector.quarantinedWorkers()).contains("slow-worker");
+    assertThat(detector.quarantinedWorkers()).doesNotContain("clean-worker");
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.poison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test: verifies that once a worker is quarantined by {@link PoisonPillDetector}, the
+ * engine skips scheduling it and the case transitions to FAULTED without additional execution
+ * attempts.
+ *
+ * <p>The test pre-quarantines the worker directly via {@link PoisonPillDetector} (bypassing the
+ * failure count mechanism), then starts a case and verifies the worker is never invoked.
+ */
+@QuarkusTest
+class PoisonPillIntegrationTest {
+
+  @Inject PoisonPillDetector detector;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject QuarantineSkipCaseHub quarantineSkipCase;
+
+  @BeforeEach
+  void releaseAll() {
+    detector.release("quarantine-checked-worker");
+    QuarantineSkipCaseHub.runCount.set(0);
+  }
+
+  /**
+   * When the worker is quarantined, the engine must NOT invoke it — the worker function should
+   * never run, and the case should fault due to no eligible workers.
+   */
+  @Test
+  void quarantinedWorker_isNeverInvoked_andCaseFaults() {
+    // Pre-quarantine: record enough failures to trigger quarantine (threshold=3 in test config)
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isTrue();
+
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    quarantineSkipCase
+        .startCase(Map.of("status", "run"))
+        .thenAccept(caseIdRef::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(caseIdRef.get()).isNotNull();
+            });
+
+    UUID caseId = caseIdRef.get();
+
+    // Case must reach FAULTED — quarantined worker cannot execute
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
+            });
+
+    // Worker function must have been called zero times
+    assertThat(QuarantineSkipCaseHub.runCount.get())
+        .as("quarantined worker must not execute")
+        .isZero();
+  }
+
+  /** After releasing the quarantine, the worker should execute normally and complete the case. */
+  @Test
+  void afterRelease_workerExecutesNormally() {
+    // Pre-quarantine then release
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    detector.recordFailure("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isTrue();
+
+    detector.release("quarantine-checked-worker");
+    assertThat(detector.isQuarantined("quarantine-checked-worker")).isFalse();
+
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    quarantineSkipCase
+        .startCase(Map.of("status", "run"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseIdRef.get());
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    assertThat(QuarantineSkipCaseHub.runCount.get())
+        .as("released worker should have executed once")
+        .isEqualTo(1);
+  }
+
+  // ---- CaseHub bean ---------------------------------------------------------
+
+  @ApplicationScoped
+  public static class QuarantineSkipCaseHub extends CaseHub {
+
+    static final AtomicInteger runCount = new AtomicInteger(0);
+
+    private final Capability capability =
+        Capability.builder()
+            .name("checkedWork")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder()
+            .name("done")
+            .condition(".status == \"complete\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-poison-pill-e2e")
+          .name("Quarantine Skip Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("quarantine-checked-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        runCount.incrementAndGet();
+                        return Map.of("status", "complete");
+                      })
+                  .executionPolicy(new ExecutionPolicy(5000, new RetryPolicy(1, 100)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"run\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+}

--- a/casehub-resilience/src/test/resources/application.properties
+++ b/casehub-resilience/src/test/resources/application.properties
@@ -1,0 +1,14 @@
+%test.quarkus.hibernate-orm.mapping.format.global=ignore
+%test.quarkus.flyway.clean-at-start=true
+
+# Index engine and api modules so Quarkus discovers their CDI beans
+quarkus.index-dependency.engine.group-id=io.casehub
+quarkus.index-dependency.engine.artifact-id=engine
+quarkus.index-dependency.api.group-id=io.casehub
+quarkus.index-dependency.api.artifact-id=api
+
+# Activate PoisonPill guard so quarantined workers are skipped by the scheduler
+quarkus.arc.selected-alternatives=io.casehub.resilience.poison.PoisonPillWorkerExecutionGuard
+
+# Lower threshold for faster integration tests (default is 5)
+casehub.resilience.poison-pill.threshold=3

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -84,6 +84,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/engine/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import io.fabric8.zjsonpatch.JsonDiff;
 import io.fabric8.zjsonpatch.JsonPatch;
 import java.util.ArrayList;
@@ -35,8 +35,8 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 
-@JsonDeserialize(as = StateContextImpl.class)
-public class StateContextImpl implements StateContext {
+@JsonDeserialize(as = CaseContextImpl.class)
+public class CaseContextImpl implements CaseContext {
 
   private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -44,22 +44,22 @@ public class StateContextImpl implements StateContext {
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
   private long version = 0L;
 
-  public StateContextImpl() {}
+  public CaseContextImpl() {}
 
-  public StateContextImpl(Map<String, Object> initial) {
+  public CaseContextImpl(Map<String, Object> initial) {
     if (initial != null) {
       data.putAll(initial);
     }
   }
 
-  public StateContextImpl(Map<String, Object> initial, long version) {
+  public CaseContextImpl(Map<String, Object> initial, long version) {
     if (initial != null) {
       data.putAll(initial);
     }
     this.version = version;
   }
 
-  public StateContextImpl(JsonNode asNode) {
+  public CaseContextImpl(JsonNode asNode) {
     this(mapper.convertValue(asNode == null ? mapper.createObjectNode() : asNode, Map.class));
   }
 
@@ -76,7 +76,7 @@ public class StateContextImpl implements StateContext {
 
   @JsonAnySetter
   @Override
-  public StateContext set(String key, Object value) {
+  public CaseContext set(String key, Object value) {
     lock.writeLock().lock();
     try {
       Object prev = data.get(key);
@@ -179,7 +179,7 @@ public class StateContextImpl implements StateContext {
   }
 
   @Override
-  public StateContext update(String key, Function<Object, Object> updateFunction) {
+  public CaseContext update(String key, Function<Object, Object> updateFunction) {
     lock.writeLock().lock();
     try {
       Object current = data.get(key);
@@ -288,7 +288,7 @@ public class StateContextImpl implements StateContext {
 
   @SuppressWarnings("unchecked")
   @Override
-  public StateContext setPath(String path, Object value) {
+  public CaseContext setPath(String path, Object value) {
     lock.writeLock().lock();
     try {
       String[] parts = path.split("\\.");
@@ -319,7 +319,7 @@ public class StateContextImpl implements StateContext {
   }
 
   @Override
-  public StateContext setAll(Map<String, Object> values) {
+  public CaseContext setAll(Map<String, Object> values) {
     if (values == null || values.isEmpty()) return this;
     lock.writeLock().lock();
     try {
@@ -368,7 +368,7 @@ public class StateContextImpl implements StateContext {
   }
 
   @Override
-  public StateContext remove(String key) {
+  public CaseContext remove(String key) {
     lock.writeLock().lock();
     try {
       if (data.containsKey(key)) {
@@ -382,7 +382,7 @@ public class StateContextImpl implements StateContext {
   }
 
   @Override
-  public StateContext clear() {
+  public CaseContext clear() {
     lock.writeLock().lock();
     try {
       if (!data.isEmpty()) {
@@ -439,7 +439,7 @@ public class StateContextImpl implements StateContext {
   }
 
   @Override
-  public StateContext merge(StateContext other) {
+  public CaseContext merge(CaseContext other) {
     if (other == null) return this;
     lock.writeLock().lock();
     try {
@@ -462,17 +462,17 @@ public class StateContextImpl implements StateContext {
   }
 
   @Override
-  public StateContext snapshot() {
+  public CaseContext snapshot() {
     lock.readLock().lock();
     try {
-      return new StateContextImpl(deepCopy(data), version);
+      return new CaseContextImpl(deepCopy(data), version);
     } finally {
       lock.readLock().unlock();
     }
   }
 
   @Override
-  public JsonNode diff(StateContext other) {
+  public JsonNode diff(CaseContext other) {
     lock.readLock().lock();
     try {
       JsonNode thisNode = mapper.convertValue(this.data, JsonNode.class);
@@ -543,7 +543,7 @@ public class StateContextImpl implements StateContext {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof StateContextImpl that)) return false;
+    if (!(o instanceof CaseContextImpl that)) return false;
     Map<String, Object> thisData = this.getData();
     Map<String, Object> thatData = that.getData();
     return thisData.equals(thatData);

--- a/engine/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -313,6 +314,42 @@ public class CaseContextImpl implements CaseContext {
         version++;
       }
       return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<JsonNode> applyAndDiff(String path, Object value) {
+    lock.writeLock().lock();
+    try {
+      JsonNode before = mapper.convertValue(data, JsonNode.class);
+
+      String[] parts = path.split("\\.");
+      Map<String, Object> current = data;
+      for (int i = 0; i < parts.length - 1; i++) {
+        Object next = current.get(parts[i]);
+        if (next == null) {
+          next = new LinkedHashMap<String, Object>();
+          current.put(parts[i], next);
+        }
+        if (next instanceof Map) {
+          current = (Map<String, Object>) next;
+        } else {
+          throw new IllegalStateException("Cannot set path: " + parts[i] + " is not a Map");
+        }
+      }
+      String leaf = parts[parts.length - 1];
+      Object prev = current.get(leaf);
+      if (!Objects.equals(prev, value)) {
+        current.put(leaf, value);
+        version++;
+      }
+
+      JsonNode after = mapper.convertValue(data, JsonNode.class);
+      JsonNode diff = JsonDiff.asJson(before, after);
+      return diff.isEmpty() ? Optional.empty() : Optional.of(diff);
     } finally {
       lock.writeLock().unlock();
     }

--- a/engine/src/main/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.spi.ContextDiffStrategy;
+import io.fabric8.zjsonpatch.JsonDiff;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * RFC 6902 JSON Patch {@link ContextDiffStrategy} using {@code zjsonpatch}.
+ *
+ * <p>Produces a JSON array of patch operations ({@code add}, {@code replace}, {@code remove}).
+ * Records changes at every affected path, including nested keys — more precise than {@link
+ * TopLevelContextDiffStrategy} but less readable for humans.
+ *
+ * <p>Useful as a foundation for future replay support (issues #10–#13).
+ *
+ * <p>Activate via:
+ *
+ * <pre>
+ * quarkus.arc.selected-alternatives=io.casehub.engine.internal.diff.JsonPatchContextDiffStrategy
+ * </pre>
+ */
+@Alternative
+@ApplicationScoped
+public class JsonPatchContextDiffStrategy implements ContextDiffStrategy {
+
+  @Override
+  public JsonNode compute(JsonNode before, JsonNode after) {
+    return JsonDiff.asJson(before, after);
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.spi.ContextDiffStrategy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * No-op {@link ContextDiffStrategy}: skips diff computation entirely. {@code contextChanges} is
+ * omitted from {@code WORKER_EXECUTION_COMPLETED} metadata. Use when diff overhead is unwanted.
+ *
+ * <p>Activate via:
+ *
+ * <pre>quarkus.arc.selected-alternatives=io.casehub.engine.internal.diff.NoOpContextDiffStrategy
+ * </pre>
+ */
+@Alternative
+@ApplicationScoped
+public class NoOpContextDiffStrategy implements ContextDiffStrategy {
+
+  @Override
+  public JsonNode compute(JsonNode before, JsonNode after) {
+    return null;
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategy.java
+++ b/engine/src/main/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategy.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.casehub.api.spi.ContextDiffStrategy;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Default {@link ContextDiffStrategy}: records a before/after entry per changed top-level key.
+ *
+ * <p>Output format per key:
+ *
+ * <ul>
+ *   <li>Added: {@code { "after": value }} — no {@code before} field
+ *   <li>Updated: {@code { "before": oldValue, "after": newValue }}
+ *   <li>Removed: {@code { "before": oldValue }} — no {@code after} field
+ *   <li>Unchanged: omitted entirely
+ * </ul>
+ *
+ * <p>Operates on top-level keys only. Nested changes within an object value are captured as a
+ * whole-object before/after, not path-by-path. Use {@link JsonPatchContextDiffStrategy} for full
+ * path precision.
+ */
+@ApplicationScoped
+public class TopLevelContextDiffStrategy implements ContextDiffStrategy {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Override
+  public JsonNode compute(JsonNode before, JsonNode after) {
+    ObjectNode changes = MAPPER.createObjectNode();
+
+    // Added or updated keys — present in `after`
+    after
+        .fieldNames()
+        .forEachRemaining(
+            key -> {
+              JsonNode afterVal = after.get(key);
+              JsonNode beforeVal = before.get(key);
+              if (afterVal.equals(beforeVal)) {
+                return; // unchanged — omit
+              }
+              ObjectNode change = MAPPER.createObjectNode();
+              if (beforeVal != null && !beforeVal.isMissingNode()) {
+                change.set("before", beforeVal);
+              }
+              // null written by worker is treated as removal — no "after" field
+              if (afterVal != null && !afterVal.isNull()) {
+                change.set("after", afterVal);
+              }
+              changes.set(key, change);
+            });
+
+    // Removed keys — present in `before` but absent in `after`
+    before
+        .fieldNames()
+        .forEachRemaining(
+            key -> {
+              if (!after.has(key)) {
+                ObjectNode change = MAPPER.createObjectNode();
+                change.set("before", before.get(key));
+                changes.set(key, change);
+              }
+            });
+
+    return changes;
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -18,14 +18,14 @@ package io.casehub.engine.internal.engine;
 import static io.casehub.engine.internal.event.EventBusAddresses.CASE_STARTED;
 import static io.casehub.engine.internal.event.EventBusAddresses.SIGNAL_RECEIVED;
 
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.event.CaseStartedEvent;
 import io.casehub.engine.internal.event.SignalReceivedEvent;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.model.CaseMetaModel;
-import io.casehub.engine.internal.model.CaseState;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -49,7 +49,7 @@ class CaseHubReactor {
 
   @Inject EventBus eventBus;
 
-  CompletionStage<UUID> startCase(CaseDefinition definition, StateContext context) {
+  CompletionStage<UUID> startCase(CaseDefinition definition, CaseContext context) {
     return getCaseInstance(definition, context)
         .invoke(
             instance -> {
@@ -61,15 +61,15 @@ class CaseHubReactor {
         .subscribeAsCompletionStage();
   }
 
-  private Uni<CaseInstance> getCaseInstance(CaseDefinition definition, StateContext context) {
+  private Uni<CaseInstance> getCaseInstance(CaseDefinition definition, CaseContext context) {
     CaseMetaModel model = caseDefinitionRegistry.getCaseMetaModel(definition);
 
     CaseInstance instance = new CaseInstance();
     instance.setUuid(UUID.randomUUID());
     instance.setCaseMetaModel(model);
     instance.setVersion(0L);
-    instance.setState(CaseState.ACTIVE);
-    instance.setStateContext(context);
+    instance.setState(CaseStatus.RUNNING);
+    instance.setCaseContext(context);
 
     caseInstanceCache.put(instance);
     return sessionFactory.withTransaction(session -> instance.persist());
@@ -85,7 +85,7 @@ class CaseHubReactor {
           if (caseInstanceCache.get(caseId) == null) {
             throw new RuntimeException("Case instance not found for caseId: " + caseId);
           }
-          return caseInstanceCache.get(caseId).getStateContext().getPath(path);
+          return caseInstanceCache.get(caseId).getCaseContext().getPath(path);
         });
   }
 

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
@@ -17,7 +17,7 @@ package io.casehub.engine.internal.engine;
 
 import io.casehub.api.engine.CaseHubRuntime;
 import io.casehub.api.model.CaseDefinition;
-import io.casehub.engine.internal.context.StateContextImpl;
+import io.casehub.engine.internal.context.CaseContextImpl;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -31,12 +31,12 @@ class CaseHubRuntimeImpl implements CaseHubRuntime {
 
   @Override
   public CompletionStage<UUID> startCase(CaseDefinition definition) {
-    return reactor.startCase(definition, new StateContextImpl());
+    return reactor.startCase(definition, new CaseContextImpl());
   }
 
   @Override
   public CompletionStage<UUID> startCase(CaseDefinition definition, Map<String, Object> inputData) {
-    return reactor.startCase(definition, new StateContextImpl(inputData));
+    return reactor.startCase(definition, new CaseContextImpl(inputData));
   }
 
   @Override

--- a/engine/src/main/java/io/casehub/engine/internal/engine/ChoreographyLoopControl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/ChoreographyLoopControl.java
@@ -15,8 +15,8 @@
  */
 package io.casehub.engine.internal.engine;
 
-import io.casehub.api.context.StateContext;
 import io.casehub.api.engine.LoopControl;
+import io.casehub.api.engine.PlanExecutionContext;
 import io.casehub.api.model.Binding;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
@@ -32,7 +32,7 @@ import java.util.List;
 public class ChoreographyLoopControl implements LoopControl {
 
   @Override
-  public List<Binding> select(final StateContext context, final List<Binding> eligible) {
+  public List<Binding> select(final PlanExecutionContext context, final List<Binding> eligible) {
     return eligible;
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/ExpressionEngineRegistry.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/ExpressionEngineRegistry.java
@@ -16,10 +16,10 @@
 package io.casehub.engine.internal.engine;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import io.casehub.api.engine.ExpressionEngine;
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
-import io.casehub.engine.internal.context.StateContextImpl;
+import io.casehub.engine.internal.context.CaseContextImpl;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -47,7 +47,7 @@ public class ExpressionEngineRegistry {
    * @return {@code true} if the expression matches or is absent
    * @throws IllegalArgumentException if no engine is registered for the evaluator type
    */
-  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+  public boolean evaluate(final ExpressionEvaluator evaluator, final CaseContext context) {
     if (evaluator == null) {
       return true;
     }
@@ -62,7 +62,7 @@ public class ExpressionEngineRegistry {
 
   // TODO do not use JsonNode
   public boolean evaluate(final ExpressionEvaluator evaluator, final JsonNode asNode) {
-    return evaluate(evaluator, new StateContextImpl(asNode));
+    return evaluate(evaluator, new CaseContextImpl(asNode));
   }
 
   /**

--- a/engine/src/main/java/io/casehub/engine/internal/engine/JQExpressionEngine.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/JQExpressionEngine.java
@@ -15,7 +15,7 @@
  */
 package io.casehub.engine.internal.engine;
 
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import io.casehub.api.engine.ExpressionEngine;
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
@@ -38,7 +38,7 @@ public class JQExpressionEngine implements ExpressionEngine {
   }
 
   @Override
-  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+  public boolean evaluate(final ExpressionEvaluator evaluator, final CaseContext context) {
     final String expr = ((JQExpressionEvaluator) evaluator).expression();
     if (expr == null || expr.isBlank()) {
       return true;

--- a/engine/src/main/java/io/casehub/engine/internal/engine/LambdaExpressionEngine.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/LambdaExpressionEngine.java
@@ -15,7 +15,7 @@
  */
 package io.casehub.engine.internal.engine;
 
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import io.casehub.api.engine.ExpressionEngine;
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
@@ -31,7 +31,7 @@ public class LambdaExpressionEngine implements ExpressionEngine {
   }
 
   @Override
-  public boolean evaluate(final ExpressionEvaluator evaluator, final StateContext context) {
+  public boolean evaluate(final ExpressionEvaluator evaluator, final CaseContext context) {
     return ((LambdaExpressionEvaluator) evaluator).test(context);
   }
 

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -17,23 +17,24 @@ package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.casehub.api.engine.LoopControl;
+import io.casehub.api.engine.PlanExecutionContext;
 import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
 import io.casehub.engine.internal.engine.ExpressionEngineRegistry;
-import io.casehub.engine.internal.event.CaseStateContextChangedEvent;
+import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.GoalReachedEvent;
 import io.casehub.engine.internal.event.MilestoneReachedEvent;
 import io.casehub.engine.internal.event.WorkerScheduleEvent;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.model.CaseMetaModel;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -44,9 +45,9 @@ import java.util.List;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
-public class CaseStateContextChangedEventHandler {
+public class CaseContextChangedEventHandler {
 
-  private static final Logger LOG = Logger.getLogger(CaseStateContextChangedEventHandler.class);
+  private static final Logger LOG = Logger.getLogger(CaseContextChangedEventHandler.class);
 
   @Inject EventBus eventBus;
 
@@ -57,10 +58,10 @@ public class CaseStateContextChangedEventHandler {
   @Inject LoopControl loopControl;
 
   @ConsumeEvent(value = EventBusAddresses.CONTEXT_CHANGED)
-  public Uni<Void> onCaseStateContextChangedEventHandler(CaseStateContextChangedEvent event) {
+  public Uni<Void> onCaseStateContextChangedEventHandler(CaseContextChangedEvent event) {
     CaseInstance caseInstance = event.instance();
     JsonNode contextSnapshot = event.contextSnapshot();
-    if (!caseInstance.getState().equals(CaseState.ACTIVE)) {
+    if (!caseInstance.getState().equals(CaseStatus.RUNNING)) {
       return Uni.createFrom().voidItem();
     }
 
@@ -119,7 +120,9 @@ public class CaseStateContextChangedEventHandler {
     }
 
     // LoopControl decides which eligible rules to fire (default: all of them)
-    List<Binding> selected = loopControl.select(caseInstance.getStateContext(), eligible);
+    PlanExecutionContext planCtx =
+        new PlanExecutionContext(caseInstance.getUuid(), definition, caseInstance.getCaseContext());
+    List<Binding> selected = loopControl.select(planCtx, eligible);
 
     List<Uni<Void>> unis = new ArrayList<>(selected.size());
     for (Binding b : selected) {
@@ -142,7 +145,7 @@ public class CaseStateContextChangedEventHandler {
 
     for (Milestone milestone : milestones) {
       if (!expressionEngineRegistry.evaluate(
-          milestone.getCondition(), caseInstance.getStateContext())) continue;
+          milestone.getCondition(), caseInstance.getCaseContext())) continue;
 
       LOG.infof("Milestone '%s' REACHED! Publishing MilestoneReachedEvent", milestone.getName());
 
@@ -161,7 +164,7 @@ public class CaseStateContextChangedEventHandler {
     }
 
     for (Goal goal : goals) {
-      if (!expressionEngineRegistry.evaluate(goal.getCondition(), caseInstance.getStateContext()))
+      if (!expressionEngineRegistry.evaluate(goal.getCondition(), caseInstance.getCaseContext()))
         continue;
 
       LOG.infof("Goal '%s' REACHED! Publishing GoalReachedEvent", goal.getName());

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
@@ -16,8 +16,8 @@
 package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.CaseStartedEvent;
-import io.casehub.engine.internal.event.CaseStateContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
@@ -42,7 +42,7 @@ public class CaseStartedEventHandler {
   @ConsumeEvent(value = EventBusAddresses.CASE_STARTED)
   public Uni<Void> onCaseStarted(CaseStartedEvent event) {
     CaseInstance instance = event.instance();
-    JsonNode contextSnapshot = instance.getStateContext().asJsonNode();
+    JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
     EventLog eventLog = new EventLog();
     eventLog.setCaseId(instance.getUuid());
     eventLog.setEventType(CaseHubEventType.CASE_STARTED);
@@ -55,6 +55,6 @@ public class CaseStartedEventHandler {
             () ->
                 eventBus.publish(
                     EventBusAddresses.CONTEXT_CHANGED,
-                    new CaseStateContextChangedEvent(instance, contextSnapshot)));
+                    new CaseContextChangedEvent(instance, contextSnapshot)));
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
@@ -16,13 +16,13 @@
 package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.event.CaseStatusChanged;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.history.EventStreamType;
 import io.casehub.engine.internal.model.CaseInstance;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
@@ -43,7 +43,7 @@ public class CaseStatusChangedHandler {
   @ConsumeEvent(value = EventBusAddresses.CASE_STATUS_CHANGED)
   public Uni<Void> onCaseStatusChangedHandler(CaseStatusChanged event) {
     CaseInstance caseInstance = event.instance();
-    CaseState newState = CaseState.valueOf(event.newStatus());
+    CaseStatus newState = CaseStatus.valueOf(event.newStatus());
     String oldStatus = event.oldStatus();
 
     LOG.infof(
@@ -80,18 +80,18 @@ public class CaseStatusChangedHandler {
         .replaceWithVoid();
   }
 
-  private CaseHubEventType resolveState(CaseState state) {
+  private CaseHubEventType resolveState(CaseStatus state) {
     return switch (state) {
       case COMPLETED -> CaseHubEventType.CASE_COMPLETED;
-      case FAILED -> CaseHubEventType.CASE_FAILED;
+      case FAULTED -> CaseHubEventType.CASE_FAULTED;
       default -> CaseHubEventType.CASE_STATUS_CHANGED;
     };
   }
 
-  private String resolveStateAsString(CaseState state) {
+  private String resolveStateAsString(CaseStatus state) {
     return switch (state) {
       case COMPLETED -> EventBusAddresses.CASE_COMPLETED;
-      case FAILED -> EventBusAddresses.CASE_FAILED;
+      case FAULTED -> EventBusAddresses.CASE_FAULTED;
       default -> null;
     };
   }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/GoalReachedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/GoalReachedEventHandler.java
@@ -20,6 +20,7 @@ import static io.casehub.engine.internal.history.CaseHubEventType.GOAL_REACHED;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.CaseCompletion;
 import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalBasedCompletion;
 import io.casehub.api.model.GoalExpression;
@@ -30,7 +31,6 @@ import io.casehub.engine.internal.event.GoalReachedEvent;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.history.EventStreamType;
 import io.casehub.engine.internal.model.CaseInstance;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
@@ -111,7 +111,7 @@ public class GoalReachedEventHandler {
                 LOG.infof("Case FAILED: caseId=%s", caseInstance.getUuid());
                 eventBus.publish(
                     EventBusAddresses.CASE_STATUS_CHANGED,
-                    new CaseStatusChanged(caseInstance, oldStatus, CaseState.FAILED.name()));
+                    new CaseStatusChanged(caseInstance, oldStatus, CaseStatus.FAULTED.name()));
                 return Uni.createFrom().voidItem();
               }
 
@@ -120,7 +120,7 @@ public class GoalReachedEventHandler {
                 LOG.infof("Case COMPLETED: caseId=%s", caseInstance.getUuid());
                 eventBus.publish(
                     EventBusAddresses.CASE_STATUS_CHANGED,
-                    new CaseStatusChanged(caseInstance, oldStatus, CaseState.COMPLETED.name()));
+                    new CaseStatusChanged(caseInstance, oldStatus, CaseStatus.COMPLETED.name()));
                 return Uni.createFrom().voidItem();
               }
 

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
@@ -19,10 +19,10 @@ import static io.casehub.engine.internal.event.EventBusAddresses.CONTEXT_CHANGED
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
-import io.casehub.engine.internal.event.CaseStateContextChangedEvent;
+import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.SignalReceivedEvent;
 import io.casehub.engine.internal.history.CaseHubEventType;
@@ -63,10 +63,10 @@ public class SignalReceivedEventHandler {
   }
 
   private Uni<Void> applySignal(CaseInstance instance, SignalReceivedEvent event) {
-    StateContext before = instance.getStateContext().snapshot();
-    instance.getStateContext().setPath(event.path(), event.value());
-    JsonNode diff = before.diff(instance.getStateContext());
-    JsonNode contextSnapshot = instance.getStateContext().asJsonNode();
+    CaseContext before = instance.getCaseContext().snapshot();
+    instance.getCaseContext().setPath(event.path(), event.value());
+    JsonNode diff = before.diff(instance.getCaseContext());
+    JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
 
     if (diff.isEmpty()) {
       LOG.debugf(
@@ -84,7 +84,7 @@ public class SignalReceivedEventHandler {
                       () ->
                           eventBus.publish(
                               CONTEXT_CHANGED,
-                              new CaseStateContextChangedEvent(instance, contextSnapshot)));
+                              new CaseContextChangedEvent(instance, contextSnapshot)));
             })
         .replaceWithVoid()
         .onFailure()

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
@@ -19,7 +19,6 @@ import static io.casehub.engine.internal.event.EventBusAddresses.CONTEXT_CHANGED
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.casehub.api.context.CaseContext;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
 import io.casehub.engine.internal.event.CaseContextChangedEvent;
@@ -36,6 +35,7 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Instant;
+import java.util.Optional;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -63,17 +63,18 @@ public class SignalReceivedEventHandler {
   }
 
   private Uni<Void> applySignal(CaseInstance instance, SignalReceivedEvent event) {
-    CaseContext before = instance.getCaseContext().snapshot();
-    instance.getCaseContext().setPath(event.path(), event.value());
-    JsonNode diff = before.diff(instance.getCaseContext());
-    JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
+    Optional<JsonNode> maybeDiff =
+        instance.getCaseContext().applyAndDiff(event.path(), event.value());
 
-    if (diff.isEmpty()) {
+    if (maybeDiff.isEmpty()) {
       LOG.debugf(
           "Signal path='%s' produced no state change for caseId=%s — skipping",
           event.path(), event.caseId());
       return Uni.createFrom().voidItem();
     }
+
+    JsonNode diff = maybeDiff.get();
+    JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
 
     return Panache.withTransaction(
             () -> {

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerRetriesExhaustedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerRetriesExhaustedEventHandler.java
@@ -16,6 +16,7 @@
 package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.event.CaseStatusChanged;
 import io.casehub.engine.internal.event.EventBusAddresses;
@@ -24,7 +25,6 @@ import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.history.EventStreamType;
 import io.casehub.engine.internal.model.CaseInstance;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
@@ -49,10 +49,10 @@ public class WorkerRetriesExhaustedEventHandler {
   public Uni<Void> onWorkerRetriesExhaustedEvent(WorkerRetriesExhaustedEvent event) {
     CaseInstance caseInstance = caseInstanceCache.get(event.caseId());
     String oldStatus = caseInstance.getState().name();
-    caseInstance.setState(CaseState.FAILED);
+    caseInstance.setState(CaseStatus.FAULTED);
 
     EventLog eventLog = new EventLog();
-    eventLog.setEventType(CaseHubEventType.CASE_FAILED);
+    eventLog.setEventType(CaseHubEventType.CASE_FAULTED);
     eventLog.setCaseId(caseInstance.getUuid());
     eventLog.setStreamType(EventStreamType.CASE);
     eventLog.setTimestamp(Instant.now());
@@ -63,7 +63,11 @@ public class WorkerRetriesExhaustedEventHandler {
             .put("workerId", event.workerId())
             .put("inputDataHash", event.idempotency()));
 
-    return Panache.withTransaction(() -> caseInstance.persist().chain(eventLog::persist))
+    return Panache.withTransaction(
+            () ->
+                Panache.getSession()
+                    .chain(session -> session.merge(caseInstance))
+                    .chain(merged -> eventLog.persist()))
         .invoke(
             () -> {
               LOG.warnf(
@@ -71,7 +75,7 @@ public class WorkerRetriesExhaustedEventHandler {
                   event.caseId(), event.workerId());
               eventBus.publish(
                   EventBusAddresses.CASE_STATUS_CHANGED,
-                  new CaseStatusChanged(caseInstance, oldStatus, CaseState.FAILED.name()));
+                  new CaseStatusChanged(caseInstance, oldStatus, CaseStatus.FAULTED.name()));
             })
         .replaceWithVoid();
   }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.Worker;
+import io.casehub.api.spi.WorkerExecutionGuard;
 import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
 import io.casehub.engine.internal.event.WorkerScheduleEvent;
 import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
@@ -47,10 +49,29 @@ public class WorkerScheduleEventHandler {
 
   @Inject WorkerExecutionManager workflowExecutionManager;
 
+  @Inject WorkerExecutionGuard workerExecutionGuard;
+
+  @Inject io.vertx.mutiny.core.eventbus.EventBus eventBus;
+
   @ConsumeEvent(value = EventBusAddresses.WORKER_SCHEDULE)
   public Uni<Void> onWorkerScheduleEventHandler(WorkerScheduleEvent event) {
     CaseInstance instance = event.caseInstance();
     Worker worker = event.worker();
+
+    if (workerExecutionGuard.isBlocked(worker.getName(), instance.getUuid())) {
+      LOG.warnf(
+          "Worker blocked by guard (quarantined?): caseId=%s worker=%s — emitting retries exhausted",
+          instance.getUuid(), worker.getName());
+      String idempotency =
+          io.casehub.engine.internal.util.WorkerExecutionKeys.inputDataHash(
+              worker.getName(),
+              event.capability().getName(),
+              instance.getCaseContext().evalObjectTemplate(event.capability().getInputSchema()));
+      eventBus.publish(
+          EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
+          new WorkerRetriesExhaustedEvent(instance.getUuid(), worker.getName(), idempotency));
+      return Uni.createFrom().voidItem();
+    }
     Capability capability = event.capability();
 
     Map<String, Object> inputData =

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -54,7 +54,7 @@ public class WorkerScheduleEventHandler {
     Capability capability = event.capability();
 
     Map<String, Object> inputData =
-        instance.getStateContext().evalObjectTemplate(capability.getInputSchema());
+        instance.getCaseContext().evalObjectTemplate(capability.getInputSchema());
     String inputDataHash =
         WorkerExecutionKeys.inputDataHash(worker.getName(), capability.getName(), inputData);
     EventLog eventLog = buildEventLog(instance, worker, capability, inputData, inputDataHash);

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -18,7 +18,7 @@ package io.casehub.engine.internal.engine.handler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.Worker;
-import io.casehub.engine.internal.event.CaseStateContextChangedEvent;
+import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
 import io.casehub.engine.internal.history.CaseHubEventType;
@@ -55,15 +55,15 @@ public class WorkflowExecutionCompletedHandler {
         buildEventLog(caseInstance, worker, rawOutput, event.idempotency(), now);
     return Panache.withTransaction(
             () -> {
-              caseInstance.getStateContext().setAll(rawOutput);
-              JsonNode contextSnapshot = caseInstance.getStateContext().asJsonNode();
+              caseInstance.getCaseContext().setAll(rawOutput);
+              JsonNode contextSnapshot = caseInstance.getCaseContext().asJsonNode();
               return eventLog.persist().replaceWith(contextSnapshot);
             })
         .invoke(
             contextSnapshot ->
                 eventBus.publish(
                     EventBusAddresses.CONTEXT_CHANGED,
-                    new CaseStateContextChangedEvent(caseInstance, contextSnapshot)))
+                    new CaseContextChangedEvent(caseInstance, contextSnapshot)))
         .replaceWithVoid()
         .onFailure()
         .invoke(

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -17,7 +17,9 @@ package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.casehub.api.model.Worker;
+import io.casehub.api.spi.ContextDiffStrategy;
 import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
@@ -39,10 +41,10 @@ import org.jboss.logging.Logger;
 public class WorkflowExecutionCompletedHandler {
 
   @Inject EventBus eventBus;
+  @Inject ContextDiffStrategy contextDiffStrategy;
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  private static final Logger LOG = Logger.getLogger(CaseStartedEventHandler.class);
+  private static final Logger LOG = Logger.getLogger(WorkflowExecutionCompletedHandler.class);
 
   @ConsumeEvent(value = EventBusAddresses.WORKER_EXECUTION_FINISHED)
   public Uni<Void> onWorkflowExecutionCompletedHandler(WorkflowExecutionCompleted event) {
@@ -51,13 +53,18 @@ public class WorkflowExecutionCompletedHandler {
     final Map<String, Object> rawOutput = event.output() == null ? Map.of() : event.output();
     final Instant now = Instant.now();
 
-    final EventLog eventLog =
-        buildEventLog(caseInstance, worker, rawOutput, event.idempotency(), now);
     return Panache.withTransaction(
             () -> {
+              // Snapshot BEFORE applying output — deep copy so setAll cannot corrupt it
+              JsonNode contextBefore = caseInstance.getCaseContext().snapshot().asJsonNode();
               caseInstance.getCaseContext().setAll(rawOutput);
-              JsonNode contextSnapshot = caseInstance.getCaseContext().asJsonNode();
-              return eventLog.persist().replaceWith(contextSnapshot);
+              JsonNode contextAfter = caseInstance.getCaseContext().asJsonNode();
+
+              JsonNode diff = contextDiffStrategy.compute(contextBefore, contextAfter);
+              EventLog eventLog =
+                  buildEventLog(caseInstance, worker, rawOutput, event.idempotency(), now, diff);
+
+              return eventLog.persist().replaceWith(contextAfter);
             })
         .invoke(
             contextSnapshot ->
@@ -79,18 +86,25 @@ public class WorkflowExecutionCompletedHandler {
       Worker worker,
       Map<String, Object> output,
       String idempotency,
-      Instant timestamp) {
+      Instant timestamp,
+      JsonNode contextDiff) {
     final EventLog eventLog = new EventLog();
     eventLog.setCaseId(caseInstance.getUuid());
     eventLog.setWorkerId(worker.getName());
     eventLog.setStreamType(EventStreamType.CASE);
     eventLog.setTimestamp(timestamp);
     eventLog.setEventType(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
-
     eventLog.setPayload(OBJECT_MAPPER.valueToTree(output == null ? Map.of() : output));
-
-    eventLog.setMetadata(OBJECT_MAPPER.createObjectNode().put("inputDataHash", idempotency));
-
+    eventLog.setMetadata(buildMetadata(idempotency, contextDiff));
     return eventLog;
+  }
+
+  private JsonNode buildMetadata(String idempotency, JsonNode contextDiff) {
+    ObjectNode metadata = OBJECT_MAPPER.createObjectNode();
+    metadata.put("inputDataHash", idempotency);
+    if (contextDiff != null) {
+      metadata.set("contextChanges", contextDiff);
+    }
+    return metadata;
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/recovery/WorkerExecutionRecoveryService.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/recovery/WorkerExecutionRecoveryService.java
@@ -17,8 +17,8 @@ package io.casehub.engine.internal.engine.recovery;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.casehub.api.context.StateContext;
-import io.casehub.engine.internal.context.StateContextImpl;
+import io.casehub.api.context.CaseContext;
+import io.casehub.engine.internal.context.CaseContextImpl;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
@@ -85,7 +85,7 @@ public class WorkerExecutionRecoveryService {
                 rebuildStateContext(caseId)
                     .map(
                         stateContext -> {
-                          instance.setStateContext(stateContext);
+                          instance.setCaseContext(stateContext);
                           caseInstanceCache.put(instance);
                           return instance;
                         }));
@@ -134,7 +134,7 @@ public class WorkerExecutionRecoveryService {
   }
 
   @SuppressWarnings("unchecked")
-  private Uni<StateContext> rebuildStateContext(UUID caseId) {
+  private Uni<CaseContext> rebuildStateContext(UUID caseId) {
     return runOnSafeContext(
             () ->
                 sessionFactory.withSession(
@@ -153,7 +153,7 @@ public class WorkerExecutionRecoveryService {
                             .getResultList()))
         .map(
             eventLogs -> {
-              StateContext stateContext = new StateContextImpl();
+              CaseContext caseContext = new CaseContextImpl();
               EventLog caseStartedEvent =
                   eventLogs.stream()
                       .filter(eventLog -> eventLog.getEventType() == CaseHubEventType.CASE_STARTED)
@@ -161,7 +161,7 @@ public class WorkerExecutionRecoveryService {
                       .orElse(null);
 
               if (caseStartedEvent != null) {
-                stateContext = new StateContextImpl(payloadAsMap(caseStartedEvent.getPayload()));
+                caseContext = new CaseContextImpl(payloadAsMap(caseStartedEvent.getPayload()));
               }
 
               for (EventLog eventLog : eventLogs) {
@@ -172,16 +172,16 @@ public class WorkerExecutionRecoveryService {
                 if (eventLog.getEventType() == CaseHubEventType.SIGNAL_RECEIVED) {
                   JsonNode patch = payloadAsPatch(eventLog.getPayload());
                   if (patch != null) {
-                    stateContext.applyDiff(patch);
+                    caseContext.applyDiff(patch);
                   }
                 } else if (eventLog.getEventType() == CaseHubEventType.WORKER_EXECUTION_COMPLETED) {
-                  stateContext.setAll(payloadAsMap(eventLog.getPayload()));
+                  caseContext.setAll(payloadAsMap(eventLog.getPayload()));
                 } else {
                   LOG.warnf(
                       "Unexpected event type in rebuildStateContext: %s", eventLog.getEventType());
                 }
               }
-              return stateContext;
+              return caseContext;
             });
   }
 

--- a/engine/src/main/java/io/casehub/engine/internal/engine/recovery/WorkerExecutionRecoveryService.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/recovery/WorkerExecutionRecoveryService.java
@@ -106,22 +106,32 @@ public class WorkerExecutionRecoveryService {
   }
 
   private Uni<Void> reschedulePendingEvents(List<EventLog> eventLogs) {
-    Set<String> alreadyStarted = new HashSet<>();
+    // First pass: collect keys for every execution that has already been started,
+    // completed, or failed. Events are ordered by seq asc, so WORKER_SCHEDULED always
+    // appears before its matching terminal event in the stream. A single-pass approach
+    // would include every SCHEDULED event for recovery because the terminal event hasn't
+    // been seen yet when the SCHEDULED event is processed.
+    Set<String> alreadyProgressed = new HashSet<>();
+    for (EventLog eventLog : eventLogs) {
+      if (eventLog.getEventType() != CaseHubEventType.WORKER_SCHEDULED) {
+        String key = executionKey(eventLog);
+        if (key != null) {
+          alreadyProgressed.add(key);
+        }
+      }
+    }
+
+    // Second pass: only reschedule WORKER_SCHEDULED events that have no matching
+    // STARTED / COMPLETED / FAILED record (i.e. genuinely interrupted mid-flight).
     List<Uni<Void>> recoveries =
         eventLogs.stream()
             .filter(
                 eventLog -> {
-                  String executionKey = executionKey(eventLog);
-                  if (executionKey == null) {
+                  if (eventLog.getEventType() != CaseHubEventType.WORKER_SCHEDULED) {
                     return false;
                   }
-
-                  if (eventLog.getEventType() == CaseHubEventType.WORKER_SCHEDULED) {
-                    return !alreadyStarted.contains(executionKey);
-                  }
-
-                  alreadyStarted.add(executionKey);
-                  return false;
+                  String key = executionKey(eventLog);
+                  return key != null && !alreadyProgressed.contains(key);
                 })
             .map(workflowExecutionManager::schedulePersistedEvent)
             .toList();

--- a/engine/src/main/java/io/casehub/engine/internal/event/CaseContextChangedEvent.java
+++ b/engine/src/main/java/io/casehub/engine/internal/event/CaseContextChangedEvent.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.casehub.engine.internal.model.CaseInstance;
 import java.util.Objects;
 
-public record CaseStateContextChangedEvent(CaseInstance instance, JsonNode contextSnapshot) {
+public record CaseContextChangedEvent(CaseInstance instance, JsonNode contextSnapshot) {
 
-  public CaseStateContextChangedEvent {
+  public CaseContextChangedEvent {
     instance = Objects.requireNonNull(instance, "instance cannot be null");
     contextSnapshot =
         Objects.requireNonNull(contextSnapshot, "contextSnapshot cannot be null").deepCopy();
@@ -31,7 +31,7 @@ public record CaseStateContextChangedEvent(CaseInstance instance, JsonNode conte
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    CaseStateContextChangedEvent that = (CaseStateContextChangedEvent) o;
+    CaseContextChangedEvent that = (CaseContextChangedEvent) o;
     return Objects.equals(instance, that.instance)
         && Objects.equals(contextSnapshot, that.contextSnapshot);
   }

--- a/engine/src/main/java/io/casehub/engine/internal/event/EventBusAddresses.java
+++ b/engine/src/main/java/io/casehub/engine/internal/event/EventBusAddresses.java
@@ -24,7 +24,7 @@ public final class EventBusAddresses {
 
   public static final String CASE_STARTED = "casehub.case.started";
   public static final String CASE_COMPLETED = "casehub.case.completed";
-  public static final String CASE_FAILED = "casehub.case.failed";
+  public static final String CASE_FAULTED = "casehub.case.faulted";
   public static final String CASE_STATUS_CHANGED = "casehub.case.status.changed";
 
   public static final String CONTEXT_CHANGED = "casehub.context.changed";

--- a/engine/src/main/java/io/casehub/engine/internal/history/CaseHubEventType.java
+++ b/engine/src/main/java/io/casehub/engine/internal/history/CaseHubEventType.java
@@ -18,7 +18,7 @@ package io.casehub.engine.internal.history;
 public enum CaseHubEventType {
   CASE_STARTED,
   CASE_COMPLETED,
-  CASE_FAILED,
+  CASE_FAULTED,
   CASE_CANCELLED,
 
   TASK_CREATED,

--- a/engine/src/main/java/io/casehub/engine/internal/model/CaseInstance.java
+++ b/engine/src/main/java/io/casehub/engine/internal/model/CaseInstance.java
@@ -15,7 +15,8 @@
  */
 package io.casehub.engine.internal.model;
 
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.model.CaseStatus;
 import io.quarkus.hibernate.reactive.panache.PanacheEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -37,13 +38,16 @@ public class CaseInstance extends PanacheEntity {
   @Column(name = "uuid", nullable = false, unique = true, updatable = false)
   private UUID uuid;
 
-  // TODO sync version with stateContext version
+  // TODO sync version with caseContext version
   @Transient private long version = 0L;
 
-  @Transient private StateContext stateContext;
+  @Transient private CaseContext caseContext;
+
+  @Column(name = "parent_plan_item_id", nullable = true)
+  private UUID parentPlanItemId;
 
   @Enumerated(EnumType.STRING)
-  private CaseState state;
+  private CaseStatus state;
 
   public CaseMetaModel getCaseMetaModel() {
     return caseMetaModel;
@@ -69,19 +73,27 @@ public class CaseInstance extends PanacheEntity {
     this.version = version;
   }
 
-  public StateContext getStateContext() {
-    return stateContext;
+  public CaseContext getCaseContext() {
+    return caseContext;
   }
 
-  public void setStateContext(StateContext stateContext) {
-    this.stateContext = stateContext;
+  public void setCaseContext(CaseContext caseContext) {
+    this.caseContext = caseContext;
   }
 
-  public CaseState getState() {
+  public UUID getParentPlanItemId() {
+    return parentPlanItemId;
+  }
+
+  public void setParentPlanItemId(UUID parentPlanItemId) {
+    this.parentPlanItemId = parentPlanItemId;
+  }
+
+  public CaseStatus getState() {
     return state;
   }
 
-  public void setState(CaseState state) {
+  public void setState(CaseStatus state) {
     this.state = state;
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/worker/AllowAllWorkerExecutionGuard.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/AllowAllWorkerExecutionGuard.java
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.casehub.api.model;
+package io.casehub.engine.internal.worker;
 
-public record RetryPolicy(Integer maxAttempts, Integer delayMs, BackoffStrategy backoffStrategy) {
+import io.casehub.api.spi.WorkerExecutionGuard;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.UUID;
 
-  /** Default: 3 attempts, 10s fixed delay. */
-  public RetryPolicy() {
-    this(3, 10000, BackoffStrategy.FIXED);
-  }
+/**
+ * Default no-op {@link WorkerExecutionGuard}: all workers are always allowed to execute. Active
+ * when {@code casehub-resilience} is not on the classpath or no alternative is selected.
+ */
+@ApplicationScoped
+public class AllowAllWorkerExecutionGuard implements WorkerExecutionGuard {
 
-  /** Backwards-compatible 2-arg constructor — defaults to FIXED backoff. */
-  public RetryPolicy(Integer maxAttempts, Integer delayMs) {
-    this(maxAttempts, delayMs, BackoffStrategy.FIXED);
+  @Override
+  public boolean isBlocked(String workerId, UUID caseId) {
+    return false;
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
@@ -163,12 +163,12 @@ public class WorkerExecutionJobListener implements JobListener {
                       failureCount -> {
                         if (failureCount < retryPolicy.maxAttempts()) {
                           LOG.infof(
-                              "Rescheduling worker %s: attempt %d/%d, delayMs=%d",
+                              "Rescheduling worker %s: attempt %d/%d, strategy=%s",
                               workerId,
                               failureCount + 1,
                               retryPolicy.maxAttempts(),
-                              retryPolicy.delayMs());
-                          rescheduleJob(context, retryPolicy);
+                              retryPolicy.backoffStrategy());
+                          rescheduleJob(context, retryPolicy, failureCount + 1);
                         } else {
                           LOG.warnf(
                               "Worker %s exhausted all %d retry attempts for case %s",
@@ -216,7 +216,8 @@ public class WorkerExecutionJobListener implements JobListener {
     return executionPolicy.retries();
   }
 
-  private void rescheduleJob(JobExecutionContext context, RetryPolicy retryPolicy) {
+  private void rescheduleJob(
+      JobExecutionContext context, RetryPolicy retryPolicy, long attemptNumber) {
     String idempotency = context.getMergedJobDataMap().getString("inputDataHash");
     String group = context.getMergedJobDataMap().getString("caseHubInstanceUuid");
     JobKey jobKey = new JobKey(idempotency, group);
@@ -228,7 +229,7 @@ public class WorkerExecutionJobListener implements JobListener {
             .usingJobData(context.getMergedJobDataMap())
             .build();
 
-    int delayMs = retryPolicy.delayMs() > 0 ? retryPolicy.delayMs() : 0;
+    long delayMs = computeBackoffDelayMs(retryPolicy, attemptNumber);
 
     Trigger trigger =
         newTrigger()
@@ -294,5 +295,30 @@ public class WorkerExecutionJobListener implements JobListener {
 
   private <T> Uni<T> runOnSafeVertxContext(Supplier<Uni<? extends T>> action) {
     return ReactiveUtils.runOnSafeVertxContext(vertx, action);
+  }
+
+  /**
+   * Computes the retry delay using the policy's {@link io.casehub.api.model.BackoffStrategy}.
+   * FIXED: constant delayMs. EXPONENTIAL: delayMs * 2^(attempt-1), capped at 30s.
+   * EXPONENTIAL_WITH_JITTER: random in [0, exponential cap].
+   */
+  private static long computeBackoffDelayMs(RetryPolicy policy, long attemptNumber) {
+    long baseDelayMs = policy.delayMs() != null ? policy.delayMs() : 0L;
+    io.casehub.api.model.BackoffStrategy strategy =
+        policy.backoffStrategy() != null
+            ? policy.backoffStrategy()
+            : io.casehub.api.model.BackoffStrategy.FIXED;
+    return switch (strategy) {
+      case FIXED -> baseDelayMs;
+      case EXPONENTIAL -> {
+        long shift = Math.min(attemptNumber - 1, 30);
+        yield Math.min(baseDelayMs * (1L << shift), 30_000L);
+      }
+      case EXPONENTIAL_WITH_JITTER -> {
+        long shift = Math.min(attemptNumber - 1, 30);
+        long cap = Math.min(baseDelayMs * (1L << shift), 30_000L);
+        yield cap == 0 ? 0 : java.util.concurrent.ThreadLocalRandom.current().nextLong(cap + 1);
+      }
+    };
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionTask.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionTask.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.Worker;
-import io.casehub.engine.internal.context.StateContextImpl;
+import io.casehub.engine.internal.context.CaseContextImpl;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
 import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
 import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
@@ -136,7 +136,7 @@ public class WorkerExecutionTask implements Job {
     }
 
     Map<String, Object> toContextOutputData =
-        new StateContextImpl(outputData).evalObjectTemplate(capability.getOutputSchema());
+        new CaseContextImpl(outputData).evalObjectTemplate(capability.getOutputSchema());
 
     WorkflowExecutionCompleted event =
         new WorkflowExecutionCompleted(instance, worker, inputDataHash, toContextOutputData);

--- a/engine/src/main/java/io/casehub/engine/spi/CaseInstanceRepository.java
+++ b/engine/src/main/java/io/casehub/engine/spi/CaseInstanceRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.spi;
+
+import io.casehub.engine.internal.model.CaseInstance;
+import io.smallrye.mutiny.Uni;
+import java.util.UUID;
+
+public interface CaseInstanceRepository {
+
+  /** Persist a new case instance. Returns the saved instance with id populated. */
+  Uni<CaseInstance> save(CaseInstance instance);
+
+  /** Merge state changes back to storage (status transitions). */
+  Uni<CaseInstance> update(CaseInstance instance);
+
+  /**
+   * Load a case instance by UUID with its CaseMetaModel eagerly joined. Returns null if not found.
+   */
+  Uni<CaseInstance> findByUuid(UUID uuid);
+}

--- a/engine/src/main/java/io/casehub/engine/spi/CaseMetaModelRepository.java
+++ b/engine/src/main/java/io/casehub/engine/spi/CaseMetaModelRepository.java
@@ -20,7 +20,7 @@ import io.smallrye.mutiny.Uni;
 
 public interface CaseMetaModelRepository {
 
-  /** Find by the unique (namespace, name, version) key. Returns null if not registered. */
+  /** Find by the unique (namespace, name, version) key. Returns null if not found. */
   Uni<CaseMetaModel> findByKey(String namespace, String name, String version);
 
   /** Persist a new case meta model. Returns the saved instance with id populated. */

--- a/engine/src/main/java/io/casehub/engine/spi/CaseMetaModelRepository.java
+++ b/engine/src/main/java/io/casehub/engine/spi/CaseMetaModelRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.spi;
+
+import io.casehub.engine.internal.model.CaseMetaModel;
+import io.smallrye.mutiny.Uni;
+
+public interface CaseMetaModelRepository {
+
+  /** Find by the unique (namespace, name, version) key. Returns null if not registered. */
+  Uni<CaseMetaModel> findByKey(String namespace, String name, String version);
+
+  /** Persist a new case meta model. Returns the saved instance with id populated. */
+  Uni<CaseMetaModel> save(CaseMetaModel metaModel);
+}

--- a/engine/src/main/java/io/casehub/engine/spi/EventLogRepository.java
+++ b/engine/src/main/java/io/casehub/engine/spi/EventLogRepository.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.spi;
+
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.smallrye.mutiny.Uni;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public interface EventLogRepository {
+
+  /** Append an event to the log. Populates eventLog.id and eventLog.seq after append. */
+  Uni<Void> append(EventLog eventLog);
+
+  /**
+   * Append an event and flush, returning the generated id. Used by WorkerScheduleEventHandler to
+   * get the id before scheduling a Quartz job.
+   */
+  Uni<Long> appendAndReturnId(EventLog eventLog);
+
+  /** Load an event by id. Returns null if not found. */
+  Uni<EventLog> findById(Long id);
+
+  /**
+   * Find WORKER_SCHEDULED, WORKER_EXECUTION_STARTED, and WORKER_EXECUTION_COMPLETED events for a
+   * specific case+worker. Used by WorkerScheduleEventHandler for idempotency checking.
+   */
+  Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId);
+
+  /**
+   * Find all events matching any of the given types, ordered by seq ascending. Used by
+   * WorkerExecutionRecoveryService to find pending scheduled workers on startup.
+   */
+  Uni<List<EventLog>> findByTypes(Collection<CaseHubEventType> types);
+
+  /**
+   * Find events for a specific case matching any of the given types, ordered by seq ascending. Used
+   * by WorkerExecutionRecoveryService to rebuild CaseContext state.
+   */
+  Uni<List<EventLog>> findByCaseAndTypes(UUID caseId, Collection<CaseHubEventType> types);
+
+  /**
+   * Find events for a specific case+worker of a specific type. Used by WorkerExecutionJobListener
+   * to count failed attempts for retry logic.
+   */
+  Uni<List<EventLog>> findByCaseAndWorkerAndType(
+      UUID caseId, String workerId, CaseHubEventType type);
+}

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -19,3 +19,8 @@ quarkus.hibernate-orm.schema-management.strategy=validate
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:casehub}
 %prod.quarkus.datasource.username=${DB_USERNAME}
 %prod.quarkus.datasource.password=${DB_PASSWORD}
+
+quarkus.index-dependency.engine.group-id=io.casehub
+quarkus.index-dependency.engine.artifact-id=engine
+quarkus.index-dependency.api.group-id=io.casehub
+quarkus.index-dependency.api.artifact-id=api

--- a/engine/src/main/resources/db/migration/V1.1.0__Create_Application_Tables.sql
+++ b/engine/src/main/resources/db/migration/V1.1.0__Create_Application_Tables.sql
@@ -22,10 +22,11 @@ CREATE TABLE IF NOT EXISTS case_meta_model (
 
 -- Represents a running case instance linked to a definition
 CREATE TABLE IF NOT EXISTS case_instance (
-    id                 BIGINT      NOT NULL DEFAULT nextval('case_instance_seq'),
-    uuid               UUID        NOT NULL,
-    case_definition_id BIGINT      NOT NULL,
-    state              VARCHAR(50),
+    id                   BIGINT      NOT NULL DEFAULT nextval('case_instance_seq'),
+    uuid                 UUID        NOT NULL,
+    case_definition_id   BIGINT      NOT NULL,
+    state                VARCHAR(50),
+    parent_plan_item_id  UUID,
     PRIMARY KEY (id),
     CONSTRAINT uq_case_instance_uuid
         UNIQUE (uuid),

--- a/engine/src/main/resources/db/migration/V1.2.0__Align_CaseStatus_With_Serverless_Workflow.sql
+++ b/engine/src/main/resources/db/migration/V1.2.0__Align_CaseStatus_With_Serverless_Workflow.sql
@@ -1,0 +1,16 @@
+-- Align CaseInstance state values and EventLog event_type values with the
+-- CNCF Serverless Workflow specification (as used by Quarkus Flow).
+--
+-- Renames:
+--   ACTIVE      → RUNNING   (case is now directly RUNNING on creation; no PENDING state)
+--   FAILED      → FAULTED   (aligns with WorkflowStatus.FAULTED)
+--   TERMINATED  → CANCELLED (aligns with WorkflowStatus.CANCELLED; was unused in practice)
+--
+-- WAITING, SUSPENDED, COMPLETED are unchanged.
+
+UPDATE case_instance SET state = 'RUNNING'    WHERE state = 'ACTIVE';
+UPDATE case_instance SET state = 'FAULTED'    WHERE state = 'FAILED';
+UPDATE case_instance SET state = 'CANCELLED'  WHERE state = 'TERMINATED';
+
+-- Migrate matching event_type values in the event log
+UPDATE event_log SET event_type = 'CASE_FAULTED' WHERE event_type = 'CASE_FAILED';

--- a/engine/src/main/resources/db/migration/V1.3.0__Add_Parent_Plan_Item_Id.sql
+++ b/engine/src/main/resources/db/migration/V1.3.0__Add_Parent_Plan_Item_Id.sql
@@ -1,0 +1,3 @@
+-- Supports sub-case wiring: a child CaseInstance references the parent PlanItem<SubCase>.
+-- Null for root cases (the vast majority). No foreign key — PlanItems are in-memory.
+ALTER TABLE case_instance ADD COLUMN IF NOT EXISTS parent_plan_item_id UUID;

--- a/engine/src/test/java/io/casehub/engine/AgentPipelineBeanTest.java
+++ b/engine/src/test/java/io/casehub/engine/AgentPipelineBeanTest.java
@@ -23,8 +23,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -117,7 +117,7 @@ public class AgentPipelineBeanTest {
             () -> {
               var instance = caseInstanceCache.get(ref.get());
               assertNotNull(instance);
-              assertEquals(CaseState.COMPLETED, instance.getState());
+              assertEquals(CaseStatus.COMPLETED, instance.getState());
             });
 
     assertEquals(1, mockServer.getRequestCount());

--- a/engine/src/test/java/io/casehub/engine/CaseFaultedStateTest.java
+++ b/engine/src/test/java/io/casehub/engine/CaseFaultedStateTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.internal.util.ReactiveUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a {@link CaseStatus#FAULTED} transition occurs correctly — both via exhausted
+ * worker retries and via a failure goal — and that the EventLog records {@code CASE_FAULTED} (not
+ * the pre-alignment {@code CASE_FAILED}).
+ */
+@QuarkusTest
+class CaseFaultedStateTest {
+
+  private static final Duration DB_TIMEOUT = Duration.ofSeconds(10);
+
+  @Inject AlwaysFailingCaseHubBean alwaysFailingBean;
+
+  @Inject FailureGoalCaseHubBean failureGoalBean;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @Inject Mutiny.SessionFactory sessionFactory;
+
+  @Inject Vertx vertx;
+
+  @BeforeEach
+  void reset() {
+    AlwaysFailingCaseHubBean.runCount.set(0);
+  }
+
+  // ------------------------------------------------------------------ //
+  // FAULTED via exhausted retries                                         //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void caseTransitionsToFaultedWhenAllRetriesExhausted() {
+    UUID caseId =
+        alwaysFailingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState())
+                  .as("Case must be FAULTED after all retries exhausted")
+                  .isEqualTo(CaseStatus.FAULTED);
+            });
+  }
+
+  @Test
+  void faultedCaseHasCaseFaultedInEventLog() {
+    // The event type must be CASE_FAULTED — not the legacy CASE_FAILED.
+    UUID caseId =
+        alwaysFailingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    // WorkerRetriesExhaustedEventHandler writes one CASE_FAULTED entry directly;
+    // CaseStatusChangedHandler writes a second one via the CASE_STATUS_CHANGED event.
+    // Assert at least one exists — the important thing is the correct event type is recorded.
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(findEvents(caseId, CaseHubEventType.CASE_FAULTED))
+                    .as("EventLog must contain at least one CASE_FAULTED entry")
+                    .isNotEmpty());
+  }
+
+  @Test
+  void faultedCaseHasNoLegacyCaseFailedInEventLog() {
+    UUID caseId =
+        alwaysFailingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState()).isEqualTo(CaseStatus.FAULTED));
+
+    assertThat(findEventsByTypeName(caseId, "CASE_FAILED"))
+        .as("CASE_FAILED must never appear — correct name is CASE_FAULTED")
+        .isEmpty();
+  }
+
+  @Test
+  void faultedStateIsPersistedInDatabase() {
+    UUID caseId =
+        alwaysFailingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState()).isEqualTo(CaseStatus.FAULTED));
+
+    // DB must store "FAULTED" — not the legacy "FAILED" value.
+    String persistedState =
+        ReactiveUtils.runOnSafeVertxContext(
+                vertx,
+                () ->
+                    sessionFactory.withSession(
+                        session ->
+                            session
+                                .createNativeQuery(
+                                    "SELECT state FROM case_instance WHERE uuid = :uuid",
+                                    String.class)
+                                .setParameter("uuid", caseId)
+                                .getSingleResult()))
+            .await()
+            .atMost(DB_TIMEOUT);
+
+    assertThat(persistedState)
+        .as("DB column must store FAULTED, not legacy FAILED")
+        .isEqualTo("FAULTED");
+  }
+
+  @Test
+  void allRetriesAreAttemptedBeforeFaulting() {
+    // RetryPolicy(2, 200) = 2 max attempts. Worker must be called exactly twice.
+    UUID caseId =
+        alwaysFailingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState()).isEqualTo(CaseStatus.FAULTED));
+
+    assertThat(AlwaysFailingCaseHubBean.runCount.get())
+        .as("Worker must be attempted exactly maxAttempts times before FAULTED")
+        .isEqualTo(2);
+  }
+
+  // ------------------------------------------------------------------ //
+  // FAULTED via failure goal                                              //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void caseTransitionsToFaultedWhenFailureGoalReached() {
+    // Worker writes {status: "error"}, which satisfies the failure goal condition.
+    // GoalReachedEventHandler then drives the FAULTED transition.
+    UUID caseId =
+        failureGoalBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState())
+                  .as("Case must be FAULTED when failure goal is reached")
+                  .isEqualTo(CaseStatus.FAULTED);
+            });
+  }
+
+  @Test
+  void failureGoalCaseHasCaseFaultedInEventLog() {
+    UUID caseId =
+        failureGoalBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(findEvents(caseId, CaseHubEventType.CASE_FAULTED))
+                    .as("Failure goal must produce exactly one CASE_FAULTED EventLog entry")
+                    .hasSize(1));
+  }
+
+  // ------------------------------------------------------------------ //
+  // Helpers                                                               //
+  // ------------------------------------------------------------------ //
+
+  private List<EventLog> findEvents(UUID caseId, CaseHubEventType eventType) {
+    return ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                sessionFactory.withSession(
+                    session ->
+                        session
+                            .createSelectionQuery(
+                                "from EventLog where caseId = :caseId and eventType = :eventType order by seq asc",
+                                EventLog.class)
+                            .setParameter("caseId", caseId)
+                            .setParameter("eventType", eventType)
+                            .getResultList()))
+        .await()
+        .atMost(DB_TIMEOUT);
+  }
+
+  private List<EventLog> findEventsByTypeName(UUID caseId, String eventTypeName) {
+    return ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                sessionFactory.withSession(
+                    session ->
+                        session
+                            .createSelectionQuery(
+                                "from EventLog where caseId = :caseId and cast(eventType as string) = :name order by seq asc",
+                                EventLog.class)
+                            .setParameter("caseId", caseId)
+                            .setParameter("name", eventTypeName)
+                            .getResultList()))
+        .await()
+        .atMost(DB_TIMEOUT);
+  }
+
+  // ------------------------------------------------------------------ //
+  // Test beans                                                            //
+  // ------------------------------------------------------------------ //
+
+  /** Worker that always throws — retries exhaust and the case becomes FAULTED. */
+  @ApplicationScoped
+  public static class AlwaysFailingCaseHubBean extends CaseHub {
+
+    static final AtomicInteger runCount = new AtomicInteger(0);
+
+    private final Capability capability =
+        Capability.builder()
+            .name("alwaysFailCapability")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-faulted-state")
+          .name("Always Failing Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("always-failing-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        runCount.incrementAndGet();
+                        throw new RuntimeException("Simulated permanent failure");
+                      })
+                  // 2 max attempts, 200 ms between retries — fast but realistic
+                  .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(2, 200)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger-on-processing")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"processing\""))
+                  .build())
+          .build();
+    }
+  }
+
+  /**
+   * Worker writes {@code {status: "error"}}, satisfying the failure goal — case becomes FAULTED via
+   * {@code GoalReachedEventHandler}, not via retry exhaustion.
+   */
+  @ApplicationScoped
+  public static class FailureGoalCaseHubBean extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("failureGoalCapability")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal failureGoal =
+        Goal.builder()
+            .name("processingFailed")
+            .condition(".status == \"error\"")
+            .kind(GoalKind.FAILURE)
+            .build();
+
+    private final Goal successGoal =
+        Goal.builder()
+            .name("processingSucceeded")
+            .condition(".status == \"ok\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-faulted-state")
+          .name("Failure Goal Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("error-producing-worker")
+                  .capabilities(capability)
+                  .function(input -> Map.of("status", "error")) // satisfies failure goal
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger-on-processing")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"processing\""))
+                  .build())
+          .goals(failureGoal, successGoal)
+          .completion(GoalExpression.allOf(successGoal), GoalExpression.allOf(failureGoal))
+          .build();
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/CaseLifecycleStateTest.java
+++ b/engine/src/test/java/io/casehub/engine/CaseLifecycleStateTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.internal.util.ReactiveUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that CaseInstance transitions through the correct {@link CaseStatus} states and that the
+ * EventLog records the right event types at each transition.
+ */
+@QuarkusTest
+class CaseLifecycleStateTest {
+
+  private static final Duration DB_TIMEOUT = Duration.ofSeconds(10);
+
+  @Inject IdleCaseHubBean idleBean;
+
+  @Inject CompletingCaseHubBean completingBean;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @Inject Mutiny.SessionFactory sessionFactory;
+
+  @Inject Vertx vertx;
+
+  // ------------------------------------------------------------------ //
+  // RUNNING state                                                         //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void caseStartsInRunningState() {
+    // A case whose binding trigger does not match the initial context never fires a worker,
+    // so the case stays in RUNNING. This lets us assert RUNNING without racing against
+    // an asynchronous completion.
+    UUID caseId =
+        idleBean
+            .startCase(Map.of("status", "idle")) // trigger requires "active" — never fires
+            .toCompletableFuture()
+            .join();
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.RUNNING);
+            });
+  }
+
+  @Test
+  void runningStateIsPersistedInDatabase() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(caseInstanceCache.get(caseId)).isNotNull());
+
+    // DB must store "RUNNING" — not the legacy "ACTIVE" value.
+    String persistedState =
+        ReactiveUtils.runOnSafeVertxContext(
+                vertx,
+                () ->
+                    sessionFactory.withSession(
+                        session ->
+                            session
+                                .createNativeQuery(
+                                    "SELECT state FROM case_instance WHERE uuid = :uuid",
+                                    String.class)
+                                .setParameter("uuid", caseId)
+                                .getSingleResult()))
+            .await()
+            .atMost(DB_TIMEOUT);
+
+    assertThat(persistedState)
+        .as("DB column must store RUNNING, not legacy ACTIVE")
+        .isEqualTo("RUNNING");
+  }
+
+  // ------------------------------------------------------------------ //
+  // COMPLETED state                                                       //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void caseTransitionsToCompletedWhenSuccessGoalReached() {
+    UUID caseId =
+        completingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+  }
+
+  @Test
+  void completedCaseHasCaseCompletedInEventLog() {
+    UUID caseId =
+        completingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              List<EventLog> events = findEvents(caseId, CaseHubEventType.CASE_COMPLETED);
+              assertThat(events)
+                  .as("EventLog must contain exactly one CASE_COMPLETED entry")
+                  .hasSize(1);
+            });
+  }
+
+  @Test
+  void completedCaseDoesNotHaveLegacyCaseFailedInEventLog() {
+    // Guard: CASE_FAILED must never appear — the correct name is CASE_FAULTED.
+    UUID caseId =
+        completingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .isEqualTo(CaseStatus.COMPLETED));
+
+    List<EventLog> legacyEvents = findEventsByTypeName(caseId, "CASE_FAILED");
+    assertThat(legacyEvents)
+        .as("CASE_FAILED must not appear in EventLog — correct name is CASE_FAULTED")
+        .isEmpty();
+  }
+
+  // ------------------------------------------------------------------ //
+  // Helpers                                                               //
+  // ------------------------------------------------------------------ //
+
+  private List<EventLog> findEvents(UUID caseId, CaseHubEventType eventType) {
+    return ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                sessionFactory.withSession(
+                    session ->
+                        session
+                            .createSelectionQuery(
+                                "from EventLog where caseId = :caseId and eventType = :eventType order by seq asc",
+                                EventLog.class)
+                            .setParameter("caseId", caseId)
+                            .setParameter("eventType", eventType)
+                            .getResultList()))
+        .await()
+        .atMost(DB_TIMEOUT);
+  }
+
+  private List<EventLog> findEventsByTypeName(UUID caseId, String eventTypeName) {
+    return ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                sessionFactory.withSession(
+                    session ->
+                        session
+                            .createSelectionQuery(
+                                "from EventLog where caseId = :caseId and cast(eventType as string) = :name order by seq asc",
+                                EventLog.class)
+                            .setParameter("caseId", caseId)
+                            .setParameter("name", eventTypeName)
+                            .getResultList()))
+        .await()
+        .atMost(DB_TIMEOUT);
+  }
+
+  // ------------------------------------------------------------------ //
+  // Test beans                                                            //
+  // ------------------------------------------------------------------ //
+
+  /** Case whose binding trigger never fires — stays RUNNING indefinitely. */
+  @ApplicationScoped
+  public static class IdleCaseHubBean extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("idleCapability")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-lifecycle-state")
+          .name("Idle Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("idle-worker")
+                  .capabilities(capability)
+                  .function(input -> Map.of("status", "done"))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger-when-active")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"active\"")) // never matches "idle"
+                  .build())
+          .build();
+    }
+  }
+
+  /** Case that completes via a success goal. */
+  @ApplicationScoped
+  public static class CompletingCaseHubBean extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("processDocumentLifecycle")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal successGoal =
+        Goal.builder()
+            .name("processingComplete")
+            .condition(".status == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-lifecycle-state")
+          .name("Completing Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("completing-worker")
+                  .capabilities(capability)
+                  .function(input -> Map.of("status", "done"))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger-on-processing")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"processing\""))
+                  .build())
+          .goals(successGoal)
+          .completion(GoalExpression.allOf(successGoal))
+          .build();
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/CaseStatusTest.java
+++ b/engine/src/test/java/io/casehub/engine/CaseStatusTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.casehub.api.model.CaseStatus;
+import java.util.EnumSet;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link CaseStatus} conforms to the CNCF Serverless Workflow specification as
+ * implemented by {@code io.serverlessworkflow.impl.WorkflowStatus} in Quarkus Flow.
+ */
+class CaseStatusTest {
+
+  @Test
+  void containsExactlyTheExpectedValues() {
+    assertThat(EnumSet.allOf(CaseStatus.class))
+        .containsExactlyInAnyOrder(
+            CaseStatus.RUNNING,
+            CaseStatus.WAITING,
+            CaseStatus.SUSPENDED,
+            CaseStatus.COMPLETED,
+            CaseStatus.FAULTED,
+            CaseStatus.CANCELLED);
+  }
+
+  @Test
+  void doesNotContainPending() {
+    // PENDING is a casehub-blackboard concern (PlanItem/Stage lifecycle).
+    // CaseInstance transitions directly to RUNNING on creation — there is no
+    // observable PENDING window in the async event cycle.
+    assertThat(EnumSet.allOf(CaseStatus.class))
+        .extracting(CaseStatus::name)
+        .doesNotContain("PENDING");
+  }
+
+  @Test
+  void doesNotContainLegacyNames() {
+    // These were the pre-alignment names — must not appear after the CNCF rename.
+    assertThat(EnumSet.allOf(CaseStatus.class))
+        .extracting(CaseStatus::name)
+        .doesNotContain("ACTIVE", "FAILED", "TERMINATED");
+  }
+
+  @Test
+  void allThreeTerminalStatesArePresent() {
+    assertThat(EnumSet.allOf(CaseStatus.class))
+        .contains(CaseStatus.COMPLETED, CaseStatus.FAULTED, CaseStatus.CANCELLED);
+  }
+
+  @Test
+  void valueOfRoundTripsForAllValues() {
+    // String serialisation round-trips matter — state is stored as VARCHAR in the DB.
+    for (CaseStatus status : CaseStatus.values()) {
+      assertThatCode(() -> CaseStatus.valueOf(status.name()))
+          .as("valueOf must not throw for %s", status.name())
+          .doesNotThrowAnyException();
+      assertThat(CaseStatus.valueOf(status.name()))
+          .as("valueOf must return same instance for %s", status.name())
+          .isSameAs(status);
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
+++ b/engine/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.internal.util.ReactiveUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test: verifies that WORKER_EXECUTION_COMPLETED EventLog entries contain a {@code
+ * contextChanges} field reflecting the before/after state of CaseContext keys modified by the
+ * worker.
+ */
+@QuarkusTest
+class ContextDiffEndToEndTest {
+
+  private static final Duration DB_TIMEOUT = Duration.ofSeconds(10);
+
+  @Inject DiffCaseHub diffCase;
+  @Inject UpdateCaseHub updateCase;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject Mutiny.SessionFactory sessionFactory;
+  @Inject Vertx vertx;
+
+  /**
+   * Happy path: initial context has "status"="start". Worker writes "status"="done" and adds
+   * "result"="ok". EventLog must record status as updated, result as added.
+   */
+  @Test
+  void workerOutput_isReflectedInContextChanges() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+
+    diffCase
+        .startCase(Map.of("status", "start"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    UUID caseId = caseIdRef.get();
+
+    // Wait for COMPLETED
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    // Query the WORKER_EXECUTION_COMPLETED EventLog entry
+    EventLog completedEvent = fetchCompletedEvent(caseId);
+    assertThat(completedEvent).isNotNull();
+
+    var metadata = completedEvent.getMetadata();
+    assertThat(metadata.has("contextChanges")).isTrue();
+
+    var changes = metadata.get("contextChanges");
+
+    // "status" was updated: before="start", after="done"
+    assertThat(changes.has("status")).isTrue();
+    assertThat(changes.get("status").get("before").asText()).isEqualTo("start");
+    assertThat(changes.get("status").get("after").asText()).isEqualTo("done");
+
+    // "result" was added: no before, after="ok"
+    assertThat(changes.has("result")).isTrue();
+    assertThat(changes.get("result").has("before")).isFalse();
+    assertThat(changes.get("result").get("after").asText()).isEqualTo("ok");
+  }
+
+  /**
+   * Keys present in initial context that the worker does NOT touch must be absent from
+   * contextChanges.
+   */
+  @Test
+  void unchangedKeys_areAbsentFromContextChanges() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+
+    // Start with two keys; worker only touches "status"
+    updateCase
+        .startCase(Map.of("status", "start", "unchanged", "keep-me"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    UUID caseId = caseIdRef.get();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    EventLog completedEvent = fetchCompletedEvent(caseId);
+    var changes = completedEvent.getMetadata().get("contextChanges");
+
+    assertThat(changes.has("status")).isTrue();
+    assertThat(changes.has("unchanged")).isFalse();
+  }
+
+  /** The inputDataHash must still be present alongside contextChanges. */
+  @Test
+  void inputDataHash_remainsPresentAlongsideContextChanges() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    diffCase
+        .startCase(Map.of("status", "start"))
+        .thenAccept(caseIdRef::set)
+        .toCompletableFuture()
+        .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseIdRef.get());
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.COMPLETED);
+            });
+
+    EventLog completedEvent = fetchCompletedEvent(caseIdRef.get());
+    var metadata = completedEvent.getMetadata();
+
+    assertThat(metadata.has("inputDataHash")).isTrue();
+    assertThat(metadata.get("inputDataHash").asText()).isNotBlank();
+    assertThat(metadata.has("contextChanges")).isTrue();
+  }
+
+  // ---- Helper ---------------------------------------------------------------
+
+  private EventLog fetchCompletedEvent(UUID caseId) {
+    List<EventLog> events =
+        ReactiveUtils.runOnSafeVertxContext(
+                vertx,
+                () ->
+                    sessionFactory.withSession(
+                        session ->
+                            session
+                                .createSelectionQuery(
+                                    "from EventLog where caseId = :caseId and eventType = :eventType order by seq asc",
+                                    EventLog.class)
+                                .setParameter("caseId", caseId)
+                                .setParameter(
+                                    "eventType", CaseHubEventType.WORKER_EXECUTION_COMPLETED)
+                                .getResultList()))
+            .await()
+            .atMost(DB_TIMEOUT);
+    return events.isEmpty() ? null : events.get(0);
+  }
+
+  // ---- CaseHub beans --------------------------------------------------------
+
+  /** Worker writes status="done" and adds result="ok". */
+  @ApplicationScoped
+  public static class DiffCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("doWork")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status, result: .result }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-context-diff")
+          .name("Context Diff Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("diff-worker")
+                  .capabilities(capability)
+                  .function(input -> Map.of("status", "done", "result", "ok"))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+
+  /** Worker writes only status="done"; leaves "unchanged" key untouched. */
+  @ApplicationScoped
+  public static class UpdateCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("partialUpdate")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-context-diff-partial")
+          .name("Partial Update Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("partial-worker")
+                  .capabilities(capability)
+                  .function(input -> Map.of("status", "done"))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/MultiWorkerPipelineBeanTest.java
+++ b/engine/src/test/java/io/casehub/engine/MultiWorkerPipelineBeanTest.java
@@ -19,8 +19,8 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -67,7 +67,7 @@ public class MultiWorkerPipelineBeanTest {
             () -> {
               var instance = caseInstanceCache.get(ref.get());
               assertNotNull(instance);
-              assertEquals(CaseState.COMPLETED, instance.getState());
+              assertEquals(CaseStatus.COMPLETED, instance.getState());
             });
   }
 }

--- a/engine/src/test/java/io/casehub/engine/MultipleCaseInstancesTest.java
+++ b/engine/src/test/java/io/casehub/engine/MultipleCaseInstancesTest.java
@@ -20,8 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -53,8 +53,8 @@ public class MultipleCaseInstancesTest {
 
               assertNotNull(instance1);
               assertNotNull(instance2);
-              assertEquals(CaseState.COMPLETED, instance1.getState());
-              assertEquals(CaseState.COMPLETED, instance2.getState());
+              assertEquals(CaseStatus.COMPLETED, instance1.getState());
+              assertEquals(CaseStatus.COMPLETED, instance2.getState());
 
               assertEquals(
                   instance1.getCaseMetaModel().getId(),
@@ -106,9 +106,9 @@ public class MultipleCaseInstancesTest {
         .atMost(15, TimeUnit.SECONDS)
         .untilAsserted(
             () -> {
-              assertEquals(CaseState.COMPLETED, caseInstanceCache.get(ref1.get()).getState());
-              assertEquals(CaseState.COMPLETED, caseInstanceCache.get(ref2.get()).getState());
-              assertEquals(CaseState.COMPLETED, caseInstanceCache.get(ref3.get()).getState());
+              assertEquals(CaseStatus.COMPLETED, caseInstanceCache.get(ref1.get()).getState());
+              assertEquals(CaseStatus.COMPLETED, caseInstanceCache.get(ref2.get()).getState());
+              assertEquals(CaseStatus.COMPLETED, caseInstanceCache.get(ref3.get()).getState());
             });
 
     Long defId = caseInstanceCache.get(ref1.get()).getCaseMetaModel().getId();

--- a/engine/src/test/java/io/casehub/engine/SignalPersistenceAndDedupTest.java
+++ b/engine/src/test/java/io/casehub/engine/SignalPersistenceAndDedupTest.java
@@ -202,10 +202,10 @@ public class SignalPersistenceAndDedupTest {
         recoveryService.loadOrRestoreCaseInstance(caseId).await().atMost(DB_TIMEOUT);
 
     assertNotNull(restored);
-    assertEquals(420, ((Number) restored.getStateContext().getPath("payment.amount")).intValue());
-    assertEquals("CAD", restored.getStateContext().getPathAsString("payment.currency"));
-    assertEquals("processed", restored.getStateContext().getPathAsString("status"));
-    assertEquals(420, ((Number) restored.getStateContext().get("lastProcessedAmount")).intValue());
+    assertEquals(420, ((Number) restored.getCaseContext().getPath("payment.amount")).intValue());
+    assertEquals("CAD", restored.getCaseContext().getPathAsString("payment.currency"));
+    assertEquals("processed", restored.getCaseContext().getPathAsString("status"));
+    assertEquals(420, ((Number) restored.getCaseContext().get("lastProcessedAmount")).intValue());
   }
 
   private EventLog latestEvent(UUID caseId, CaseHubEventType eventType) {

--- a/engine/src/test/java/io/casehub/engine/SignalTest.java
+++ b/engine/src/test/java/io/casehub/engine/SignalTest.java
@@ -23,13 +23,13 @@ import io.casehub.api.engine.CaseHub;
 import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -87,7 +87,7 @@ public class SignalTest {
             () -> {
               assertEquals(
                   1, SignalCaseHubBean.runCount.get(), "Worker must run exactly once after signal");
-              assertEquals(CaseState.COMPLETED, caseInstanceCache.get(caseId).getState());
+              assertEquals(CaseStatus.COMPLETED, caseInstanceCache.get(caseId).getState());
             });
   }
 
@@ -163,7 +163,7 @@ public class SignalTest {
             () -> {
               assertEquals(1, TwoSignalCaseHubBean.paymentRunCount.get());
               assertEquals(1, TwoSignalCaseHubBean.documentRunCount.get());
-              assertEquals(CaseState.COMPLETED, caseInstanceCache.get(caseId).getState());
+              assertEquals(CaseStatus.COMPLETED, caseInstanceCache.get(caseId).getState());
             });
   }
 

--- a/engine/src/test/java/io/casehub/engine/SimpleCaseHubBeanTest.java
+++ b/engine/src/test/java/io/casehub/engine/SimpleCaseHubBeanTest.java
@@ -19,8 +19,8 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
-import io.casehub.engine.internal.model.CaseState;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -68,7 +68,7 @@ public class SimpleCaseHubBeanTest {
             () -> {
               var instance = caseInstanceCache.get(ref.get());
               assertNotNull(instance);
-              assertEquals(CaseState.COMPLETED, instance.getState());
+              assertEquals(CaseStatus.COMPLETED, instance.getState());
             });
   }
 }

--- a/engine/src/test/java/io/casehub/engine/internal/context/CaseContextImplApplyDiffTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/context/CaseContextImplApplyDiffTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.casehub.api.context.StateContext;
+import io.casehub.api.context.CaseContext;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("StateContextImpl.applyDiff")
-class StateContextImplApplyDiffTest {
+class CaseContextImplApplyDiffTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -45,7 +45,7 @@ class StateContextImplApplyDiffTest {
   // ------------------------------------------------------------------ //
 
   /** Produces a patch that transforms {@code before} into {@code after}. */
-  private JsonNode diffFromSnapshots(StateContextImpl before, StateContextImpl after) {
+  private JsonNode diffFromSnapshots(CaseContextImpl before, CaseContextImpl after) {
     return before.snapshot().diff(after);
   }
 
@@ -58,7 +58,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should add a new string field to an empty context")
     void addStringToEmpty() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       ctx.applyDiff(patch("[{\"op\":\"add\",\"path\":\"/status\",\"value\":\"active\"}]"));
 
       assertEquals("active", ctx.getString("status"));
@@ -67,7 +67,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should add a new integer field")
     void addInteger() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       ctx.applyDiff(patch("[{\"op\":\"add\",\"path\":\"/amount\",\"value\":42}]"));
 
       assertEquals(42, ctx.getInt("amount"));
@@ -76,7 +76,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should add a boolean field")
     void addBoolean() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       ctx.applyDiff(patch("[{\"op\":\"add\",\"path\":\"/approved\",\"value\":true}]"));
 
       assertTrue(ctx.getBoolean("approved"));
@@ -85,7 +85,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should add a null field")
     void addNull() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("x", "y"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("x", "y"));
       ctx.applyDiff(patch("[{\"op\":\"add\",\"path\":\"/empty\",\"value\":null}]"));
 
       assertTrue(ctx.contains("empty"));
@@ -95,7 +95,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should add a nested object field")
     void addNestedObject() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       ctx.applyDiff(
           patch(
               """
@@ -111,7 +111,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should add a list field")
     void addList() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       ctx.applyDiff(patch("[{\"op\":\"add\",\"path\":\"/tags\",\"value\":[\"a\",\"b\"]}]"));
 
       List<?> tags = ctx.getList("tags", Object.class);
@@ -122,7 +122,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should add multiple fields in one patch")
     void addMultipleFields() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       ctx.applyDiff(
           patch(
               """
@@ -146,7 +146,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should replace an existing string field")
     void replaceString() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("status", "pending"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("status", "pending"));
       ctx.applyDiff(patch("[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"active\"}]"));
 
       assertEquals("active", ctx.getString("status"));
@@ -155,7 +155,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should replace an integer field")
     void replaceInteger() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("count", 1));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("count", 1));
       ctx.applyDiff(patch("[{\"op\":\"replace\",\"path\":\"/count\",\"value\":99}]"));
 
       assertEquals(99, ctx.getInt("count"));
@@ -164,7 +164,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should replace a field with a nested object")
     void replaceWithObject() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("data", "simple"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("data", "simple"));
       ctx.applyDiff(patch("[{\"op\":\"replace\",\"path\":\"/data\",\"value\":{\"key\":\"val\"}}]"));
 
       @SuppressWarnings("unchecked")
@@ -175,7 +175,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should not affect other fields when replacing one")
     void replaceDoesNotAffectOthers() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("a", "1", "b", "2"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("a", "1", "b", "2"));
       ctx.applyDiff(patch("[{\"op\":\"replace\",\"path\":\"/a\",\"value\":\"updated\"}]"));
 
       assertEquals("updated", ctx.getString("a"));
@@ -192,7 +192,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should remove an existing field")
     void removeField() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("status", "active", "other", "keep"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("status", "active", "other", "keep"));
       ctx.applyDiff(patch("[{\"op\":\"remove\",\"path\":\"/status\"}]"));
 
       assertFalse(ctx.contains("status"));
@@ -202,7 +202,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should leave context empty when removing the only field")
     void removeOnlyField() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("x", "y"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("x", "y"));
       ctx.applyDiff(patch("[{\"op\":\"remove\",\"path\":\"/x\"}]"));
 
       assertTrue(ctx.isEmpty());
@@ -218,7 +218,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should leave context unchanged for empty patch array")
     void emptyPatchLeavesContextUnchanged() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("status", "original"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("status", "original"));
       ctx.applyDiff(patch("[]"));
 
       assertEquals("original", ctx.getString("status"));
@@ -228,7 +228,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should still increment version for empty patch")
     void emptyPatchIncrementsVersion() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       long before = ctx.getVersion();
       ctx.applyDiff(patch("[]"));
 
@@ -245,7 +245,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should increment version on each applyDiff call")
     void versionIncrementsEachCall() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       long initial = ctx.getVersion();
 
       ctx.applyDiff(patch("[{\"op\":\"add\",\"path\":\"/a\",\"value\":1}]"));
@@ -268,13 +268,13 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("add field roundtrip")
     void addFieldRoundtrip() {
-      StateContextImpl original = new StateContextImpl(Map.of("x", "1"));
-      StateContext snapshot = original.snapshot();
+      CaseContextImpl original = new CaseContextImpl(Map.of("x", "1"));
+      CaseContext snapshot = original.snapshot();
 
       original.set("y", "2");
       JsonNode patch = snapshot.diff(original);
 
-      StateContextImpl replica = new StateContextImpl(Map.of("x", "1"));
+      CaseContextImpl replica = new CaseContextImpl(Map.of("x", "1"));
       replica.applyDiff(patch);
 
       assertEquals("1", replica.getString("x"));
@@ -284,13 +284,13 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("replace field roundtrip")
     void replaceFieldRoundtrip() {
-      StateContextImpl original = new StateContextImpl(Map.of("status", "pending"));
-      StateContext snapshot = original.snapshot();
+      CaseContextImpl original = new CaseContextImpl(Map.of("status", "pending"));
+      CaseContext snapshot = original.snapshot();
 
       original.set("status", "active");
       JsonNode patch = snapshot.diff(original);
 
-      StateContextImpl replica = new StateContextImpl(Map.of("status", "pending"));
+      CaseContextImpl replica = new CaseContextImpl(Map.of("status", "pending"));
       replica.applyDiff(patch);
 
       assertEquals("active", replica.getString("status"));
@@ -299,13 +299,13 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("remove field roundtrip")
     void removeFieldRoundtrip() {
-      StateContextImpl original = new StateContextImpl(Map.of("a", "1", "b", "2"));
-      StateContext snapshot = original.snapshot();
+      CaseContextImpl original = new CaseContextImpl(Map.of("a", "1", "b", "2"));
+      CaseContext snapshot = original.snapshot();
 
       original.remove("b");
       JsonNode patch = snapshot.diff(original);
 
-      StateContextImpl replica = new StateContextImpl(Map.of("a", "1", "b", "2"));
+      CaseContextImpl replica = new CaseContextImpl(Map.of("a", "1", "b", "2"));
       replica.applyDiff(patch);
 
       assertTrue(replica.contains("a"));
@@ -315,15 +315,15 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("multiple changes roundtrip")
     void multipleChangesRoundtrip() {
-      StateContextImpl original = new StateContextImpl(Map.of("a", "old", "b", "keep"));
-      StateContext snapshot = original.snapshot();
+      CaseContextImpl original = new CaseContextImpl(Map.of("a", "old", "b", "keep"));
+      CaseContext snapshot = original.snapshot();
 
       original.set("a", "new");
       original.set("c", "added");
       original.remove("b");
       JsonNode patch = snapshot.diff(original);
 
-      StateContextImpl replica = new StateContextImpl(Map.of("a", "old", "b", "keep"));
+      CaseContextImpl replica = new CaseContextImpl(Map.of("a", "old", "b", "keep"));
       replica.applyDiff(patch);
 
       assertEquals("new", replica.getString("a"));
@@ -334,21 +334,21 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("sequential patches reconstruct state correctly")
     void sequentialPatches() {
-      StateContextImpl source = new StateContextImpl(Map.of("step", 0));
+      CaseContextImpl source = new CaseContextImpl(Map.of("step", 0));
 
       // patch 1: step 0 → 1
-      StateContext snap1 = source.snapshot();
+      CaseContext snap1 = source.snapshot();
       source.set("step", 1);
       JsonNode patch1 = snap1.diff(source);
 
       // patch 2: step 1 → 2 + add field
-      StateContext snap2 = source.snapshot();
+      CaseContext snap2 = source.snapshot();
       source.set("step", 2);
       source.set("done", true);
       JsonNode patch2 = snap2.diff(source);
 
       // replay on fresh context
-      StateContextImpl replica = new StateContextImpl(Map.of("step", 0));
+      CaseContextImpl replica = new CaseContextImpl(Map.of("step", 0));
       replica.applyDiff(patch1);
       replica.applyDiff(patch2);
 
@@ -359,13 +359,13 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("signal roundtrip: setPath → diff → applyDiff")
     void signalSetPathRoundtrip() {
-      StateContextImpl original = new StateContextImpl(Map.of("balance", 100));
-      StateContext snapshot = original.snapshot();
+      CaseContextImpl original = new CaseContextImpl(Map.of("balance", 100));
+      CaseContext snapshot = original.snapshot();
 
       original.setPath("payment.amount", 250);
       JsonNode patch = snapshot.diff(original);
 
-      StateContextImpl replica = new StateContextImpl(Map.of("balance", 100));
+      CaseContextImpl replica = new CaseContextImpl(Map.of("balance", 100));
       replica.applyDiff(patch);
 
       assertEquals(100, replica.getInt("balance"));
@@ -382,7 +382,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should preserve pre-existing fields when adding new ones")
     void preservesExistingOnAdd() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("existing", "value"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("existing", "value"));
       ctx.applyDiff(patch("[{\"op\":\"add\",\"path\":\"/new\",\"value\":\"field\"}]"));
 
       assertEquals("value", ctx.getString("existing"));
@@ -393,7 +393,7 @@ class StateContextImplApplyDiffTest {
     @DisplayName("should preserve all fields on empty patch")
     void preservesAllOnEmptyPatch() throws Exception {
       Map<String, Object> initial = Map.of("a", "1", "b", 2, "c", true);
-      StateContextImpl ctx = new StateContextImpl(initial);
+      CaseContextImpl ctx = new CaseContextImpl(initial);
       ctx.applyDiff(patch("[]"));
 
       assertEquals("1", ctx.getString("a"));
@@ -411,7 +411,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should throw when patch references a non-existent path for replace")
     void replaceNonExistentThrows() throws Exception {
-      StateContextImpl ctx = new StateContextImpl();
+      CaseContextImpl ctx = new CaseContextImpl();
       JsonNode badPatch = patch("[{\"op\":\"replace\",\"path\":\"/missing\",\"value\":\"x\"}]");
 
       assertThrows(Exception.class, () -> ctx.applyDiff(badPatch));
@@ -420,7 +420,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should silently ignore remove of a non-existent path (library is lenient)")
     void removeNonExistentIsIgnored() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("existing", "value"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("existing", "value"));
       ctx.applyDiff(patch("[{\"op\":\"remove\",\"path\":\"/missing\"}]"));
 
       // context unchanged — library ignores the no-op
@@ -431,7 +431,7 @@ class StateContextImplApplyDiffTest {
     @Test
     @DisplayName("should not mutate context state when patch fails (replace on non-existent)")
     void contextUnchangedOnFailure() throws Exception {
-      StateContextImpl ctx = new StateContextImpl(Map.of("status", "original"));
+      CaseContextImpl ctx = new CaseContextImpl(Map.of("status", "original"));
       JsonNode badPatch = patch("[{\"op\":\"replace\",\"path\":\"/nonexistent\",\"value\":\"x\"}]");
 
       assertThrows(Exception.class, () -> ctx.applyDiff(badPatch));

--- a/engine/src/test/java/io/casehub/engine/internal/context/CaseContextImplTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/context/CaseContextImplTest.java
@@ -28,14 +28,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Pure unit tests for {@link StateContextImpl} — methods not covered by {@link
- * StateContextImplApplyDiffTest}.
+ * Pure unit tests for {@link CaseContextImpl} — methods not covered by {@link
+ * CaseContextImplApplyDiffTest}.
  *
  * <p>Focused on: set/get, typed accessors, compareAndSet, update, merge, getPath/setPath,
  * computeIfAbsent, putIfAbsent, getAll/setAll, clear, evalObjectTemplate, version semantics.
  */
 @DisplayName("StateContextImpl")
-class StateContextImplTest {
+class CaseContextImplTest {
 
   // ================================================================== //
   //  Construction                                                       //
@@ -48,7 +48,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("empty constructor creates empty context at version 0")
     void empty_createsEmptyContext() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       assertTrue(ctx.isEmpty());
       assertEquals(0, ctx.getVersion());
     }
@@ -56,7 +56,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("map constructor populates data without incrementing version")
     void mapConstructor_populatesData() {
-      final var ctx = new StateContextImpl(Map.of("a", "1", "b", 2));
+      final var ctx = new CaseContextImpl(Map.of("a", "1", "b", 2));
       assertEquals("1", ctx.getString("a"));
       assertEquals(2, ctx.getInt("b"));
       // version stays 0 because the constructor doesn't call set()
@@ -75,7 +75,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("set increments version on first write")
     void set_incrementsVersion() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.set("k", "v");
       assertEquals(1, ctx.getVersion());
     }
@@ -83,7 +83,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setting the same value twice does not increment version the second time")
     void set_sameValue_noVersionIncrement() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.set("k", "v");
       final long v1 = ctx.getVersion();
       ctx.set("k", "v");
@@ -93,7 +93,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setting a different value increments version again")
     void set_differentValue_incrementsAgain() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.set("k", "a");
       final long v1 = ctx.getVersion();
       ctx.set("k", "b");
@@ -103,21 +103,21 @@ class StateContextImplTest {
     @Test
     @DisplayName("get returns null for absent key")
     void get_absentKey_null() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       assertNull(ctx.get("missing"));
     }
 
     @Test
     @DisplayName("get returns value for present key")
     void get_presentKey_returnsValue() {
-      final var ctx = new StateContextImpl(Map.of("x", "hello"));
+      final var ctx = new CaseContextImpl(Map.of("x", "hello"));
       assertEquals("hello", ctx.get("x"));
     }
 
     @Test
     @DisplayName("contains returns true for present key, false for absent")
     void contains_presentAndAbsent() {
-      final var ctx = new StateContextImpl(Map.of("x", "y"));
+      final var ctx = new CaseContextImpl(Map.of("x", "y"));
       assertTrue(ctx.contains("x"));
       assertFalse(ctx.contains("z"));
     }
@@ -125,7 +125,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("remove decrements size and increments version")
     void remove_presentKey() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       ctx.remove("a");
       assertFalse(ctx.contains("a"));
       assertEquals(1, ctx.getVersion());
@@ -134,7 +134,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("remove absent key is a no-op (version unchanged)")
     void remove_absentKey_noOp() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       final long before = ctx.getVersion();
       ctx.remove("missing");
       assertEquals(before, ctx.getVersion());
@@ -152,114 +152,114 @@ class StateContextImplTest {
     @Test
     @DisplayName("getString returns null for absent key")
     void getString_absent_null() {
-      assertEquals(null, new StateContextImpl().getString("k"));
+      assertEquals(null, new CaseContextImpl().getString("k"));
     }
 
     @Test
     @DisplayName("getString converts int to string")
     void getString_int_convertsToString() {
-      final var ctx = new StateContextImpl(Map.of("n", 42));
+      final var ctx = new CaseContextImpl(Map.of("n", 42));
       assertEquals("42", ctx.getString("n"));
     }
 
     @Test
     @DisplayName("getInt parses integer from string")
     void getInt_stringValue_parsed() {
-      final var ctx = new StateContextImpl(Map.of("n", "7"));
+      final var ctx = new CaseContextImpl(Map.of("n", "7"));
       assertEquals(7, ctx.getInt("n"));
     }
 
     @Test
     @DisplayName("getInt returns null for absent key")
     void getInt_absent_null() {
-      assertNull(new StateContextImpl().getInt("n"));
+      assertNull(new CaseContextImpl().getInt("n"));
     }
 
     @Test
     @DisplayName("getLong returns long value")
     void getLong_returnsLong() {
-      final var ctx = new StateContextImpl(Map.of("n", 123456789012345L));
+      final var ctx = new CaseContextImpl(Map.of("n", 123456789012345L));
       assertEquals(123456789012345L, ctx.getLong("n"));
     }
 
     @Test
     @DisplayName("getLong parses from string")
     void getLong_stringValue_parsed() {
-      final var ctx = new StateContextImpl(Map.of("n", "9999999999"));
+      final var ctx = new CaseContextImpl(Map.of("n", "9999999999"));
       assertEquals(9999999999L, ctx.getLong("n"));
     }
 
     @Test
     @DisplayName("getLong returns null for absent key")
     void getLong_absent_null() {
-      assertNull(new StateContextImpl().getLong("n"));
+      assertNull(new CaseContextImpl().getLong("n"));
     }
 
     @Test
     @DisplayName("getDouble returns double value")
     void getDouble_returnsDouble() {
-      final var ctx = new StateContextImpl(Map.of("d", 3.14));
+      final var ctx = new CaseContextImpl(Map.of("d", 3.14));
       assertEquals(3.14, ctx.getDouble("d"), 0.001);
     }
 
     @Test
     @DisplayName("getDouble parses from string")
     void getDouble_stringValue_parsed() {
-      final var ctx = new StateContextImpl(Map.of("d", "2.71"));
+      final var ctx = new CaseContextImpl(Map.of("d", "2.71"));
       assertEquals(2.71, ctx.getDouble("d"), 0.001);
     }
 
     @Test
     @DisplayName("getDouble returns null for absent key")
     void getDouble_absent_null() {
-      assertNull(new StateContextImpl().getDouble("d"));
+      assertNull(new CaseContextImpl().getDouble("d"));
     }
 
     @Test
     @DisplayName("getBoolean returns true for Boolean.TRUE")
     void getBoolean_trueValue() {
-      final var ctx = new StateContextImpl(Map.of("b", Boolean.TRUE));
+      final var ctx = new CaseContextImpl(Map.of("b", Boolean.TRUE));
       assertTrue(ctx.getBoolean("b"));
     }
 
     @Test
     @DisplayName("getBoolean returns false for Boolean.FALSE")
     void getBoolean_falseValue() {
-      final var ctx = new StateContextImpl(Map.of("b", Boolean.FALSE));
+      final var ctx = new CaseContextImpl(Map.of("b", Boolean.FALSE));
       assertFalse(ctx.getBoolean("b"));
     }
 
     @Test
     @DisplayName("getBoolean parses 'true' string")
     void getBoolean_stringTrue_parsed() {
-      final var ctx = new StateContextImpl(Map.of("b", "true"));
+      final var ctx = new CaseContextImpl(Map.of("b", "true"));
       assertTrue(ctx.getBoolean("b"));
     }
 
     @Test
     @DisplayName("getBoolean returns null for absent key")
     void getBoolean_absent_null() {
-      assertNull(new StateContextImpl().getBoolean("b"));
+      assertNull(new CaseContextImpl().getBoolean("b"));
     }
 
     @Test
     @DisplayName("getOrDefault returns stored value when present")
     void getOrDefault_present_returnsStored() {
-      final var ctx = new StateContextImpl(Map.of("k", "stored"));
+      final var ctx = new CaseContextImpl(Map.of("k", "stored"));
       assertEquals("stored", ctx.getOrDefault("k", "default"));
     }
 
     @Test
     @DisplayName("getOrDefault returns default when key absent")
     void getOrDefault_absent_returnsDefault() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       assertEquals("default", ctx.getOrDefault("k", "default"));
     }
 
     @Test
     @DisplayName("getAs converts numeric to target type via Jackson")
     void getAs_numericConversion() {
-      final var ctx = new StateContextImpl(Map.of("n", 42));
+      final var ctx = new CaseContextImpl(Map.of("n", 42));
       assertEquals(Long.valueOf(42L), ctx.getAs("n", Long.class));
     }
   }
@@ -275,7 +275,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("succeeds when current value matches expected")
     void cas_match_returnsTrue() {
-      final var ctx = new StateContextImpl(Map.of("status", "pending"));
+      final var ctx = new CaseContextImpl(Map.of("status", "pending"));
       final boolean result = ctx.compareAndSet("status", "pending", "active");
       assertTrue(result);
       assertEquals("active", ctx.getString("status"));
@@ -284,7 +284,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("fails when current value does not match expected")
     void cas_mismatch_returnsFalse() {
-      final var ctx = new StateContextImpl(Map.of("status", "running"));
+      final var ctx = new CaseContextImpl(Map.of("status", "running"));
       final boolean result = ctx.compareAndSet("status", "pending", "active");
       assertFalse(result);
       assertEquals("running", ctx.getString("status"), "value must be unchanged after failed CAS");
@@ -293,7 +293,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("succeeds for absent key when expected is null")
     void cas_nullExpected_absentKey_succeeds() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final boolean result = ctx.compareAndSet("k", null, "new-value");
       assertTrue(result);
       assertEquals("new-value", ctx.getString("k"));
@@ -302,7 +302,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("does not increment version when new value equals current value")
     void cas_sameValue_noVersionIncrement() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
       final long before = ctx.getVersion();
       ctx.compareAndSet("k", "v", "v"); // same value
       assertEquals(before, ctx.getVersion(), "no-op CAS must not increment version");
@@ -311,7 +311,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("increments version on successful value change")
     void cas_successfulChange_incrementsVersion() {
-      final var ctx = new StateContextImpl(Map.of("k", "old"));
+      final var ctx = new CaseContextImpl(Map.of("k", "old"));
       final long before = ctx.getVersion();
       ctx.compareAndSet("k", "old", "new");
       assertEquals(before + 1, ctx.getVersion());
@@ -329,7 +329,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("update applies function to current value")
     void update_transformsValue() {
-      final var ctx = new StateContextImpl(Map.of("count", 5));
+      final var ctx = new CaseContextImpl(Map.of("count", 5));
       ctx.update("count", v -> ((Number) v).intValue() + 1);
       assertEquals(6, ctx.getInt("count"));
     }
@@ -337,7 +337,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("update with null result removes the key")
     void update_nullResult_removesKey() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
       ctx.update("k", v -> null);
       assertFalse(ctx.contains("k"));
     }
@@ -345,7 +345,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("update with no-op (same value) does not increment version")
     void update_noOpSameValue_noVersionIncrement() {
-      final var ctx = new StateContextImpl(Map.of("k", "same"));
+      final var ctx = new CaseContextImpl(Map.of("k", "same"));
       final long before = ctx.getVersion();
       ctx.update("k", v -> "same");
       assertEquals(before, ctx.getVersion());
@@ -354,7 +354,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("update receives null for absent key")
     void update_absentKey_receivesNull() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final Object[] received = {new Object()}; // sentinel
       ctx.update(
           "absent",
@@ -377,7 +377,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("computeIfAbsent computes and stores when key absent")
     void computeIfAbsent_absent_computesAndStores() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final Object result = ctx.computeIfAbsent("k", key -> "computed");
       assertEquals("computed", result);
       assertEquals("computed", ctx.getString("k"));
@@ -386,7 +386,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("computeIfAbsent returns existing value without calling function")
     void computeIfAbsent_present_returnsExisting() {
-      final var ctx = new StateContextImpl(Map.of("k", "existing"));
+      final var ctx = new CaseContextImpl(Map.of("k", "existing"));
       final boolean[] called = {false};
       final Object result =
           ctx.computeIfAbsent(
@@ -402,7 +402,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("computeIfAbsent does not store when function returns null")
     void computeIfAbsent_functionReturnsNull_notStored() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final long before = ctx.getVersion();
       ctx.computeIfAbsent("k", key -> null);
       assertFalse(ctx.contains("k"));
@@ -412,7 +412,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("putIfAbsent stores value when key absent")
     void putIfAbsent_absent_stores() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final Object previous = ctx.putIfAbsent("k", "new");
       assertNull(previous, "previous should be null when key was absent");
       assertEquals("new", ctx.getString("k"));
@@ -421,7 +421,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("putIfAbsent returns existing value without overwriting")
     void putIfAbsent_present_returnsExisting() {
-      final var ctx = new StateContextImpl(Map.of("k", "existing"));
+      final var ctx = new CaseContextImpl(Map.of("k", "existing"));
       final Object previous = ctx.putIfAbsent("k", "new");
       assertEquals("existing", previous);
       assertEquals("existing", ctx.getString("k"), "existing value must not be overwritten");
@@ -439,7 +439,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setAll stores all provided key-value pairs")
     void setAll_storesAll() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.setAll(Map.of("a", "1", "b", "2"));
       assertEquals("1", ctx.getString("a"));
       assertEquals("2", ctx.getString("b"));
@@ -448,7 +448,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setAll with null map is a no-op")
     void setAll_nullMap_noOp() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
       final long before = ctx.getVersion();
       ctx.setAll(null);
       assertEquals(before, ctx.getVersion());
@@ -457,7 +457,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setAll with empty map is a no-op")
     void setAll_emptyMap_noOp() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
       final long before = ctx.getVersion();
       ctx.setAll(Map.of());
       assertEquals(before, ctx.getVersion());
@@ -466,7 +466,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setAll only increments version once for multiple changes")
     void setAll_multipleChanges_singleVersionIncrement() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final long before = ctx.getVersion();
       ctx.setAll(Map.of("a", "1", "b", "2", "c", "3"));
       assertEquals(before + 1, ctx.getVersion(), "setAll should increment version exactly once");
@@ -475,7 +475,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setAll no-op when all values are identical")
     void setAll_allSameValues_noVersionIncrement() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       final long before = ctx.getVersion();
       ctx.setAll(Map.of("a", "1")); // no actual change
       assertEquals(before, ctx.getVersion());
@@ -484,7 +484,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("getAll returns only present keys")
     void getAll_returnsOnlyPresentKeys() {
-      final var ctx = new StateContextImpl(Map.of("a", "1", "b", "2"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1", "b", "2"));
       final var result = ctx.getAll("a", "c"); // 'c' is missing
       assertEquals(1, result.size());
       assertEquals("1", result.get("a"));
@@ -494,7 +494,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("getAll with no matching keys returns empty map")
     void getAll_noMatchingKeys_empty() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       final var result = ctx.getAll("x", "y");
       assertTrue(result.isEmpty());
     }
@@ -511,7 +511,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("clear empties the context and increments version")
     void clear_emptiesContext() {
-      final var ctx = new StateContextImpl(Map.of("a", "1", "b", "2"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1", "b", "2"));
       ctx.clear();
       assertTrue(ctx.isEmpty());
       assertEquals(0, ctx.size());
@@ -521,7 +521,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("clear on already-empty context is a no-op")
     void clear_alreadyEmpty_noOp() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final long before = ctx.getVersion();
       ctx.clear();
       assertEquals(before, ctx.getVersion(), "clearing empty context must not increment version");
@@ -539,7 +539,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setPath creates nested structure and getPath retrieves it")
     void setPath_createsNested_getPathRetrieve() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.setPath("payment.amount", 500);
       assertEquals(500, ctx.getPath("payment.amount"));
     }
@@ -547,7 +547,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("setPath creates intermediate map nodes")
     void setPath_createsIntermediateNodes() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.setPath("a.b.c", "deep");
       assertEquals("deep", ctx.getPath("a.b.c"));
     }
@@ -555,21 +555,21 @@ class StateContextImplTest {
     @Test
     @DisplayName("getPath returns null for absent top-level key")
     void getPath_absentTopLevel_null() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       assertNull(ctx.getPath("missing.path"));
     }
 
     @Test
     @DisplayName("getPath returns null when intermediate key is absent")
     void getPath_absentIntermediate_null() {
-      final var ctx = new StateContextImpl(Map.of("a", Map.of("x", "1")));
+      final var ctx = new CaseContextImpl(Map.of("a", Map.of("x", "1")));
       assertNull(ctx.getPath("a.b.c"));
     }
 
     @Test
     @DisplayName("setPath on non-map node throws IllegalStateException")
     void setPath_nonMapNode_throws() {
-      final var ctx = new StateContextImpl(Map.of("a", "scalar"));
+      final var ctx = new CaseContextImpl(Map.of("a", "scalar"));
       assertThrows(
           IllegalStateException.class,
           () -> ctx.setPath("a.b", "value"),
@@ -579,7 +579,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("getPathAsString returns string representation")
     void getPathAsString_returnsString() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.setPath("x.y", 42);
       assertEquals("42", ctx.getPathAsString("x.y"));
     }
@@ -587,13 +587,13 @@ class StateContextImplTest {
     @Test
     @DisplayName("getPathAsString returns null for absent path")
     void getPathAsString_absent_null() {
-      assertNull(new StateContextImpl().getPathAsString("missing"));
+      assertNull(new CaseContextImpl().getPathAsString("missing"));
     }
 
     @Test
     @DisplayName("setPath with same value does not increment version")
     void setPath_sameValue_noVersionIncrement() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.setPath("a.b", "v");
       final long before = ctx.getVersion();
       ctx.setPath("a.b", "v");
@@ -612,8 +612,8 @@ class StateContextImplTest {
     @Test
     @DisplayName("merge adds new keys from other context")
     void merge_addsNewKeys() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
-      final var other = new StateContextImpl(Map.of("b", "2"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
+      final var other = new CaseContextImpl(Map.of("b", "2"));
       ctx.merge(other);
       assertEquals("1", ctx.getString("a"));
       assertEquals("2", ctx.getString("b"));
@@ -622,8 +622,8 @@ class StateContextImplTest {
     @Test
     @DisplayName("merge overwrites existing keys with values from other")
     void merge_overwritesExisting() {
-      final var ctx = new StateContextImpl(Map.of("k", "old"));
-      final var other = new StateContextImpl(Map.of("k", "new"));
+      final var ctx = new CaseContextImpl(Map.of("k", "old"));
+      final var other = new CaseContextImpl(Map.of("k", "new"));
       ctx.merge(other);
       assertEquals("new", ctx.getString("k"));
     }
@@ -631,7 +631,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("merge with null is a no-op")
     void merge_null_noOp() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
       final long before = ctx.getVersion();
       ctx.merge(null);
       assertEquals(before, ctx.getVersion());
@@ -641,17 +641,17 @@ class StateContextImplTest {
     @Test
     @DisplayName("merge with empty context is a no-op")
     void merge_emptyOther_noOp() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
       final long before = ctx.getVersion();
-      ctx.merge(new StateContextImpl());
+      ctx.merge(new CaseContextImpl());
       assertEquals(before, ctx.getVersion());
     }
 
     @Test
     @DisplayName("merge with identical values does not increment version")
     void merge_sameValues_noVersionIncrement() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
-      final var other = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
+      final var other = new CaseContextImpl(Map.of("k", "v"));
       final long before = ctx.getVersion();
       ctx.merge(other);
       assertEquals(before, ctx.getVersion());
@@ -669,8 +669,8 @@ class StateContextImplTest {
     @Test
     @DisplayName("snapshot captures current data at current version")
     void snapshot_capturesState() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
-      final var snap = (StateContextImpl) ctx.snapshot();
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
+      final var snap = (CaseContextImpl) ctx.snapshot();
       assertEquals("v", snap.getString("k"));
       assertEquals(ctx.getVersion(), snap.getVersion());
     }
@@ -678,8 +678,8 @@ class StateContextImplTest {
     @Test
     @DisplayName("modifying original after snapshot does not affect snapshot")
     void snapshot_isIndependent() {
-      final var ctx = new StateContextImpl(Map.of("k", "original"));
-      final var snap = (StateContextImpl) ctx.snapshot();
+      final var ctx = new CaseContextImpl(Map.of("k", "original"));
+      final var snap = (CaseContextImpl) ctx.snapshot();
       ctx.set("k", "modified");
       assertEquals("original", snap.getString("k"), "snapshot must be independent of original");
     }
@@ -687,8 +687,8 @@ class StateContextImplTest {
     @Test
     @DisplayName("modifying snapshot does not affect original")
     void snapshot_modifySnap_doesNotAffectOriginal() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
-      final var snap = (StateContextImpl) ctx.snapshot();
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
+      final var snap = (CaseContextImpl) ctx.snapshot();
       snap.set("k", "changed");
       assertEquals("v", ctx.getString("k"), "original must be unaffected by snapshot changes");
     }
@@ -705,7 +705,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("getKeys returns all stored keys")
     void getKeys_returnsAllKeys() {
-      final var ctx = new StateContextImpl(Map.of("a", "1", "b", "2"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1", "b", "2"));
       final var keys = ctx.getKeys();
       assertEquals(2, keys.size());
       assertTrue(keys.contains("a"));
@@ -715,20 +715,20 @@ class StateContextImplTest {
     @Test
     @DisplayName("size returns count of stored entries")
     void size_returnsCount() {
-      final var ctx = new StateContextImpl(Map.of("a", "1", "b", "2", "c", "3"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1", "b", "2", "c", "3"));
       assertEquals(3, ctx.size());
     }
 
     @Test
     @DisplayName("isEmpty returns true for empty context")
     void isEmpty_empty_true() {
-      assertTrue(new StateContextImpl().isEmpty());
+      assertTrue(new CaseContextImpl().isEmpty());
     }
 
     @Test
     @DisplayName("isEmpty returns false after adding entry")
     void isEmpty_afterAdd_false() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.set("k", "v");
       assertFalse(ctx.isEmpty());
     }
@@ -745,7 +745,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("asJsonNode returns an object node with all entries")
     void asJsonNode_returnsObjectNode() {
-      final var ctx = new StateContextImpl(Map.of("status", "active", "count", 3));
+      final var ctx = new CaseContextImpl(Map.of("status", "active", "count", 3));
       final var node = ctx.asJsonNode();
       assertNotNull(node);
       assertEquals("active", node.get("status").asText());
@@ -755,7 +755,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("getData returns a copy — modifying it does not affect context")
     void getData_returnsCopy() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
       final var data = ctx.getData();
       data.put("k", "modified");
       assertEquals("v", ctx.getString("k"), "getData must return a defensive copy");
@@ -773,7 +773,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("extracts single field via path expression")
     void singleField_extracted() {
-      final var ctx = new StateContextImpl(Map.of("documentId", "doc-123", "status", "active"));
+      final var ctx = new CaseContextImpl(Map.of("documentId", "doc-123", "status", "active"));
       final var result = ctx.evalObjectTemplate("{ documentId: .documentId }");
       assertEquals("doc-123", result.get("documentId"));
       assertFalse(result.containsKey("status"), "only requested field should be present");
@@ -782,7 +782,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("extracts multiple fields")
     void multipleFields_extracted() {
-      final var ctx = new StateContextImpl(Map.of("id", "x1", "status", "ok", "extra", "ignored"));
+      final var ctx = new CaseContextImpl(Map.of("id", "x1", "status", "ok", "extra", "ignored"));
       final var result = ctx.evalObjectTemplate("{ id: .id, status: .status }");
       assertEquals("x1", result.get("id"));
       assertEquals("ok", result.get("status"));
@@ -792,7 +792,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("dot expression maps to whole context snapshot")
     void dotExpression_wholeContext() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       final var result = ctx.evalObjectTemplate("{ all: . }");
       assertNotNull(result.get("all"));
     }
@@ -800,7 +800,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("absent path produces null value for the key")
     void absentPath_nullValue() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       final var result = ctx.evalObjectTemplate("{ missing: .nonExistent }");
       assertTrue(result.containsKey("missing"), "key must still be present");
       assertNull(result.get("missing"), "value for absent path must be null");
@@ -809,7 +809,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("JSON literal value is included directly")
     void jsonLiteralValue_included() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       final var result = ctx.evalObjectTemplate("{ fixed: \"hello\" }");
       assertEquals("hello", result.get("fixed"));
     }
@@ -817,28 +817,28 @@ class StateContextImplTest {
     @Test
     @DisplayName("null template returns empty map")
     void nullTemplate_returnsEmpty() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       assertTrue(ctx.evalObjectTemplate(null).isEmpty());
     }
 
     @Test
     @DisplayName("blank template returns empty map")
     void blankTemplate_returnsEmpty() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       assertTrue(ctx.evalObjectTemplate("   ").isEmpty());
     }
 
     @Test
     @DisplayName("empty braces {} returns empty map")
     void emptyBraces_returnsEmpty() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       assertTrue(ctx.evalObjectTemplate("{}").isEmpty());
     }
 
     @Test
     @DisplayName("template not wrapped with braces throws IllegalArgumentException")
     void unwrappedTemplate_throws() {
-      final var ctx = new StateContextImpl(Map.of("a", "1"));
+      final var ctx = new CaseContextImpl(Map.of("a", "1"));
       assertThrows(
           IllegalArgumentException.class,
           () -> ctx.evalObjectTemplate("id: .id"),
@@ -848,7 +848,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("nested path extracts from nested structure")
     void nestedPath_extracted() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       ctx.setPath("doc.id", "doc-42");
       final var result = ctx.evalObjectTemplate("{ docId: .doc }");
       assertNotNull(result.get("docId"), "nested extraction should work via . path to top key");
@@ -857,7 +857,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("boolean literal value in template")
     void booleanLiteral_included() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final var result = ctx.evalObjectTemplate("{ flag: true }");
       assertEquals(true, result.get("flag"));
     }
@@ -865,7 +865,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("numeric literal value in template")
     void numericLiteral_included() {
-      final var ctx = new StateContextImpl();
+      final var ctx = new CaseContextImpl();
       final var result = ctx.evalObjectTemplate("{ count: 42 }");
       assertEquals(42, result.get("count"));
     }
@@ -882,31 +882,31 @@ class StateContextImplTest {
     @Test
     @DisplayName("two contexts with same data are equal regardless of version")
     void equalData_equalContexts() {
-      final var a = new StateContextImpl(Map.of("k", "v"), 1L);
-      final var b = new StateContextImpl(Map.of("k", "v"), 99L);
+      final var a = new CaseContextImpl(Map.of("k", "v"), 1L);
+      final var b = new CaseContextImpl(Map.of("k", "v"), 99L);
       assertEquals(a, b, "equality is based on data, not version");
     }
 
     @Test
     @DisplayName("contexts with different data are not equal")
     void differentData_notEqual() {
-      final var a = new StateContextImpl(Map.of("k", "v1"));
-      final var b = new StateContextImpl(Map.of("k", "v2"));
+      final var a = new CaseContextImpl(Map.of("k", "v1"));
+      final var b = new CaseContextImpl(Map.of("k", "v2"));
       assertFalse(a.equals(b));
     }
 
     @Test
     @DisplayName("same instance equals itself")
     void sameInstance_equal() {
-      final var ctx = new StateContextImpl(Map.of("k", "v"));
+      final var ctx = new CaseContextImpl(Map.of("k", "v"));
       assertTrue(ctx.equals(ctx));
     }
 
     @Test
     @DisplayName("hashCode consistent with equals")
     void hashCode_consistentWithEquals() {
-      final var a = new StateContextImpl(Map.of("k", "v"));
-      final var b = new StateContextImpl(Map.of("k", "v"));
+      final var a = new CaseContextImpl(Map.of("k", "v"));
+      final var b = new CaseContextImpl(Map.of("k", "v"));
       assertEquals(a.hashCode(), b.hashCode());
     }
   }
@@ -922,7 +922,7 @@ class StateContextImplTest {
     @Test
     @DisplayName("toString returns valid JSON representation")
     void toString_returnsJson() {
-      final var ctx = new StateContextImpl(Map.of("status", "ok"));
+      final var ctx = new CaseContextImpl(Map.of("status", "ok"));
       final var json = ctx.toString();
       assertNotNull(json);
       assertTrue(json.contains("status"), "toString should contain the key");

--- a/engine/src/test/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategyTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/diff/JsonPatchContextDiffStrategyTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+/** Pure unit tests — no CDI, no Quarkus. */
+class JsonPatchContextDiffStrategyTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final JsonPatchContextDiffStrategy strategy = new JsonPatchContextDiffStrategy();
+
+  @Test
+  void addedKey_producesAddOperation() {
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), after);
+
+    assertThat(diff.isArray()).isTrue();
+    assertThat(findOp(diff, "add", "/status")).isNotNull();
+    assertThat(findOp(diff, "add", "/status").get("value").asText()).isEqualTo("done");
+  }
+
+  @Test
+  void updatedKey_producesReplaceOperation() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(findOp(diff, "replace", "/status")).isNotNull();
+    assertThat(findOp(diff, "replace", "/status").get("value").asText()).isEqualTo("done");
+  }
+
+  @Test
+  void removedKey_producesRemoveOperation() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("tempKey", "bye");
+
+    JsonNode diff = strategy.compute(before, MAPPER.createObjectNode());
+
+    assertThat(findOp(diff, "remove", "/tempKey")).isNotNull();
+  }
+
+  @Test
+  void noChanges_producesEmptyArray() {
+    ObjectNode both = MAPPER.createObjectNode();
+    both.put("status", "done");
+
+    JsonNode diff = strategy.compute(both, both);
+
+    assertThat(diff.isArray()).isTrue();
+    assertThat(diff.size()).isZero();
+  }
+
+  @Test
+  void bothEmpty_producesEmptyArray() {
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), MAPPER.createObjectNode());
+
+    assertThat(diff.isArray()).isTrue();
+    assertThat(diff.size()).isZero();
+  }
+
+  @Test
+  void nestedChange_producesPathWithSlashSeparator() {
+    ObjectNode beforeDoc = MAPPER.createObjectNode();
+    beforeDoc.put("status", "draft");
+    ObjectNode before = MAPPER.createObjectNode();
+    before.set("doc", beforeDoc);
+
+    ObjectNode afterDoc = MAPPER.createObjectNode();
+    afterDoc.put("status", "published");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.set("doc", afterDoc);
+
+    JsonNode diff = strategy.compute(before, after);
+
+    // JSON Patch records /doc/status as the changed path
+    assertThat(findOp(diff, "replace", "/doc/status")).isNotNull();
+  }
+
+  /** Finds the first operation matching op type and path, or null. */
+  private JsonNode findOp(JsonNode patch, String op, String path) {
+    for (JsonNode node : patch) {
+      if (op.equals(node.path("op").asText()) && path.equals(node.path("path").asText())) {
+        return node;
+      }
+    }
+    return null;
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategyTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/diff/NoOpContextDiffStrategyTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class NoOpContextDiffStrategyTest {
+
+  private final NoOpContextDiffStrategy strategy = new NoOpContextDiffStrategy();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void alwaysReturnsNull_forEmptyNodes() {
+    assertThat(strategy.compute(MAPPER.createObjectNode(), MAPPER.createObjectNode())).isNull();
+  }
+
+  @Test
+  void alwaysReturnsNull_forNonEmptyNodes() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    assertThat(strategy.compute(before, after)).isNull();
+  }
+
+  @Test
+  void alwaysReturnsNull_regardlessOfContent() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    before.put("score", 10);
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+    after.put("score", 99);
+    after.put("newKey", "hello");
+
+    // NoOp returns null regardless of how much the context changed
+    assertThat(strategy.compute(before, after)).isNull();
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategyTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/diff/TopLevelContextDiffStrategyTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+/** Pure unit tests — no CDI, no Quarkus. TopLevelContextDiffStrategy is a stateless utility. */
+class TopLevelContextDiffStrategyTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final TopLevelContextDiffStrategy strategy = new TopLevelContextDiffStrategy();
+
+  // ---- Added keys -----------------------------------------------------------
+
+  @Test
+  void addedKey_hasAfterOnly_noBeforeField() {
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), after);
+
+    assertThat(diff.has("status")).isTrue();
+    assertThat(diff.get("status").get("after").asText()).isEqualTo("done");
+    assertThat(diff.get("status").has("before")).isFalse();
+  }
+
+  @Test
+  void addedObjectKey_capturesFullValue() {
+    ObjectNode afterDoc = MAPPER.createObjectNode();
+    afterDoc.put("id", "doc-1");
+    afterDoc.put("title", "Test");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.set("doc", afterDoc);
+
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), after);
+
+    assertThat(diff.get("doc").get("after").get("id").asText()).isEqualTo("doc-1");
+    assertThat(diff.get("doc").has("before")).isFalse();
+  }
+
+  // ---- Updated keys ---------------------------------------------------------
+
+  @Test
+  void updatedKey_hasBeforeAndAfter() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.get("status").get("before").asText()).isEqualTo("processing");
+    assertThat(diff.get("status").get("after").asText()).isEqualTo("done");
+  }
+
+  @Test
+  void updatedNumericKey_capturesNumericValues() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("score", 10);
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("score", 99);
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.get("score").get("before").asInt()).isEqualTo(10);
+    assertThat(diff.get("score").get("after").asInt()).isEqualTo(99);
+  }
+
+  // ---- Removed keys ---------------------------------------------------------
+
+  @Test
+  void removedKey_hasBeforeOnly_noAfterField() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("tempKey", "old-value");
+
+    JsonNode diff = strategy.compute(before, MAPPER.createObjectNode());
+
+    assertThat(diff.has("tempKey")).isTrue();
+    assertThat(diff.get("tempKey").get("before").asText()).isEqualTo("old-value");
+    assertThat(diff.get("tempKey").has("after")).isFalse();
+  }
+
+  @Test
+  void nullValueWritten_treatedAsRemoval_noAfterField() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("tempKey", "old-value");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.putNull("tempKey"); // worker explicitly sets null
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.has("tempKey")).isTrue();
+    assertThat(diff.get("tempKey").get("before").asText()).isEqualTo("old-value");
+    assertThat(diff.get("tempKey").has("after")).isFalse();
+  }
+
+  // ---- Unchanged keys -------------------------------------------------------
+
+  @Test
+  void unchangedKey_isOmittedFromDiff() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "done");
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.has("status")).isFalse();
+  }
+
+  @Test
+  void mixedContext_onlyChangedKeysAppear() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    before.put("unchanged", "same");
+
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+    after.put("unchanged", "same");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    assertThat(diff.has("status")).isTrue();
+    assertThat(diff.has("unchanged")).isFalse();
+  }
+
+  // ---- No changes -----------------------------------------------------------
+
+  @Test
+  void noChanges_returnsEmptyObject() {
+    ObjectNode both = MAPPER.createObjectNode();
+    both.put("status", "done");
+    both.put("result", "ok");
+
+    JsonNode diff = strategy.compute(both, both);
+
+    assertThat(diff.size()).isZero();
+    assertThat(diff.isObject()).isTrue();
+  }
+
+  @Test
+  void bothEmpty_returnsEmptyObject() {
+    JsonNode diff = strategy.compute(MAPPER.createObjectNode(), MAPPER.createObjectNode());
+
+    assertThat(diff.size()).isZero();
+  }
+
+  // ---- Multiple simultaneous changes ----------------------------------------
+
+  @Test
+  void multipleChanges_allCaptured() {
+    ObjectNode before = MAPPER.createObjectNode();
+    before.put("status", "processing");
+    before.put("toRemove", "bye");
+
+    ObjectNode after = MAPPER.createObjectNode();
+    after.put("status", "done");
+    after.put("newKey", "hello");
+
+    JsonNode diff = strategy.compute(before, after);
+
+    // updated
+    assertThat(diff.get("status").get("before").asText()).isEqualTo("processing");
+    assertThat(diff.get("status").get("after").asText()).isEqualTo("done");
+    // added
+    assertThat(diff.get("newKey").get("after").asText()).isEqualTo("hello");
+    assertThat(diff.get("newKey").has("before")).isFalse();
+    // removed
+    assertThat(diff.get("toRemove").get("before").asText()).isEqualTo("bye");
+    assertThat(diff.get("toRemove").has("after")).isFalse();
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/internal/engine/ExpressionEngineRegistryTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/engine/ExpressionEngineRegistryTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
-import io.casehub.engine.internal.context.StateContextImpl;
+import io.casehub.engine.internal.context.CaseContextImpl;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.Map;
@@ -43,14 +43,14 @@ class ExpressionEngineRegistryTest {
     @Test
     @DisplayName("returns true for null evaluator")
     void nullEvaluator_returnsTrue() {
-      final var context = new StateContextImpl(Map.of());
+      final var context = new CaseContextImpl(Map.of());
       assertTrue(registry.evaluate(null, context));
     }
 
     @Test
     @DisplayName("JQ — returns true when expression matches context")
     void jq_returnsTrueOnMatch() {
-      final var context = new StateContextImpl(Map.of("status", "ready"));
+      final var context = new CaseContextImpl(Map.of("status", "ready"));
       final var evaluator = new JQExpressionEvaluator(".status == \"ready\"");
       assertTrue(registry.evaluate(evaluator, context));
     }
@@ -58,7 +58,7 @@ class ExpressionEngineRegistryTest {
     @Test
     @DisplayName("JQ — returns false when expression does not match context")
     void jq_returnsFalseOnNoMatch() {
-      final var context = new StateContextImpl(Map.of("status", "pending"));
+      final var context = new CaseContextImpl(Map.of("status", "pending"));
       final var evaluator = new JQExpressionEvaluator(".status == \"ready\"");
       assertFalse(registry.evaluate(evaluator, context));
     }
@@ -66,7 +66,7 @@ class ExpressionEngineRegistryTest {
     @Test
     @DisplayName("JQ — returns true for null expression (treat as always-match)")
     void jq_nullExpression_returnsTrue() {
-      final var context = new StateContextImpl(Map.of());
+      final var context = new CaseContextImpl(Map.of());
       final var evaluator = new JQExpressionEvaluator(null);
       assertTrue(registry.evaluate(evaluator, context));
     }
@@ -74,7 +74,7 @@ class ExpressionEngineRegistryTest {
     @Test
     @DisplayName("JQ — returns true for blank expression (treat as always-match)")
     void jq_blankExpression_returnsTrue() {
-      final var context = new StateContextImpl(Map.of());
+      final var context = new CaseContextImpl(Map.of());
       final var evaluator = new JQExpressionEvaluator("   ");
       assertTrue(registry.evaluate(evaluator, context));
     }
@@ -82,7 +82,7 @@ class ExpressionEngineRegistryTest {
     @Test
     @DisplayName("Lambda — returns true when predicate matches")
     void lambda_returnsTrueOnMatch() {
-      final var context = new StateContextImpl(Map.of("score", 10));
+      final var context = new CaseContextImpl(Map.of("score", 10));
       final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("score") != null);
       assertTrue(registry.evaluate(evaluator, context));
     }
@@ -90,7 +90,7 @@ class ExpressionEngineRegistryTest {
     @Test
     @DisplayName("Lambda — returns false when predicate does not match")
     void lambda_returnsFalseOnNoMatch() {
-      final var context = new StateContextImpl(Map.of());
+      final var context = new CaseContextImpl(Map.of());
       final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("score") != null);
       assertFalse(registry.evaluate(evaluator, context));
     }
@@ -98,7 +98,7 @@ class ExpressionEngineRegistryTest {
     @Test
     @DisplayName("throws IllegalArgumentException for unregistered evaluator type")
     void unknownType_throws() {
-      final var context = new StateContextImpl(Map.of());
+      final var context = new CaseContextImpl(Map.of());
       final var unknown =
           new io.casehub.api.model.evaluator.ExpressionEvaluator() {
             @Override

--- a/engine/src/test/java/io/casehub/engine/internal/evaluator/LambdaExpressionEvaluatorTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/evaluator/LambdaExpressionEvaluatorTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.casehub.api.model.evaluator.LambdaExpressionEvaluator;
-import io.casehub.engine.internal.context.StateContextImpl;
+import io.casehub.engine.internal.context.CaseContextImpl;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +39,7 @@ class LambdaExpressionEvaluatorTest {
   @Test
   @DisplayName("test() returns true when predicate matches")
   void test_returnsTrueWhenPredicateMatches() {
-    final var context = new StateContextImpl(Map.of("status", "ready"));
+    final var context = new CaseContextImpl(Map.of("status", "ready"));
     final var evaluator = new LambdaExpressionEvaluator(ctx -> "ready".equals(ctx.get("status")));
 
     assertTrue(evaluator.test(context));
@@ -48,7 +48,7 @@ class LambdaExpressionEvaluatorTest {
   @Test
   @DisplayName("test() returns false when predicate does not match")
   void test_returnsFalseWhenPredicateDoesNotMatch() {
-    final var context = new StateContextImpl(Map.of("status", "pending"));
+    final var context = new CaseContextImpl(Map.of("status", "pending"));
     final var evaluator = new LambdaExpressionEvaluator(ctx -> "ready".equals(ctx.get("status")));
 
     assertFalse(evaluator.test(context));
@@ -57,7 +57,7 @@ class LambdaExpressionEvaluatorTest {
   @Test
   @DisplayName("test() receives the exact context passed in")
   void test_receivesExactContext() {
-    final var context = new StateContextImpl(Map.of("count", 42));
+    final var context = new CaseContextImpl(Map.of("count", 42));
     final var evaluator = new LambdaExpressionEvaluator(ctx -> ctx.get("count") != null);
 
     assertTrue(evaluator.test(context));

--- a/engine/src/test/java/io/casehub/engine/model/ModelBuilderTest.java
+++ b/engine/src/test/java/io/casehub/engine/model/ModelBuilderTest.java
@@ -280,8 +280,6 @@ class ModelBuilderTest {
     @Test
     @DisplayName("null ExpressionEvaluator condition throws NullPointerException")
     void nullEvaluatorCondition_throws() {
-      // condition(String null) wraps null in JQExpressionEvaluator (non-null object) — that path
-      // does not throw. condition(ExpressionEvaluator) with null does hit requireNonNull at build.
       assertThrows(
           NullPointerException.class,
           () ->
@@ -289,6 +287,14 @@ class ModelBuilderTest {
                   .name("m")
                   .condition((io.casehub.api.model.evaluator.ExpressionEvaluator) null)
                   .build());
+    }
+
+    @Test
+    @DisplayName("null String condition throws NullPointerException")
+    void nullStringCondition_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Milestone.builder().name("m").condition((String) null).build());
     }
 
     @Test
@@ -340,6 +346,31 @@ class ModelBuilderTest {
           Milestone.builder().name("m").condition(".x == true").description("my milestone").build();
       assertEquals("my milestone", m.getDescription());
     }
+
+    @Test
+    @DisplayName("condition(Predicate) creates LambdaExpressionEvaluator")
+    void conditionPredicate_createsLambdaEvaluator() {
+      final var m =
+          Milestone.builder()
+              .name("m")
+              .condition((io.casehub.api.context.CaseContext ctx) -> true)
+              .build();
+      assertInstanceOf(
+          io.casehub.api.model.evaluator.LambdaExpressionEvaluator.class, m.getCondition());
+    }
+
+    @Test
+    @DisplayName("null Predicate condition throws NullPointerException")
+    void nullPredicateCondition_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              Milestone.builder()
+                  .name("m")
+                  .condition(
+                      (java.util.function.Predicate<io.casehub.api.context.CaseContext>) null)
+                  .build());
+    }
   }
 
   // ================================================================== //
@@ -361,8 +392,6 @@ class ModelBuilderTest {
     @Test
     @DisplayName("null ExpressionEvaluator condition throws NullPointerException")
     void nullEvaluatorCondition_throws() {
-      // condition(String null) wraps null in JQExpressionEvaluator (non-null object) so does not
-      // throw. Passing a null ExpressionEvaluator directly hits requireNonNull at build time.
       assertThrows(
           NullPointerException.class,
           () ->
@@ -371,6 +400,14 @@ class ModelBuilderTest {
                   .condition((io.casehub.api.model.evaluator.ExpressionEvaluator) null)
                   .kind(GoalKind.SUCCESS)
                   .build());
+    }
+
+    @Test
+    @DisplayName("null String condition throws NullPointerException")
+    void nullStringCondition_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Goal.builder().name("g").condition((String) null).kind(GoalKind.SUCCESS).build());
     }
 
     @Test
@@ -449,6 +486,33 @@ class ModelBuilderTest {
       final var failure =
           Goal.builder().name("g").condition(".x == true").kind(GoalKind.FAILURE).build();
       assertNotEquals(success, failure);
+    }
+
+    @Test
+    @DisplayName("condition(Predicate) creates LambdaExpressionEvaluator")
+    void conditionPredicate_createsLambdaEvaluator() {
+      final var g =
+          Goal.builder()
+              .name("g")
+              .condition((io.casehub.api.context.CaseContext ctx) -> true)
+              .kind(GoalKind.SUCCESS)
+              .build();
+      assertInstanceOf(
+          io.casehub.api.model.evaluator.LambdaExpressionEvaluator.class, g.getCondition());
+    }
+
+    @Test
+    @DisplayName("null Predicate condition throws NullPointerException")
+    void nullPredicateCondition_throws() {
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              Goal.builder()
+                  .name("g")
+                  .condition(
+                      (java.util.function.Predicate<io.casehub.api.context.CaseContext>) null)
+                  .kind(GoalKind.SUCCESS)
+                  .build());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <module>codegen</module>
         <module>schema</module>
         <module>engine</module>
+        <module>casehub-blackboard</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <module>schema</module>
         <module>engine</module>
         <module>casehub-blackboard</module>
+        <module>casehub-resilience</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

Adds three repository SPI interfaces to `engine/src/main/java/io/casehub/engine/spi/`:

- `CaseMetaModelRepository` — `findByKey` + `save`
- `CaseInstanceRepository` — `save` + `update` + `findByUuid`
- `EventLogRepository` — `append`, `appendAndReturnId`, `findById`, `findSchedulingEvents`, `findByTypes`, `findByCaseAndTypes`, `findByCaseAndWorkerAndType`

All methods return `Uni<T>` consistent with the engine's reactive model. No implementations here — this PR is the contract only.

## Why

Part of persistence decoupling (issue #55). The engine currently calls Panache directly in every handler, making every `@QuarkusTest` require a real PostgreSQL container. These interfaces let persistence be swapped: JPA for production, in-memory for tests.

## Stacked on

Base: `feat/rename-binding-casedefinition`
Next: `feat/persistence/hibernate-entities` (module scaffold + JPA entity classes)

Refs #55

🤖 Generated with [Claude Code](https://claude.ai/claude-code)