### PR TITLE
feat(persistence-hibernate): scaffold module + JPA entity classes

### DIFF
--- a/casehub-persistence-hibernate/pom.xml
+++ b/casehub-persistence-hibernate/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.casehub</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>casehub-persistence-hibernate</artifactId>
+    <name>Case Hub :: Persistence :: Hibernate</name>
+    <description>JPA entity classes and Hibernate Reactive repository implementations for the engine SPI</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-reactive-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-pg-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/CaseInstanceEntity.java
+++ b/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/CaseInstanceEntity.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.persistence.jpa;
+
+import io.casehub.api.model.CaseStatus;
+import io.quarkus.hibernate.reactive.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@DynamicUpdate
+@Table(name = "case_instance")
+public class CaseInstanceEntity extends PanacheEntity {
+
+  @Column(name = "uuid", nullable = false, unique = true, updatable = false)
+  public UUID uuid;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "state", nullable = false)
+  public CaseStatus state;
+
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "case_definition_id", nullable = false)
+  public CaseMetaModelEntity caseMetaModel;
+
+  @Column(name = "parent_plan_item_id", nullable = true)
+  public UUID parentPlanItemId;
+}

--- a/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/CaseInstanceEntity.java
+++ b/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/CaseInstanceEntity.java
@@ -37,7 +37,7 @@ public class CaseInstanceEntity extends PanacheEntity {
   public UUID uuid;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "state", nullable = false)
+  @Column(name = "state", nullable = false, length = 50)
   public CaseStatus state;
 
   @ManyToOne(fetch = FetchType.EAGER)

--- a/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/CaseMetaModelEntity.java
+++ b/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/CaseMetaModelEntity.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.persistence.jpa;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkus.hibernate.reactive.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(
+    name = "case_meta_model",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"namespace", "name", "version"})})
+public class CaseMetaModelEntity extends PanacheEntity {
+
+  @Column(nullable = false, length = 255)
+  public String name;
+
+  @Column(length = 255)
+  public String namespace;
+
+  @Column(nullable = false, length = 50)
+  public String version;
+
+  @Column(length = 500)
+  public String title;
+
+  @Column(length = 50)
+  public String dsl;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb")
+  public JsonNode definition;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  public Instant createdAt;
+}

--- a/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/EventLogEntity.java
+++ b/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/EventLogEntity.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.persistence.jpa;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventStreamType;
+import io.quarkus.hibernate.reactive.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.generator.EventType;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "event_log")
+public class EventLogEntity extends PanacheEntity {
+
+  @Column(
+      name = "seq",
+      nullable = false,
+      updatable = false,
+      insertable = false,
+      columnDefinition = "BIGINT GENERATED ALWAYS AS IDENTITY")
+  @Generated(event = EventType.INSERT)
+  public Long seq;
+
+  @Column(name = "case_id", nullable = false, updatable = false)
+  public UUID caseId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "event_type", nullable = false, length = 255)
+  public CaseHubEventType eventType;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "stream_type", nullable = false, length = 255)
+  public EventStreamType streamType;
+
+  @Column(name = "worker_id", nullable = true, length = 255)
+  public String workerId;
+
+  @Column(name = "timestamp", nullable = false)
+  public Instant timestamp;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "payload", columnDefinition = "jsonb")
+  public JsonNode payload;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "metadata", columnDefinition = "jsonb")
+  public JsonNode metadata;
+}

--- a/casehub-persistence-hibernate/src/main/resources/application.properties
+++ b/casehub-persistence-hibernate/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+# Schema validation — Flyway manages DDL, Hibernate validates on startup
+quarkus.hibernate-orm.schema-management.strategy=validate
+
+# Flyway: migrate at start; SQL files arrive from engine JAR on classpath
+quarkus.flyway.migrate-at-start=true
+quarkus.flyway.baseline-version=0
+quarkus.flyway.baseline-on-migrate=true

--- a/casehub-persistence-hibernate/src/test/resources/application.properties
+++ b/casehub-persistence-hibernate/src/test/resources/application.properties
@@ -1,0 +1,14 @@
+# Test: clean DB before each test class startup so migrations always run on a fresh schema
+%test.quarkus.flyway.clean-at-start=true
+
+# Suppress Hibernate mapping format warnings in tests
+%test.quarkus.hibernate-orm.mapping.format.global=ignore
+
+# Index the api module (needed for CaseStatus enum used in entity mappings).
+# Do NOT index the engine module: its @Entity classes (CaseMetaModel, CaseInstance, EventLog)
+# map to the same tables as our *Entity classes. Indexing both would cause Hibernate to
+# discover duplicate entity mappings and fail to start.
+# Flyway still finds migration SQL files from the engine JAR via classpath:db/migration
+# regardless of this indexing setting.
+quarkus.index-dependency.api.group-id=io.casehub
+quarkus.index-dependency.api.artifact-id=api

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
         <module>engine</module>
         <module>casehub-blackboard</module>
         <module>casehub-resilience</module>
+        <module>casehub-persistence-hibernate</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

- Adds `casehub-persistence-hibernate` Maven module (pom.xml, Flyway + Hibernate config, test config)
- Adds three JPA entity classes in `io.casehub.persistence.jpa`:
  - `CaseMetaModelEntity` — maps `case_meta_model`
  - `CaseInstanceEntity` — maps `case_instance` (`@DynamicUpdate`)
  - `EventLogEntity` — maps `event_log` (`seq` via `@Generated INSERT`)

## Design

Entity classes are **separate from engine domain POJOs**. This avoids `LazyInitializationException` when domain objects live outside session boundaries (e.g. `CaseInstanceCache`) — per Francisco Javier Tirado Sarti's advice, following the quarkus-flow convention.

The test `application.properties` deliberately does **not** index the engine module — otherwise Hibernate would discover both the existing domain `@Entity` classes and the new `*Entity` classes mapping to the same tables and fail to start.

## Stack

- Previous: SPI interfaces (#65)
- **This PR** → `feat/persistence/spi`
- Next: JPA repository implementations + tests

Refs #55
🤖 Generated with [Claude Code](https://claude.ai/claude-code)