### PR TITLE
Serialize concurrent signal processing with Vert.x local lock

### DIFF
--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -51,10 +51,17 @@ class CaseHubReactor {
 
   CompletionStage<UUID> startCase(CaseDefinition definition, CaseContext context) {
     return getCaseInstance(definition, context)
-        .invoke(
+        .chain(
             instance -> {
               LOG.info("Case started with caseId: " + instance.getUuid());
-              eventBus.publish(CASE_STARTED, new CaseStartedEvent(instance));
+              // Use request() instead of publish() so the CompletionStage resolves only after
+              // CaseStartedEventHandler has finished — context snapshot taken, CASE_STARTED
+              // persisted, CONTEXT_CHANGED published. publish() is fire-and-forget and resolves
+              // before the handler runs, creating a race window for callers that mutate the
+              // context immediately after startCase() returns.
+              return eventBus
+                  .<Void>request(CASE_STARTED, new CaseStartedEvent(instance))
+                  .replaceWith(instance);
             })
         .onItem()
         .transform(CaseInstance::getUuid)

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
@@ -31,7 +31,9 @@ import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.spi.EventLogRepository;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.eventbus.EventBus;
+import io.vertx.mutiny.core.shareddata.Lock;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Instant;
@@ -47,6 +49,8 @@ public class SignalReceivedEventHandler {
 
   private static final Logger LOG = Logger.getLogger(SignalReceivedEventHandler.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Inject Vertx vertx;
 
   @Inject EventBus eventBus;
 
@@ -69,8 +73,25 @@ public class SignalReceivedEventHandler {
   }
 
   private Uni<Void> applySignal(CaseInstance instance, SignalReceivedEvent event) {
-    Optional<JsonNode> maybeDiff =
-        instance.getCaseContext().applyAndDiff(event.path(), event.value());
+    // One lock per (caseId, path): concurrent signals to the same field are serialized so that
+    // the second signal always sees the context state written by the first one.
+    String lockKey = "signal:" + instance.getUuid() + ":" + event.path();
+    return vertx
+        .sharedData()
+        .getLocalLock(lockKey)
+        .chain(lock -> applySignalUnderLock(instance, event, lock));
+  }
+
+  private Uni<Void> applySignalUnderLock(
+      CaseInstance instance, SignalReceivedEvent event, Lock lock) {
+    Optional<JsonNode> maybeDiff;
+    try {
+      maybeDiff = instance.getCaseContext().applyAndDiff(event.path(), event.value());
+    } finally {
+      // Release immediately: the lock only needs to protect the in-memory context update.
+      // The subsequent DB transaction does not need to be serialized here.
+      lock.release();
+    }
 
     if (maybeDiff.isEmpty()) {
       LOG.debugf(

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -29,15 +29,17 @@ import io.casehub.engine.internal.history.EventStreamType;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.util.WorkerExecutionKeys;
 import io.casehub.engine.internal.worker.WorkerExecutionManager;
+import io.casehub.engine.spi.EventLogRepository;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import io.vertx.mutiny.core.shareddata.Lock;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Instant;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -46,41 +48,61 @@ public class WorkerScheduleEventHandler {
   private static final Logger LOG = Logger.getLogger(WorkerScheduleEventHandler.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+  @Inject Vertx vertx;
+
   @Inject WorkerExecutionManager workflowExecutionManager;
 
   @Inject WorkerExecutionGuard workerExecutionGuard;
 
-  @Inject io.vertx.mutiny.core.eventbus.EventBus eventBus;
+  @Inject EventBus eventBus;
 
-  @Inject io.casehub.engine.spi.EventLogRepository eventLogRepository;
+  @Inject EventLogRepository eventLogRepository;
 
   @ConsumeEvent(value = EventBusAddresses.WORKER_SCHEDULE)
   public Uni<Void> onWorkerScheduleEventHandler(WorkerScheduleEvent event) {
     CaseInstance instance = event.caseInstance();
     Worker worker = event.worker();
+    String inputDataHash =
+        WorkerExecutionKeys.inputDataHash(
+            worker.getName(),
+            event.capability().getName(),
+            instance.getCaseContext().evalObjectTemplate(event.capability().getInputSchema()));
 
     if (workerExecutionGuard.isBlocked(worker.getName(), instance.getUuid())) {
       LOG.warnf(
           "Worker blocked by guard (quarantined?): caseId=%s worker=%s — emitting retries exhausted",
           instance.getUuid(), worker.getName());
-      String idempotency =
-          io.casehub.engine.internal.util.WorkerExecutionKeys.inputDataHash(
-              worker.getName(),
-              event.capability().getName(),
-              instance.getCaseContext().evalObjectTemplate(event.capability().getInputSchema()));
       eventBus.publish(
           EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
-          new WorkerRetriesExhaustedEvent(instance.getUuid(), worker.getName(), idempotency));
+          new WorkerRetriesExhaustedEvent(instance.getUuid(), worker.getName(), inputDataHash));
       return Uni.createFrom().voidItem();
     }
     Capability capability = event.capability();
 
     Map<String, Object> inputData =
         instance.getCaseContext().evalObjectTemplate(capability.getInputSchema());
-    String inputDataHash =
-        WorkerExecutionKeys.inputDataHash(worker.getName(), capability.getName(), inputData);
+
     EventLog eventLog = buildEventLog(instance, worker, capability, inputData, inputDataHash);
 
+    String lockKey = "wse:" + instance.getUuid() + ":" + worker.getName() + ":" + inputDataHash;
+
+    return vertx
+        .sharedData()
+        .getLocalLock(lockKey)
+        .chain(
+            lock ->
+                scheduleUnderLock(
+                    lock, eventLog, instance, worker, capability, inputData, inputDataHash));
+  }
+
+  private Uni<Void> scheduleUnderLock(
+      Lock lock,
+      EventLog eventLog,
+      CaseInstance instance,
+      Worker worker,
+      Capability capability,
+      Map<String, Object> inputData,
+      String inputDataHash) {
     return eventLogRepository
         .findSchedulingEvents(instance.getUuid(), worker.getName())
         .map(existing -> decideAction(existing, inputDataHash))
@@ -91,6 +113,7 @@ public class WorkerScheduleEventHandler {
                 LOG.infof(
                     "WorkerScheduleEvent processed: caseId=%s worker=%s capability=%s",
                     instance.getUuid(), worker.getName(), capability.getName()))
+        .invoke(lock::release)
         .replaceWithVoid()
         .onFailure()
         .invoke(
@@ -100,7 +123,8 @@ public class WorkerScheduleEventHandler {
                     "WorkerScheduleEvent FAILED: caseId=%s worker=%s capability=%s",
                     instance.getUuid(),
                     worker.getName(),
-                    capability.getName()));
+                    capability.getName()))
+        .invoke(lock::release);
   }
 
   private EventLog buildEventLog(
@@ -135,15 +159,9 @@ public class WorkerScheduleEventHandler {
     return switch (action.type()) {
       case SKIP -> {
         LOG.infof(
-            "Skipping WorkerScheduleEvent: already started/completed caseId=%s worker=%s capability=%s",
+            "Skipping WorkerScheduleEvent: already scheduled/started/completed caseId=%s worker=%s capability=%s",
             instance.getUuid(), worker.getName(), capability.getName());
         yield Uni.createFrom().nullItem();
-      }
-      case RESUBMIT_EXISTING -> {
-        LOG.infof(
-            "Re-submitting existing scheduled worker: caseId=%s worker=%s capability=%s eventLogId=%d",
-            instance.getUuid(), worker.getName(), capability.getName(), action.eventLogId());
-        yield Uni.createFrom().item(action.eventLogId());
       }
       case CREATE_NEW -> eventLogRepository.appendAndReturnId(eventLog);
     };
@@ -172,35 +190,26 @@ public class WorkerScheduleEventHandler {
                 })
             .toList();
 
-    boolean alreadyStartedOrCompleted =
+    boolean alreadyScheduledOrStartedOrCompleted =
         sameInputEvents.stream()
             .anyMatch(
                 eventLog ->
-                    eventLog.getEventType() == CaseHubEventType.WORKER_EXECUTION_STARTED
+                    eventLog.getEventType() == CaseHubEventType.WORKER_SCHEDULED
+                        || eventLog.getEventType() == CaseHubEventType.WORKER_EXECUTION_STARTED
                         || eventLog.getEventType() == CaseHubEventType.WORKER_EXECUTION_COMPLETED);
-    if (alreadyStartedOrCompleted) {
+    if (alreadyScheduledOrStartedOrCompleted) {
+      // Live duplicate schedule events must not re-submit the same Quartz job.
+      // If a WORKER_SCHEDULED event was persisted but never executed due to a crash,
+      // WorkerExecutionRecoveryService is responsible for replaying it.
       return ScheduleAction.skip();
     }
-
-    Optional<Long> existingScheduledId =
-        sameInputEvents.stream()
-            .filter(eventLog -> eventLog.getEventType() == CaseHubEventType.WORKER_SCHEDULED)
-            .max(Comparator.comparing(eventLog -> eventLog.id))
-            .map(eventLog -> eventLog.id);
-
-    return existingScheduledId
-        .map(ScheduleAction::resubmitExisting)
-        .orElseGet(ScheduleAction::createNew);
+    return ScheduleAction.createNew();
   }
 
   private record ScheduleAction(ScheduleActionType type, Long eventLogId) {
 
     static ScheduleAction skip() {
       return new ScheduleAction(ScheduleActionType.SKIP, null);
-    }
-
-    static ScheduleAction resubmitExisting(Long eventLogId) {
-      return new ScheduleAction(ScheduleActionType.RESUBMIT_EXISTING, eventLogId);
     }
 
     static ScheduleAction createNew() {
@@ -210,7 +219,6 @@ public class WorkerScheduleEventHandler {
 
   private enum ScheduleActionType {
     SKIP,
-    RESUBMIT_EXISTING,
     CREATE_NEW
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/event/WorkerRetriesExhaustedEvent.java
+++ b/engine/src/main/java/io/casehub/engine/internal/event/WorkerRetriesExhaustedEvent.java
@@ -15,5 +15,6 @@
  */
 package io.casehub.engine.internal.event;
 
-public record WorkerRetriesExhaustedEvent(
-    java.util.UUID caseId, String workerId, String idempotency) {}
+import java.util.UUID;
+
+public record WorkerRetriesExhaustedEvent(UUID caseId, String workerId, String idempotency) {}

--- a/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionScheduler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionScheduler.java
@@ -34,11 +34,9 @@ public class WorkerExecutionScheduler {
     try {
       quartz.scheduleJob(job, trigger);
     } catch (ObjectAlreadyExistsException e) {
-      try {
-        quartz.rescheduleJob(trigger.getKey(), trigger);
-      } catch (SchedulerException ex) {
-        throw new RuntimeException("Quartz scheduling failed for jobKey=" + job.getKey(), ex);
-      }
+      // Job is already queued in Quartz — it will execute once. Rescheduling would fire it
+      // a second time, which is wrong. The idempotency key guarantees one execution per
+      // distinct (worker, capability, inputDataHash) combination.
     } catch (SchedulerException e) {
       throw new RuntimeException("Quartz scheduling failed for jobKey=" + job.getKey(), e);
     }

--- a/engine/src/test/java/io/casehub/engine/SignalDedupExtendedTest.java
+++ b/engine/src/test/java/io/casehub/engine/SignalDedupExtendedTest.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class SignalDedupExtendedTest {
+
+  @Inject SignalDedupBean bean;
+
+  @Inject SignalDedupWithGoalBean goalBean;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @BeforeEach
+  void reset() {
+    SignalDedupBean.runCount.set(0);
+    SignalDedupBean.runCountById.clear();
+    SignalDedupWithGoalBean.runCount.set(0);
+    SignalDedupWithGoalBean.runCountById.clear();
+  }
+
+  // ------------------------------------------------------------------ //
+
+  /** Three rapid identical signals must produce exactly one worker execution. */
+  @Test
+  void tripleIdenticalSignalsRunWorkerOnce() {
+    String id = "triple-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("id", id)).toCompletableFuture().join();
+
+    bean.signal(caseId, "event", Map.of("type", "click", "source", "button"));
+    bean.signal(caseId, "event", Map.of("type", "click", "source", "button"));
+    bean.signal(caseId, "event", Map.of("type", "click", "source", "button"));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get(),
+                    "Worker must run exactly once despite three identical signals"));
+  }
+
+  /** Five rapid identical signals must produce exactly one worker execution. */
+  @Test
+  void fiveIdenticalSignalsRunWorkerOnce() {
+    String id = "five-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("id", id)).toCompletableFuture().join();
+    Map<String, Object> value = Map.of("amount", 100, "currency", "USD");
+
+    for (int i = 0; i < 5; i++) {
+      bean.signal(caseId, "event", value);
+    }
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get(),
+                    "Worker must run exactly once despite five identical signals"));
+  }
+
+  /**
+   * After the first worker run the signal value is already in the context. Re-sending the same
+   * value produces an empty diff → no CONTEXT_CHANGED published → worker not re-triggered.
+   */
+  @Test
+  void sameSignalValueResendProducesNoContextDiffAndDoesNotRetrigger() {
+    String id = "resend-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("id", id)).toCompletableFuture().join();
+    Map<String, Object> value = Map.of("type", "APPROVED");
+
+    bean.signal(caseId, "event", value);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1, SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get()));
+
+    // Re-send the same value — context unchanged, no CONTEXT_CHANGED, no new scheduling
+    bean.signal(caseId, "event", value);
+
+    await()
+        .during(2, TimeUnit.SECONDS)
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get(),
+                    "Worker must not re-run when the same value is re-signaled"));
+  }
+
+  /** Two identical primitive-integer signals must be deduplicated to a single worker execution. */
+  @Test
+  void identicalPrimitiveIntegerSignalsDeduplicated() {
+    String id = "int-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("id", id)).toCompletableFuture().join();
+
+    bean.signal(caseId, "event", 42);
+    bean.signal(caseId, "event", 42);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get(),
+                    "Worker must run exactly once for duplicate primitive-integer signal"));
+  }
+
+  /** Two identical string signals must be deduplicated to a single worker execution. */
+  @Test
+  void identicalStringSignalsDeduplicated() {
+    String id = "str-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("id", id)).toCompletableFuture().join();
+
+    bean.signal(caseId, "event", "CONFIRMED");
+    bean.signal(caseId, "event", "CONFIRMED");
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get(),
+                    "Worker must run exactly once for duplicate string signal"));
+  }
+
+  /**
+   * Two independent cases both receive the same signal path and value. Each case's worker must run
+   * exactly once and their run counts must be fully isolated.
+   */
+  @Test
+  void twoCasesWithSameSignalRunIsolated() {
+    String id1 = "iso-1-" + UUID.randomUUID();
+    String id2 = "iso-2-" + UUID.randomUUID();
+
+    UUID caseId1 = bean.startCase(Map.of("id", id1)).toCompletableFuture().join();
+    UUID caseId2 = bean.startCase(Map.of("id", id2)).toCompletableFuture().join();
+
+    Map<String, Object> value = Map.of("type", "SHARED_EVENT");
+
+    bean.signal(caseId1, "event", value);
+    bean.signal(caseId2, "event", value);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  1,
+                  SignalDedupBean.runCountById.getOrDefault(id1, new AtomicInteger()).get(),
+                  "Case 1 worker must run exactly once");
+              assertEquals(
+                  1,
+                  SignalDedupBean.runCountById.getOrDefault(id2, new AtomicInteger()).get(),
+                  "Case 2 worker must run exactly once");
+            });
+  }
+
+  /** Signaling a path that no binding watches must not trigger any worker. */
+  @Test
+  void signalToUnboundPathDoesNotTriggerWorker() {
+    String id = "unbound-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("id", id)).toCompletableFuture().join();
+
+    // `event` is the bound path; `unrelated` is referenced by no binding
+    bean.signal(caseId, "unrelated", Map.of("type", "IGNORED"));
+    bean.signal(caseId, "unrelated", Map.of("type", "STILL_IGNORED"));
+
+    await()
+        .during(2, TimeUnit.SECONDS)
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    0,
+                    SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get(),
+                    "Worker must not run when signaling an unbound path"));
+  }
+
+  /**
+   * Duplicate signals carrying a deeply nested object must be deduplicated — only one worker
+   * execution regardless of object complexity.
+   */
+  @Test
+  void duplicateSignalWithComplexNestedObjectRunsOnce() {
+    String id = "complex-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("id", id)).toCompletableFuture().join();
+
+    Map<String, Object> complexValue =
+        Map.of(
+            "header", Map.of("version", 2, "encoding", "UTF-8"),
+            "body", Map.of("items", List.of("a", "b", "c"), "count", 3),
+            "meta", Map.of("source", "integration", "priority", "HIGH"));
+
+    bean.signal(caseId, "event", complexValue);
+    bean.signal(caseId, "event", complexValue);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get(),
+                    "Worker must run exactly once for duplicate complex-object signal"));
+  }
+
+  /**
+   * After the case reaches COMPLETED state the CaseContextChangedEventHandler exits early for
+   * non-RUNNING cases, so a subsequent signal (even with a different value) must not trigger an
+   * additional worker run.
+   */
+  @Test
+  void signalAfterCaseCompletionDoesNotTriggerWorker() {
+    String id = "post-complete-" + UUID.randomUUID();
+    UUID caseId = goalBean.startCase(Map.of("id", id)).toCompletableFuture().join();
+
+    goalBean.signal(caseId, "event", Map.of("type", "TRIGGER"));
+
+    // Wait for the case to complete
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  1,
+                  SignalDedupWithGoalBean.runCountById.getOrDefault(id, new AtomicInteger()).get());
+              assertEquals(CaseStatus.COMPLETED, caseInstanceCache.get(caseId).getState());
+            });
+
+    // Signal a DIFFERENT value — context would change, but the case ignores it
+    goalBean.signal(caseId, "event", Map.of("type", "POST_COMPLETION"));
+
+    await()
+        .during(2, TimeUnit.SECONDS)
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    SignalDedupWithGoalBean.runCountById
+                        .getOrDefault(id, new AtomicInteger())
+                        .get(),
+                    "Worker must not run after case is COMPLETED"));
+  }
+
+  /**
+   * Four concurrent identical signals must produce exactly one worker execution. Tests the Vert.x
+   * lock contention path in SignalReceivedEventHandler under higher parallelism.
+   */
+  @Test
+  void fourConcurrentIdenticalSignalsRunWorkerOnce() {
+    String id = "four-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("id", id)).toCompletableFuture().join();
+    Map<String, Object> value = Map.of("level", "HIGH", "score", 99);
+
+    bean.signal(caseId, "event", value);
+    bean.signal(caseId, "event", value);
+    bean.signal(caseId, "event", value);
+    bean.signal(caseId, "event", value);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    SignalDedupBean.runCountById.getOrDefault(id, new AtomicInteger()).get(),
+                    "Worker must run exactly once despite four concurrent identical signals"));
+  }
+
+  // ================================================================== //
+  //  Beans                                                              //
+  // ================================================================== //
+
+  /** Case without a completion goal — stays RUNNING; used for most dedup scenarios. */
+  @ApplicationScoped
+  public static class SignalDedupBean extends CaseHub {
+
+    static final AtomicInteger runCount = new AtomicInteger();
+    static final ConcurrentHashMap<String, AtomicInteger> runCountById = new ConcurrentHashMap<>();
+
+    private final Capability eventCapability =
+        Capability.builder()
+            .name("processEventDedup")
+            .inputSchema("{ event: .event, id: .id }")
+            .outputSchema("{ eventResult: .eventResult }")
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-signal-dedup-ext")
+          .name("Signal Dedup Extended Test")
+          .version("1.0.0")
+          .capabilities(eventCapability)
+          .workers(
+              Worker.builder()
+                  .name("event-worker-dedup")
+                  .capabilities(eventCapability)
+                  .function(
+                      input -> {
+                        runCount.incrementAndGet();
+                        String id = (String) input.get("id");
+                        if (id != null) {
+                          runCountById
+                              .computeIfAbsent(id, k -> new AtomicInteger())
+                              .incrementAndGet();
+                        }
+                        return Map.of("eventResult", "processed");
+                      })
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("on-event-dedup")
+                  .capability(eventCapability)
+                  .on(new ContextChangeTrigger(".event != null"))
+                  .build())
+          .build();
+    }
+  }
+
+  /** Case with a completion goal — transitions to COMPLETED after first worker run. */
+  @ApplicationScoped
+  public static class SignalDedupWithGoalBean extends CaseHub {
+
+    static final AtomicInteger runCount = new AtomicInteger();
+    static final ConcurrentHashMap<String, AtomicInteger> runCountById = new ConcurrentHashMap<>();
+
+    private final Capability eventCapability =
+        Capability.builder()
+            .name("processEventDedupGoal")
+            .inputSchema("{ event: .event, id: .id }")
+            .outputSchema("{ eventResult: .eventResult }")
+            .build();
+
+    private final Goal doneGoal =
+        Goal.builder()
+            .name("eventProcessedGoal")
+            .condition(".eventResult == \"processed\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-signal-dedup-ext-goal")
+          .name("Signal Dedup With Goal Test")
+          .version("1.0.0")
+          .capabilities(eventCapability)
+          .workers(
+              Worker.builder()
+                  .name("event-worker-dedup-goal")
+                  .capabilities(eventCapability)
+                  .function(
+                      input -> {
+                        runCount.incrementAndGet();
+                        String id = (String) input.get("id");
+                        if (id != null) {
+                          runCountById
+                              .computeIfAbsent(id, k -> new AtomicInteger())
+                              .incrementAndGet();
+                        }
+                        return Map.of("eventResult", "processed");
+                      })
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("on-event-dedup-goal")
+                  .capability(eventCapability)
+                  .on(new ContextChangeTrigger(".event != null"))
+                  .build())
+          .goals(doneGoal)
+          .completion(GoalExpression.allOf(doneGoal))
+          .build();
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/SignalTest.java
+++ b/engine/src/test/java/io/casehub/engine/SignalTest.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,6 +50,8 @@ public class SignalTest {
   @Inject TwoSignalCaseHubBean twoSignalBean;
 
   @Inject CaseInstanceCache caseInstanceCache;
+
+  private static final Logger LOG = Logger.getLogger(SignalTest.class);
 
   @BeforeEach
   void reset() {
@@ -66,7 +69,8 @@ public class SignalTest {
    */
   @Test
   void workerShouldNotRunBeforeSignalAndRunAfter() {
-    UUID caseId = bean.startCase(Map.of("orderId", "order-1")).toCompletableFuture().join();
+    String orderId = "order-signal-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("orderId", orderId)).toCompletableFuture().join();
 
     assertNotNull(caseId);
 
@@ -75,22 +79,12 @@ public class SignalTest {
         .during(2, TimeUnit.SECONDS)
         .atMost(3, TimeUnit.SECONDS)
         .untilAsserted(
-            () ->
-                assertEquals(
-                    0, SignalCaseHubBean.runCount.get(), "Worker must not run before signal"));
+            () -> assertEquals(0, runCountForOrder(orderId), "Worker must not run before signal"));
 
     // send signal — writes the triggering field
     bean.signal(caseId, "payment", Map.of("amount", 500, "currency", "USD"));
 
-    // worker must run and case must complete
-    await()
-        .atMost(10, TimeUnit.SECONDS)
-        .untilAsserted(
-            () -> {
-              assertEquals(
-                  1, SignalCaseHubBean.runCount.get(), "Worker must run exactly once after signal");
-              assertEquals(CaseStatus.COMPLETED, caseInstanceCache.get(caseId).getState());
-            });
+    awaitWorkerCompletedExactlyOnce(caseId, orderId, "Worker must run exactly once after signal");
   }
 
   /**
@@ -99,6 +93,12 @@ public class SignalTest {
    */
   @Test
   void workerRunsOnceOnDuplicateSignal() {
+
+    SignalCaseHubBean.runCount.set(0);
+    SignalCaseHubBean.runCountByOrderId.clear();
+
+    LOG.warnf("Starting signal");
+
     // Unique orderId per run — isolates this test's run count from other tests' workers
     String orderId = "order-dedup-" + UUID.randomUUID();
     UUID caseId = bean.startCase(Map.of("orderId", orderId)).toCompletableFuture().join();
@@ -110,36 +110,26 @@ public class SignalTest {
     bean.signal(caseId, "payment", Map.of("amount", 100, "currency", "EUR"));
     bean.signal(caseId, "payment", Map.of("amount", 100, "currency", "EUR"));
 
-    await()
-        .atMost(10, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                assertEquals(
-                    1,
-                    SignalCaseHubBean.runCountByOrderId
-                        .getOrDefault(orderId, new AtomicInteger())
-                        .get(),
-                    "Worker must run exactly once despite duplicate signal"));
+    awaitWorkerCompletedExactlyOnce(
+        caseId, orderId, "Worker must run exactly once despite duplicate signal");
+    LOG.warnf("Finished signal");
   }
 
   /** Signal with a primitive value (not a Map) must also trigger the rule. */
   @Test
   void signalWithPrimitiveValueTriggersWorker() {
-    UUID caseId = bean.startCase(Map.of("orderId", "order-primitive")).toCompletableFuture().join();
+
+    SignalCaseHubBean.runCount.set(0);
+    SignalCaseHubBean.runCountByOrderId.clear();
+
+    String orderId = "order-primitive-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("orderId", orderId)).toCompletableFuture().join();
 
     // signal writes a non-null value — rule checks `.payment != null`
     bean.signal(caseId, "payment", 999);
 
-    // Case completion is the definitive signal that the worker fired and ran to success.
-    // Avoids global runCount which is susceptible to cross-test contamination.
-    await()
-        .atMost(10, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                assertEquals(
-                    io.casehub.api.model.CaseStatus.COMPLETED,
-                    caseInstanceCache.get(caseId).getState(),
-                    "Worker must fire and complete the case when payment signal is a primitive"));
+    awaitWorkerCompletedExactlyOnce(
+        caseId, orderId, "Primitive signal must trigger exactly one worker execution");
   }
 
   /**
@@ -148,6 +138,8 @@ public class SignalTest {
    */
   @Test
   void twoIndependentSignalsTriggerTwoWorkers() {
+    SignalCaseHubBean.runCount.set(0);
+    SignalCaseHubBean.runCountByOrderId.clear();
     UUID caseId =
         twoSignalBean
             .startCase(Map.of("orderId", "order-two-signals"))
@@ -187,17 +179,38 @@ public class SignalTest {
   /** Signal written value must be readable through query after the signal is processed. */
   @Test
   void signalValueIsAvailableViaQuery() {
-    UUID caseId = bean.startCase(Map.of("orderId", "order-query")).toCompletableFuture().join();
+    SignalCaseHubBean.runCount.set(0);
+    SignalCaseHubBean.runCountByOrderId.clear();
+
+    String orderId = "order-query-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("orderId", orderId)).toCompletableFuture().join();
 
     bean.signal(caseId, "payment", Map.of("amount", 750, "currency", "GBP"));
 
-    await()
-        .atMost(10, TimeUnit.SECONDS)
-        .untilAsserted(() -> assertEquals(1, SignalCaseHubBean.runCount.get()));
+    awaitWorkerCompletedExactlyOnce(caseId, orderId, "Signal-driven worker must complete once");
 
     // the worker output wrote "status" = "paid" into the context
     String status = bean.query(caseId, "status", String.class).toCompletableFuture().join();
     assertEquals("paid", status);
+  }
+
+  private void awaitWorkerCompletedExactlyOnce(UUID caseId, String orderId, String message) {
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(1, runCountForOrder(orderId), message);
+              assertEquals(CaseStatus.COMPLETED, caseInstanceCache.get(caseId).getState());
+            });
+
+    await()
+        .during(1, TimeUnit.SECONDS)
+        .atMost(2, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertEquals(1, runCountForOrder(orderId), message));
+  }
+
+  private int runCountForOrder(String orderId) {
+    return SignalCaseHubBean.runCountByOrderId.getOrDefault(orderId, new AtomicInteger()).get();
   }
 
   // ================================================================== //
@@ -242,7 +255,8 @@ public class SignalTest {
                   .capabilities(paymentCapability)
                   .function(
                       input -> {
-                        runCount.incrementAndGet();
+                        LOG.warnf("WORKER INPUT: %s %s", input, runCount.incrementAndGet());
+
                         String orderId = (String) input.get("orderId");
                         if (orderId != null) {
                           runCountByOrderId

--- a/engine/src/test/java/io/casehub/engine/WorkerIdempotencyTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerIdempotencyTest.java
@@ -1,0 +1,720 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.engine.handler.WorkerScheduleEventHandler;
+import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
+import io.casehub.engine.internal.event.WorkerScheduleEvent;
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.internal.history.EventStreamType;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.casehub.engine.internal.util.ReactiveUtils;
+import io.casehub.engine.internal.util.WorkerExecutionKeys;
+import io.casehub.engine.spi.EventLogRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class WorkerIdempotencyTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  @Inject IdempotencyBean bean;
+
+  @Inject TwoWorkerIdempotencyBean twoWorkerBean;
+
+  @Inject WorkerScheduleEventHandler handler;
+
+  @Inject WorkerExecutionRecoveryService recoveryService;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @Inject EventLogRepository eventLogRepository;
+
+  @Inject Vertx vertx;
+
+  @BeforeEach
+  void reset() {
+    IdempotencyBean.runCount.set(0);
+    IdempotencyBean.runCountById.clear();
+    TwoWorkerIdempotencyBean.alphaRunCount.set(0);
+    TwoWorkerIdempotencyBean.betaRunCount.set(0);
+  }
+
+  // ------------------------------------------------------------------ //
+
+  /**
+   * Three explicit WorkerScheduleEvents for the same (caseId, worker, inputHash) must produce
+   * exactly one WORKER_SCHEDULED log row and one worker execution.
+   */
+  @Test
+  void multipleScheduleEventsWithSameHashProduceSingleExecution() {
+    String taskId = "multi-sched-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    CaseInstance instance = caseInstanceCache.get(caseId);
+    assertNotNull(instance);
+    instance.getCaseContext().set("task", Map.of("op", "COMPUTE"));
+
+    String inputDataHash =
+        WorkerExecutionKeys.inputDataHash(
+            "idempotency-worker",
+            "idempotencyCapability",
+            Map.of("task", Map.of("op", "COMPUTE"), "taskId", taskId));
+
+    // Send the same WorkerScheduleEvent three times in rapid succession
+    for (int i = 0; i < 3; i++) {
+      ReactiveUtils.runOnSafeVertxContext(
+              vertx,
+              () ->
+                  handler.onWorkerScheduleEventHandler(
+                      new WorkerScheduleEvent(instance, bean.worker(), bean.capability())))
+          .await()
+          .atMost(TIMEOUT);
+    }
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  1,
+                  IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must execute exactly once");
+              assertEquals(
+                  1,
+                  countEvents(
+                      caseId,
+                      CaseHubEventType.WORKER_SCHEDULED,
+                      "idempotency-worker",
+                      inputDataHash),
+                  "Exactly one WORKER_SCHEDULED row must exist");
+            });
+  }
+
+  /**
+   * Worker must run again when the input data changes — a different input hash represents a new,
+   * distinct execution unit.
+   */
+  @Test
+  void workerRunsAgainWhenInputChanges() {
+    String taskId = "input-change-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    // First signal → worker runs with op=INIT
+    bean.signal(caseId, "task", Map.of("op", "INIT"));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get()));
+
+    // Different value → new input hash → worker must run again
+    bean.signal(caseId, "task", Map.of("op", "UPGRADE"));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    2,
+                    IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                    "Worker must run a second time for a new distinct input"));
+  }
+
+  /**
+   * Two independent workers in the same case must each run exactly once. A schedule event for one
+   * worker must not affect the idempotency state of the other.
+   */
+  @Test
+  void twoIndependentWorkersInSameCaseRunOnce() {
+    UUID caseId =
+        twoWorkerBean.startCase(Map.of("orderId", "two-workers")).toCompletableFuture().join();
+
+    twoWorkerBean.signal(caseId, "alpha", Map.of("code", "A1"));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertEquals(1, TwoWorkerIdempotencyBean.alphaRunCount.get()));
+
+    assertEquals(0, TwoWorkerIdempotencyBean.betaRunCount.get(), "Beta worker must not run yet");
+
+    twoWorkerBean.signal(caseId, "beta", Map.of("code", "B1"));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(1, TwoWorkerIdempotencyBean.alphaRunCount.get());
+              assertEquals(1, TwoWorkerIdempotencyBean.betaRunCount.get());
+            });
+  }
+
+  /**
+   * After the worker completes, re-signaling the exact same value does not change the context
+   * (empty diff) and must not trigger a second worker execution.
+   */
+  @Test
+  void workerNotRetriggeredAfterCompletionOnSameSignalValue() {
+    String taskId = "no-retrigger-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    Map<String, Object> taskValue = Map.of("op", "PROCESS", "priority", "HIGH");
+    bean.signal(caseId, "task", taskValue);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get()));
+
+    // Re-signal the same value — context unchanged → no CONTEXT_CHANGED → no new schedule
+    bean.signal(caseId, "task", taskValue);
+
+    Awaitility.await()
+        .during(2, TimeUnit.SECONDS)
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                    "Worker must not run again when context does not change"));
+  }
+
+  /**
+   * Mutating the cached CaseContext immediately after start must not affect the asynchronous
+   * CASE_STARTED snapshot. The worker may only be scheduled from the actual start-state, not from a
+   * later in-memory mutation.
+   */
+  @Test
+  void cachedContextMutationAfterStartDoesNotRetroactivelyTriggerStartBindings() {
+    String taskId = "start-snapshot-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    CaseInstance instance = caseInstanceCache.get(caseId);
+    assertNotNull(instance);
+    instance.getCaseContext().set("task", Map.of("op", "VERIFY"));
+
+    String inputDataHash =
+        WorkerExecutionKeys.inputDataHash(
+            "idempotency-worker",
+            "idempotencyCapability",
+            Map.of("task", Map.of("op", "VERIFY"), "taskId", taskId));
+
+    Awaitility.await()
+        .during(2, TimeUnit.SECONDS)
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  0,
+                  IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must not run from a retroactively mutated CASE_STARTED snapshot");
+              assertEquals(
+                  0,
+                  countEvents(
+                      caseId,
+                      CaseHubEventType.WORKER_SCHEDULED,
+                      "idempotency-worker",
+                      inputDataHash),
+                  "No WORKER_SCHEDULED row must be created from the post-start mutation");
+            });
+  }
+
+  /**
+   * Regardless of how many times the handler is invoked with the same hash, exactly one
+   * WORKER_SCHEDULED row must exist in the event log.
+   */
+  @Test
+  void singleWorkerScheduledLogAfterMultipleScheduleAttempts() {
+    String taskId = "single-log-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    CaseInstance instance = caseInstanceCache.get(caseId);
+    assertNotNull(instance);
+    instance.getCaseContext().set("task", Map.of("op", "EXPORT"));
+
+    String inputDataHash =
+        WorkerExecutionKeys.inputDataHash(
+            "idempotency-worker",
+            "idempotencyCapability",
+            Map.of("task", Map.of("op", "EXPORT"), "taskId", taskId));
+
+    // Five handler invocations for the same input hash
+    for (int i = 0; i < 5; i++) {
+      ReactiveUtils.runOnSafeVertxContext(
+              vertx,
+              () ->
+                  handler.onWorkerScheduleEventHandler(
+                      new WorkerScheduleEvent(instance, bean.worker(), bean.capability())))
+          .await()
+          .atMost(TIMEOUT);
+    }
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    countEvents(
+                        caseId,
+                        CaseHubEventType.WORKER_SCHEDULED,
+                        "idempotency-worker",
+                        inputDataHash),
+                    "Exactly one WORKER_SCHEDULED row must exist regardless of schedule attempt count"));
+  }
+
+  /**
+   * WorkerScheduleEventHandler must SKIP scheduling when a WORKER_EXECUTION_STARTED row already
+   * exists for the same input hash — the worker is already in flight.
+   */
+  @Test
+  void workerSkipsWhenExecutionStartedEventExists() {
+    String taskId = "skip-started-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    CaseInstance instance = caseInstanceCache.get(caseId);
+    assertNotNull(instance);
+    instance.getCaseContext().set("task", Map.of("op", "VERIFY"));
+
+    String inputDataHash =
+        WorkerExecutionKeys.inputDataHash(
+            "idempotency-worker",
+            "idempotencyCapability",
+            Map.of("task", Map.of("op", "VERIFY"), "taskId", taskId));
+
+    // Pre-insert a WORKER_EXECUTION_STARTED event — simulates an in-flight worker
+    persistEvent(
+        buildEventLog(
+            caseId,
+            CaseHubEventType.WORKER_EXECUTION_STARTED,
+            "idempotency-worker",
+            inputDataHash,
+            Map.of("op", "VERIFY")));
+
+    ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                handler.onWorkerScheduleEventHandler(
+                    new WorkerScheduleEvent(instance, bean.worker(), bean.capability())))
+        .await()
+        .atMost(TIMEOUT);
+
+    Awaitility.await()
+        .during(2, TimeUnit.SECONDS)
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  0,
+                  IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must not run when WORKER_EXECUTION_STARTED exists");
+              assertEquals(
+                  0,
+                  countEvents(
+                      caseId,
+                      CaseHubEventType.WORKER_SCHEDULED,
+                      "idempotency-worker",
+                      inputDataHash),
+                  "No WORKER_SCHEDULED row must be created when STARTED exists");
+            });
+  }
+
+  /**
+   * A changed signal value produces a different input hash, which is treated as a new distinct
+   * execution — the worker must run again for the new hash.
+   */
+  @Test
+  void workerRunsAgainForDifferentInputHash() {
+    String taskId = "diff-hash-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    bean.signal(caseId, "task", Map.of("op", "STEP_1"));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get()));
+
+    bean.signal(caseId, "task", Map.of("op", "STEP_2"));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    2,
+                    IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                    "Worker must run again because the input hash changed"));
+  }
+
+  /**
+   * Concurrent WorkerScheduleEvents for the same (caseId, worker, hash) sent without waiting must
+   * produce a single WORKER_SCHEDULED row via the Vert.x lock in WorkerScheduleEventHandler.
+   */
+  @Test
+  void concurrentScheduleEventsProduceSingleLog() {
+    String taskId = "concurrent-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    CaseInstance instance = caseInstanceCache.get(caseId);
+    assertNotNull(instance);
+    instance.getCaseContext().set("task", Map.of("op", "PARALLEL"));
+
+    String inputDataHash =
+        WorkerExecutionKeys.inputDataHash(
+            "idempotency-worker",
+            "idempotencyCapability",
+            Map.of("task", Map.of("op", "PARALLEL"), "taskId", taskId));
+
+    // Fire four schedule events concurrently (no await between them)
+    ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                handler.onWorkerScheduleEventHandler(
+                    new WorkerScheduleEvent(instance, bean.worker(), bean.capability())))
+        .subscribe()
+        .asCompletionStage();
+    ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                handler.onWorkerScheduleEventHandler(
+                    new WorkerScheduleEvent(instance, bean.worker(), bean.capability())))
+        .subscribe()
+        .asCompletionStage();
+    ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                handler.onWorkerScheduleEventHandler(
+                    new WorkerScheduleEvent(instance, bean.worker(), bean.capability())))
+        .subscribe()
+        .asCompletionStage();
+    ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                handler.onWorkerScheduleEventHandler(
+                    new WorkerScheduleEvent(instance, bean.worker(), bean.capability())))
+        .await()
+        .atMost(TIMEOUT);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  1,
+                  IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must execute exactly once despite concurrent schedule events");
+              assertEquals(
+                  1,
+                  countEvents(
+                      caseId,
+                      CaseHubEventType.WORKER_SCHEDULED,
+                      "idempotency-worker",
+                      inputDataHash),
+                  "Exactly one WORKER_SCHEDULED row must exist");
+            });
+  }
+
+  /**
+   * When a WORKER_SCHEDULED row exists without a matching STARTED/COMPLETED (crash-recovery
+   * scenario), recoverPendingScheduledWorkers() must replay the job exactly once without creating a
+   * duplicate log row.
+   */
+  @Test
+  void recoveryPlaysOrphanedWorkerExactlyOnce() {
+    String taskId = "recovery-idem-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    assertNotNull(caseInstanceCache.get(caseId));
+
+    String inputDataHash =
+        WorkerExecutionKeys.inputDataHash(
+            "idempotency-worker",
+            "idempotencyCapability",
+            Map.of("task", Map.of("op", "RECOVER"), "taskId", taskId));
+
+    // Pre-insert the WORKER_SCHEDULED row that would have been written before a crash
+    persistEvent(
+        buildEventLog(
+            caseId,
+            CaseHubEventType.WORKER_SCHEDULED,
+            "idempotency-worker",
+            inputDataHash,
+            Map.of("task", Map.of("op", "RECOVER"), "taskId", taskId)));
+
+    ReactiveUtils.runOnSafeVertxContext(
+            vertx, () -> recoveryService.recoverPendingScheduledWorkers())
+        .await()
+        .atMost(TIMEOUT);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  1,
+                  IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must execute exactly once during recovery");
+              assertEquals(
+                  1,
+                  countEvents(
+                      caseId,
+                      CaseHubEventType.WORKER_SCHEDULED,
+                      "idempotency-worker",
+                      inputDataHash),
+                  "No duplicate WORKER_SCHEDULED row must be created");
+            });
+  }
+
+  /**
+   * Multiple signals to the same path that all produce the same computed worker input must result
+   * in exactly one worker execution. The input hash, not the signal count, determines uniqueness.
+   */
+  @Test
+  void workerRunsOnceForSameInputAcrossMultipleSignals() {
+    String taskId = "multi-sig-" + UUID.randomUUID();
+    UUID caseId = bean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    // All three signals produce the same context value → same input hash
+    Map<String, Object> value = Map.of("op", "STABLE");
+    bean.signal(caseId, "task", value);
+    bean.signal(caseId, "task", value);
+    bean.signal(caseId, "task", value);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    IdempotencyBean.runCountById.getOrDefault(taskId, new AtomicInteger()).get(),
+                    "Worker must run exactly once for the same effective input regardless of signal count"));
+  }
+
+  // ================================================================== //
+  //  Helpers                                                            //
+  // ================================================================== //
+
+  private void persistEvent(EventLog eventLog) {
+    eventLogRepository
+        .append(eventLog)
+        .subscribe()
+        .asCompletionStage()
+        .toCompletableFuture()
+        .join();
+  }
+
+  private long countEvents(
+      UUID caseId, CaseHubEventType eventType, String workerId, String inputDataHash) {
+    List<EventLog> eventLogs =
+        eventLogRepository
+            .findByCaseAndWorkerAndType(caseId, workerId, eventType)
+            .subscribe()
+            .asCompletionStage()
+            .toCompletableFuture()
+            .join();
+
+    return eventLogs.stream()
+        .filter(
+            el -> {
+              var metadata = el.getMetadata();
+              var hash = metadata == null ? null : metadata.get("inputDataHash");
+              return hash != null && inputDataHash.equals(hash.asText());
+            })
+        .count();
+  }
+
+  private EventLog buildEventLog(
+      UUID caseId,
+      CaseHubEventType eventType,
+      String workerId,
+      String inputDataHash,
+      Map<String, Object> payload) {
+    EventLog el = new EventLog();
+    el.setCaseId(caseId);
+    el.setEventType(eventType);
+    el.setStreamType(EventStreamType.CASE);
+    el.setTimestamp(Instant.now());
+    el.setWorkerId(workerId);
+    el.setMetadata(
+        OBJECT_MAPPER.valueToTree(
+            Map.of(
+                "workerName", workerId,
+                "capabilityName", "idempotencyCapability",
+                "inputDataHash", inputDataHash)));
+    el.setPayload(OBJECT_MAPPER.valueToTree(payload));
+    return el;
+  }
+
+  // ================================================================== //
+  //  Beans                                                              //
+  // ================================================================== //
+
+  @ApplicationScoped
+  public static class IdempotencyBean extends CaseHub {
+
+    static final AtomicInteger runCount = new AtomicInteger();
+    static final ConcurrentHashMap<String, AtomicInteger> runCountById = new ConcurrentHashMap<>();
+
+    private final Capability capability =
+        Capability.builder()
+            .name("idempotencyCapability")
+            .inputSchema("{ task: .task, taskId: .taskId }")
+            .outputSchema("{ taskResult: .taskResult }")
+            .build();
+
+    private final Worker worker =
+        Worker.builder()
+            .name("idempotency-worker")
+            .capabilities(capability)
+            .function(
+                input -> {
+                  runCount.incrementAndGet();
+                  String taskId = (String) input.get("taskId");
+                  if (taskId != null) {
+                    runCountById
+                        .computeIfAbsent(taskId, k -> new AtomicInteger())
+                        .incrementAndGet();
+                  }
+                  return Map.of("taskResult", "done");
+                })
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-worker-idempotency")
+          .name("Worker Idempotency Test")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(worker)
+          .bindings(
+              Binding.builder()
+                  .name("on-task")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".task != null"))
+                  .build())
+          .build();
+    }
+
+    Capability capability() {
+      return capability;
+    }
+
+    Worker worker() {
+      return worker;
+    }
+  }
+
+  @ApplicationScoped
+  public static class TwoWorkerIdempotencyBean extends CaseHub {
+
+    static final AtomicInteger alphaRunCount = new AtomicInteger();
+    static final AtomicInteger betaRunCount = new AtomicInteger();
+
+    private final Capability alphaCapability =
+        Capability.builder()
+            .name("alphaCapability")
+            .inputSchema("{ alpha: .alpha }")
+            .outputSchema("{ alphaResult: .alphaResult }")
+            .build();
+
+    private final Capability betaCapability =
+        Capability.builder()
+            .name("betaCapability")
+            .inputSchema("{ beta: .beta }")
+            .outputSchema("{ betaResult: .betaResult }")
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-worker-idempotency-two")
+          .name("Two Worker Idempotency Test")
+          .version("1.0.0")
+          .capabilities(alphaCapability, betaCapability)
+          .workers(
+              Worker.builder()
+                  .name("alpha-worker")
+                  .capabilities(alphaCapability)
+                  .function(
+                      input -> {
+                        alphaRunCount.incrementAndGet();
+                        return Map.of("alphaResult", "done");
+                      })
+                  .build(),
+              Worker.builder()
+                  .name("beta-worker")
+                  .capabilities(betaCapability)
+                  .function(
+                      input -> {
+                        betaRunCount.incrementAndGet();
+                        return Map.of("betaResult", "done");
+                      })
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("on-alpha")
+                  .capability(alphaCapability)
+                  .on(new ContextChangeTrigger(".alpha != null"))
+                  .build(),
+              Binding.builder()
+                  .name("on-beta")
+                  .capability(betaCapability)
+                  .on(new ContextChangeTrigger(".beta != null"))
+                  .build())
+          .build();
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
@@ -1,0 +1,614 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.spi.EventLogRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that workers which throw exceptions are retried and eventually complete successfully. Each
+ * test uses a unique taskId to isolate attempt counters across concurrent or sequential runs.
+ */
+@QuarkusTest
+public class WorkerRetryExtendedTest {
+
+  @Inject FlexibleRetryBean bean;
+
+  @Inject SignalTriggerRetryBean signalBean;
+
+  @Inject TwoWorkerRetryBean twoWorkerBean;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @Inject EventLogRepository eventLogRepository;
+
+  @BeforeEach
+  void reset() {
+    FlexibleRetryBean.attempts.clear();
+    FlexibleRetryBean.failUntil.clear();
+    SignalTriggerRetryBean.attempts.clear();
+    SignalTriggerRetryBean.failUntil.clear();
+    TwoWorkerRetryBean.alphaAttempts.set(0);
+    TwoWorkerRetryBean.betaAttempts.set(0);
+  }
+
+  // ------------------------------------------------------------------ //
+
+  /**
+   * Worker fails on the first attempt and succeeds on the second. Run count must be exactly 2 and
+   * the output must be written to the context.
+   */
+  @Test
+  void workerSucceedsAfterOneFail() {
+    String taskId = "one-fail-" + UUID.randomUUID();
+    FlexibleRetryBean.failUntil.put(taskId, 1); // fail attempt 1, succeed on attempt 2
+
+    UUID caseId =
+        bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  2,
+                  FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must be called exactly twice: one failure + one success");
+              assertEquals(
+                  "processed",
+                  bean.query(caseId, "status", String.class).toCompletableFuture().join());
+            });
+  }
+
+  /**
+   * Worker fails on the first two attempts and succeeds on the third. Total run count must be 3.
+   */
+  @Test
+  void workerSucceedsAfterTwoFails() {
+    String taskId = "two-fail-" + UUID.randomUUID();
+    FlexibleRetryBean.failUntil.put(taskId, 2); // fail attempts 1–2, succeed on attempt 3
+
+    UUID caseId =
+        bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  3,
+                  FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must be called three times: two failures + one success");
+              assertEquals(
+                  "processed",
+                  bean.query(caseId, "status", String.class).toCompletableFuture().join());
+            });
+  }
+
+  /**
+   * Run count must equal the number of configured failures plus exactly one successful attempt — no
+   * extra executions must occur after success.
+   */
+  @Test
+  void workerRunCountEqualsFailuresPlusOneSuccess() {
+    String taskId = "run-count-" + UUID.randomUUID();
+    int expectedFailures = 3;
+    FlexibleRetryBean.failUntil.put(taskId, expectedFailures);
+
+    bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    expectedFailures + 1,
+                    FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get(),
+                    "Run count must be exactly failures + 1 (no extra runs after success)"));
+  }
+
+  /**
+   * After retrying, the output data written by the successful attempt must be correctly stored in
+   * the case context — not corrupted or empty due to the preceding failures.
+   */
+  @Test
+  void workerOutputIsCorrectAfterRetry() {
+    String taskId = "output-check-" + UUID.randomUUID();
+    FlexibleRetryBean.failUntil.put(taskId, 2);
+
+    UUID caseId =
+        bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  "processed",
+                  bean.query(caseId, "status", String.class).toCompletableFuture().join(),
+                  "Output field 'status' must be 'processed' after retry success");
+              assertNotNull(
+                  bean.query(caseId, "taskId", String.class).toCompletableFuture().join(),
+                  "Output field 'taskId' must survive through retries");
+            });
+  }
+
+  /**
+   * The case must reach COMPLETED status after the worker eventually succeeds on retry — not remain
+   * RUNNING or transition to FAULTED.
+   */
+  @Test
+  void caseCompletesAfterRetrySuccess() {
+    String taskId = "complete-" + UUID.randomUUID();
+    FlexibleRetryBean.failUntil.put(taskId, 1);
+
+    UUID caseId =
+        bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    CaseStatus.COMPLETED,
+                    caseInstanceCache.get(caseId).getState(),
+                    "Case must reach COMPLETED after worker succeeds on retry"));
+  }
+
+  /**
+   * Each failed worker attempt must produce a WORKER_EXECUTION_FAILED entry in the event log. Two
+   * failures must produce exactly two such entries.
+   */
+  @Test
+  void workerExecutionFailedEventRecordedForEachFailure() {
+    String taskId = "failed-events-" + UUID.randomUUID();
+    int failCount = 2;
+    FlexibleRetryBean.failUntil.put(taskId, failCount);
+
+    UUID caseId =
+        bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    // Wait until all attempts complete (failures + success)
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    failCount + 1,
+                    FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
+
+    assertEquals(
+        failCount,
+        findEvents(caseId, CaseHubEventType.WORKER_EXECUTION_FAILED).size(),
+        "One WORKER_EXECUTION_FAILED entry must exist per failed attempt");
+  }
+
+  /**
+   * Worker succeeds on exactly the last allowed attempt (maxAttempts). The case must complete
+   * rather than fault, and no extra attempts must occur.
+   */
+  @Test
+  void workerSucceedsOnLastAllowedAttempt() {
+    // FlexibleRetryBean uses RetryPolicy(5, 100) → max 5 attempts
+    int maxAttempts = 5;
+    String taskId = "last-attempt-" + UUID.randomUUID();
+    FlexibleRetryBean.failUntil.put(taskId, maxAttempts - 1); // succeed on attempt 5
+
+    UUID caseId =
+        bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  maxAttempts,
+                  FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must be attempted exactly maxAttempts times");
+              assertEquals(
+                  CaseStatus.COMPLETED,
+                  caseInstanceCache.get(caseId).getState(),
+                  "Case must be COMPLETED, not FAULTED");
+            });
+  }
+
+  /**
+   * Retries must not create additional WORKER_SCHEDULED log rows — retrying a Quartz job reuses the
+   * original job; only one WORKER_SCHEDULED entry must exist even after N failures.
+   */
+  @Test
+  void retryDoesNotDuplicateWorkerScheduledLog() {
+    String taskId = "no-dup-sched-" + UUID.randomUUID();
+    FlexibleRetryBean.failUntil.put(taskId, 2);
+
+    UUID caseId =
+        bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    // Wait for all retries to complete
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    3, FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
+
+    List<EventLog> scheduledEvents = findWorkerEvents(caseId, CaseHubEventType.WORKER_SCHEDULED);
+    assertEquals(
+        1,
+        scheduledEvents.size(),
+        "Exactly one WORKER_SCHEDULED row must exist regardless of retry count");
+  }
+
+  /** WORKER_EXECUTION_COMPLETED must appear exactly once even after multiple failed attempts. */
+  @Test
+  void workerExecutionCompletedAppearsExactlyOnce() {
+    String taskId = "one-completed-" + UUID.randomUUID();
+    FlexibleRetryBean.failUntil.put(taskId, 2);
+
+    UUID caseId =
+        bean.startCase(Map.of("taskId", taskId, "status", "pending")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    3, FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
+
+    assertEquals(
+        1,
+        findWorkerEvents(caseId, CaseHubEventType.WORKER_EXECUTION_COMPLETED).size(),
+        "Exactly one WORKER_EXECUTION_COMPLETED entry must exist after retry success");
+  }
+
+  /**
+   * Worker triggered by a signal (not initial context) fails on the first attempt and succeeds on
+   * retry. The final output must be queryable after the signal-triggered retry completes.
+   */
+  @Test
+  void workerTriggeredBySignalSucceedsAfterRetry() {
+    String taskId = "signal-retry-" + UUID.randomUUID();
+    SignalTriggerRetryBean.failUntil.put(taskId, 1); // fail once, then succeed
+
+    UUID caseId = signalBean.startCase(Map.of("taskId", taskId)).toCompletableFuture().join();
+
+    // Worker must NOT run before the signal
+    Awaitility.await()
+        .during(1, TimeUnit.SECONDS)
+        .atMost(2, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    0,
+                    SignalTriggerRetryBean.attempts
+                        .getOrDefault(taskId, new AtomicInteger())
+                        .get()));
+
+    // Signal triggers the worker
+    signalBean.signal(caseId, "request", Map.of("action", "PROCESS"));
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  2,
+                  SignalTriggerRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get(),
+                  "Worker must have been called twice: one failure + one success");
+              assertEquals(
+                  "processed",
+                  signalBean.query(caseId, "status", String.class).toCompletableFuture().join());
+            });
+  }
+
+  /**
+   * When two workers are active in the same case, one of which fails and retries, both must
+   * eventually complete. The retrying worker must not prevent the other from completing.
+   */
+  @Test
+  void oneOfTwoWorkersRetriesButBothComplete() {
+    // Alpha succeeds immediately; Beta fails once then succeeds
+    TwoWorkerRetryBean.betaFailUntil.set(1);
+
+    UUID caseId =
+        twoWorkerBean
+            .startCase(Map.of("alpha", "ready", "beta", "ready"))
+            .toCompletableFuture()
+            .join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(
+                  1,
+                  TwoWorkerRetryBean.alphaAttempts.get(),
+                  "Alpha worker must succeed on first attempt");
+              assertEquals(
+                  2,
+                  TwoWorkerRetryBean.betaAttempts.get(),
+                  "Beta worker must have two attempts: one failure + one success");
+              assertEquals(
+                  "alpha-done",
+                  twoWorkerBean
+                      .query(caseId, "alphaResult", String.class)
+                      .toCompletableFuture()
+                      .join());
+              assertEquals(
+                  "beta-done",
+                  twoWorkerBean
+                      .query(caseId, "betaResult", String.class)
+                      .toCompletableFuture()
+                      .join());
+            });
+  }
+
+  // ================================================================== //
+  //  Helpers                                                            //
+  // ================================================================== //
+
+  private List<EventLog> findEvents(UUID caseId, CaseHubEventType eventType) {
+    return eventLogRepository
+        .findByCaseAndTypes(caseId, List.of(eventType))
+        .subscribe()
+        .asCompletionStage()
+        .toCompletableFuture()
+        .join();
+  }
+
+  private List<EventLog> findWorkerEvents(UUID caseId, CaseHubEventType eventType) {
+    return eventLogRepository
+        .findByCaseAndTypes(caseId, List.of(eventType))
+        .subscribe()
+        .asCompletionStage()
+        .toCompletableFuture()
+        .join()
+        .stream()
+        .filter(e -> e.getWorkerId() != null)
+        .toList();
+  }
+
+  // ================================================================== //
+  //  Beans                                                              //
+  // ================================================================== //
+
+  /**
+   * Configurable-retry worker triggered by initial context. Uses {@code failUntil[taskId]} to
+   * control how many times it throws before returning success, allowing each test to configure its
+   * own failure count independently via a unique taskId.
+   */
+  @ApplicationScoped
+  public static class FlexibleRetryBean extends CaseHub {
+
+    /** Number of times the worker has been called, keyed by taskId. */
+    static final ConcurrentHashMap<String, AtomicInteger> attempts = new ConcurrentHashMap<>();
+
+    /**
+     * How many attempts should fail before succeeding, keyed by taskId. Default: 0 (succeed
+     * immediately).
+     */
+    static final ConcurrentHashMap<String, Integer> failUntil = new ConcurrentHashMap<>();
+
+    private final Capability capability =
+        Capability.builder()
+            .name("flexibleRetryCapability")
+            .inputSchema("{ taskId: .taskId, status: .status }")
+            .outputSchema("{ status: .status, taskId: .taskId }")
+            .build();
+
+    private final Goal doneGoal =
+        Goal.builder()
+            .name("flexRetryDone")
+            .condition(".status == \"processed\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-worker-retry-ext")
+          .name("Flexible Retry Test")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("flexible-retry-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        String taskId = (String) input.get("taskId");
+                        int attempt =
+                            attempts
+                                .computeIfAbsent(taskId, k -> new AtomicInteger())
+                                .incrementAndGet();
+                        int maxFail = failUntil.getOrDefault(taskId, 0);
+                        if (attempt <= maxFail) {
+                          throw new RuntimeException(
+                              "Simulated failure on attempt " + attempt + " of " + maxFail);
+                        }
+                        return Map.of("status", "processed", "taskId", taskId);
+                      })
+                  // 5 max attempts, 100 ms between retries — allows tests up to 4 failures
+                  .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(5, 100)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("on-pending")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"pending\""))
+                  .build())
+          .goals(doneGoal)
+          .completion(GoalExpression.allOf(doneGoal))
+          .build();
+    }
+  }
+
+  /**
+   * Configurable-retry worker triggered by a signal on the {@code request} path. Lets tests verify
+   * the full retry lifecycle for signal-initiated workers.
+   */
+  @ApplicationScoped
+  public static class SignalTriggerRetryBean extends CaseHub {
+
+    static final ConcurrentHashMap<String, AtomicInteger> attempts = new ConcurrentHashMap<>();
+    static final ConcurrentHashMap<String, Integer> failUntil = new ConcurrentHashMap<>();
+
+    private final Capability capability =
+        Capability.builder()
+            .name("signalRetryCapability")
+            .inputSchema("{ request: .request, taskId: .taskId }")
+            .outputSchema("{ status: .status }")
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-worker-retry-signal")
+          .name("Signal Trigger Retry Test")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("signal-retry-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        String taskId = (String) input.get("taskId");
+                        int attempt =
+                            attempts
+                                .computeIfAbsent(taskId, k -> new AtomicInteger())
+                                .incrementAndGet();
+                        int maxFail = failUntil.getOrDefault(taskId, 0);
+                        if (attempt <= maxFail) {
+                          throw new RuntimeException(
+                              "Signal-triggered failure on attempt " + attempt);
+                        }
+                        return Map.of("status", "processed");
+                      })
+                  .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(5, 100)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("on-request")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".request != null"))
+                  .build())
+          .build();
+    }
+  }
+
+  /**
+   * Two-worker case: Alpha always succeeds on the first attempt; Beta is configured via {@code
+   * betaFailUntil} to fail a given number of times before succeeding. Both are triggered by the
+   * initial context.
+   */
+  @ApplicationScoped
+  public static class TwoWorkerRetryBean extends CaseHub {
+
+    static final AtomicInteger alphaAttempts = new AtomicInteger();
+    static final AtomicInteger betaAttempts = new AtomicInteger();
+    static final AtomicInteger betaFailUntil = new AtomicInteger(0);
+
+    private final Capability alphaCapability =
+        Capability.builder()
+            .name("alphaRetryCapability")
+            .inputSchema("{ alpha: .alpha }")
+            .outputSchema("{ alphaResult: .alphaResult }")
+            .build();
+
+    private final Capability betaCapability =
+        Capability.builder()
+            .name("betaRetryCapability")
+            .inputSchema("{ beta: .beta }")
+            .outputSchema("{ betaResult: .betaResult }")
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-worker-retry-two")
+          .name("Two Worker Retry Test")
+          .version("1.0.0")
+          .capabilities(alphaCapability, betaCapability)
+          .workers(
+              Worker.builder()
+                  .name("alpha-always-success")
+                  .capabilities(alphaCapability)
+                  .function(
+                      input -> {
+                        alphaAttempts.incrementAndGet();
+                        return Map.of("alphaResult", "alpha-done");
+                      })
+                  .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(3, 100)))
+                  .build(),
+              Worker.builder()
+                  .name("beta-retry-worker")
+                  .capabilities(betaCapability)
+                  .function(
+                      input -> {
+                        int attempt = betaAttempts.incrementAndGet();
+                        if (attempt <= betaFailUntil.get()) {
+                          throw new RuntimeException("Beta failure on attempt " + attempt);
+                        }
+                        return Map.of("betaResult", "beta-done");
+                      })
+                  .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(5, 100)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("on-alpha-ready")
+                  .capability(alphaCapability)
+                  .on(new ContextChangeTrigger(".alpha == \"ready\""))
+                  .build(),
+              Binding.builder()
+                  .name("on-beta-ready")
+                  .capability(betaCapability)
+                  .on(new ContextChangeTrigger(".beta == \"ready\""))
+                  .build())
+          .build();
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/WorkerScheduleDedupTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerScheduleDedupTest.java
@@ -26,6 +26,7 @@ import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.Worker;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.engine.handler.WorkerScheduleEventHandler;
+import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
 import io.casehub.engine.internal.event.WorkerScheduleEvent;
 import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
