### PR TITLE
feat(engine): add repository SPI interfaces for persistence decoupling

### DIFF
--- a/engine/src/main/java/io/casehub/engine/spi/CaseInstanceRepository.java
+++ b/engine/src/main/java/io/casehub/engine/spi/CaseInstanceRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.spi;
+
+import io.casehub.engine.internal.model.CaseInstance;
+import io.smallrye.mutiny.Uni;
+import java.util.UUID;
+
+public interface CaseInstanceRepository {
+
+  /** Persist a new case instance. Returns the saved instance with id populated. */
+  Uni<CaseInstance> save(CaseInstance instance);
+
+  /** Merge state changes back to storage (status transitions). */
+  Uni<CaseInstance> update(CaseInstance instance);
+
+  /**
+   * Load a case instance by UUID with its CaseMetaModel eagerly joined. Returns null if not found.
+   */
+  Uni<CaseInstance> findByUuid(UUID uuid);
+}

--- a/engine/src/main/java/io/casehub/engine/spi/CaseMetaModelRepository.java
+++ b/engine/src/main/java/io/casehub/engine/spi/CaseMetaModelRepository.java
@@ -20,7 +20,7 @@ import io.smallrye.mutiny.Uni;
 
 public interface CaseMetaModelRepository {
 
-  /** Find by the unique (namespace, name, version) key. Returns null if not registered. */
+  /** Find by the unique (namespace, name, version) key. Returns null if not found. */
   Uni<CaseMetaModel> findByKey(String namespace, String name, String version);
 
   /** Persist a new case meta model. Returns the saved instance with id populated. */

--- a/engine/src/main/java/io/casehub/engine/spi/CaseMetaModelRepository.java
+++ b/engine/src/main/java/io/casehub/engine/spi/CaseMetaModelRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.spi;
+
+import io.casehub.engine.internal.model.CaseMetaModel;
+import io.smallrye.mutiny.Uni;
+
+public interface CaseMetaModelRepository {
+
+  /** Find by the unique (namespace, name, version) key. Returns null if not registered. */
+  Uni<CaseMetaModel> findByKey(String namespace, String name, String version);
+
+  /** Persist a new case meta model. Returns the saved instance with id populated. */
+  Uni<CaseMetaModel> save(CaseMetaModel metaModel);
+}

--- a/engine/src/main/java/io/casehub/engine/spi/EventLogRepository.java
+++ b/engine/src/main/java/io/casehub/engine/spi/EventLogRepository.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.spi;
+
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.smallrye.mutiny.Uni;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public interface EventLogRepository {
+
+  /** Append an event to the log. Populates eventLog.id and eventLog.seq after append. */
+  Uni<Void> append(EventLog eventLog);
+
+  /**
+   * Append an event and flush, returning the generated id. Used by WorkerScheduleEventHandler to
+   * get the id before scheduling a Quartz job.
+   */
+  Uni<Long> appendAndReturnId(EventLog eventLog);
+
+  /** Load an event by id. Returns null if not found. */
+  Uni<EventLog> findById(Long id);
+
+  /**
+   * Find WORKER_SCHEDULED, WORKER_EXECUTION_STARTED, and WORKER_EXECUTION_COMPLETED events for a
+   * specific case+worker. Used by WorkerScheduleEventHandler for idempotency checking.
+   */
+  Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId);
+
+  /**
+   * Find all events matching any of the given types, ordered by seq ascending. Used by
+   * WorkerExecutionRecoveryService to find pending scheduled workers on startup.
+   */
+  Uni<List<EventLog>> findByTypes(Collection<CaseHubEventType> types);
+
+  /**
+   * Find events for a specific case matching any of the given types, ordered by seq ascending. Used
+   * by WorkerExecutionRecoveryService to rebuild CaseContext state.
+   */
+  Uni<List<EventLog>> findByCaseAndTypes(UUID caseId, Collection<CaseHubEventType> types);
+
+  /**
+   * Find events for a specific case+worker of a specific type. Used by WorkerExecutionJobListener
+   * to count failed attempts for retry logic.
+   */
+  Uni<List<EventLog>> findByCaseAndWorkerAndType(
+      UUID caseId, String workerId, CaseHubEventType type);
+}


### PR DESCRIPTION
## Summary

Adds three repository SPI interfaces to `engine/src/main/java/io/casehub/engine/spi/`:

- `CaseMetaModelRepository` — `findByKey` + `save`
- `CaseInstanceRepository` — `save` + `update` + `findByUuid`
- `EventLogRepository` — 7 methods covering append, find-by-id, and various filtered queries

All methods return `Uni<T>` consistent with the engine's reactive model. No implementations in this PR — contract only.

## Why

Part of persistence decoupling (issue #55). The engine currently calls Panache directly in every handler, making every `@QuarkusTest` require a real PostgreSQL container. These interfaces allow persistence to be swapped: JPA for production, in-memory for tests.

## Stack

- **This PR** → `main`
- Next: module scaffold + JPA entities
- Next: JPA repository implementations + tests

Refs #55
🤖 Generated with [Claude Code](https://claude.ai/claude-code)