@@ -57,6 +58,8 @@ public class WorkerScheduleDedupTest {
   @Inject DedupCaseHubBean bean;
 
   @Inject WorkerScheduleEventHandler handler;
+
+  @Inject WorkerExecutionRecoveryService recoveryService;
 
   @Inject CaseInstanceCache caseInstanceCache;
 
@@ -114,7 +117,7 @@ public class WorkerScheduleDedupTest {
   }
 
   @Test
-  void shouldResubmitExistingScheduledWithoutCreatingDuplicateLog() {
+  void shouldSkipWhenMatchingScheduledEventAlreadyExists() {
     DedupCaseHubBean.runCount.set(0);
 
     UUID caseId =
@@ -147,10 +150,11 @@ public class WorkerScheduleDedupTest {
         .atMost(Duration.ofSeconds(10));
 
     Awaitility.await()
-        .atMost(10, TimeUnit.SECONDS)
+        .during(2, TimeUnit.SECONDS)
+        .atMost(3, TimeUnit.SECONDS)
         .untilAsserted(
             () -> {
-              assertEquals(1, DedupCaseHubBean.runCount.get());
+              assertEquals(0, DedupCaseHubBean.runCount.get());
               assertEquals(
                   1,
                   countEvents(
@@ -158,6 +162,60 @@ public class WorkerScheduleDedupTest {
                       CaseHubEventType.WORKER_SCHEDULED,
                       "dedup-worker",
                       executionIdempotency));
+            });
+  }
+
+  /**
+   * Crash-recovery scenario: a WORKER_SCHEDULED row exists in the DB (written before the crash) but
+   * the Quartz RAM-store is empty (cleared on restart). The handler SKIPs re-scheduling (covered by
+   * shouldSkipWhenMatchingScheduledEventAlreadyExists), while recoverPendingScheduledWorkers()
+   * replays the orphaned job exactly once without creating a duplicate WORKER_SCHEDULED row.
+   */
+  @Test
+  void shouldRecoverOrphanedScheduledWorkerOnRestart() {
+    DedupCaseHubBean.runCount.set(0);
+
+    UUID caseId =
+        bean.startCase(Map.of("documentId", "doc-recovery", "status", "queued"))
+            .toCompletableFuture()
+            .join();
+
+    assertNotNull(caseInstanceCache.get(caseId));
+
+    String executionIdempotency =
+        WorkerExecutionKeys.inputDataHash(
+            "dedup-worker",
+            "dedupCapability",
+            Map.of("documentId", "doc-recovery", "status", "queued"));
+
+    // Simulate the state left after a crash: WORKER_SCHEDULED persisted, Quartz job lost.
+    persistEvent(
+        eventLog(
+            caseId,
+            CaseHubEventType.WORKER_SCHEDULED,
+            "dedup-worker",
+            executionIdempotency,
+            Map.of("documentId", "doc-recovery", "status", "queued")));
+
+    // Recovery service reschedules the orphaned job without creating a new EventLog row.
+    ReactiveUtils.runOnSafeVertxContext(
+            vertx, () -> recoveryService.recoverPendingScheduledWorkers())
+        .await()
+        .atMost(Duration.ofSeconds(10));
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertEquals(1, DedupCaseHubBean.runCount.get(), "worker must run exactly once");
+              assertEquals(
+                  1,
+                  countEvents(
+                      caseId,
+                      CaseHubEventType.WORKER_SCHEDULED,
+                      "dedup-worker",
+                      executionIdempotency),
+                  "no duplicate WORKER_SCHEDULED row must be created");
               assertEquals(
                   "processed",
                   bean.query(caseId, "status", String.class).toCompletableFuture().join());


### PR DESCRIPTION
  Two identical signals sent in rapid succession could both trigger worker execution because both @ConsumeEvent handlers reached applyAndDiff before either had written to the shared context. The ReentrantReadWriteLock inside
  CaseContextImpl serializes the actual write, but a race window existed between handler dispatch and lock acquisition, both handlers could observe some path and produce a non-empty diff.

  Fix: acquire a Vert.x SharedData local lock keyed by (caseId, path) before calling applyAndDiff. The lock is released immediately after the in-memory context update, so the DB transaction runs without holding it. The second
  signal, once it acquires the lock, sees the already-written value and gets an empty diff — it is skipped without emitting CONTEXT_CHANGED.