### PR TITLE
feat(api): make LoopControl.select() return Uni<List<Binding>> [1/3]

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,6 +26,10 @@
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/api/src/main/java/io/casehub/api/engine/LoopControl.java
+++ b/api/src/main/java/io/casehub/api/engine/LoopControl.java
@@ -16,27 +16,29 @@
 package io.casehub.api.engine;
 
 import io.casehub.api.model.Binding;
+import io.smallrye.mutiny.Uni;
 import java.util.List;
 
 /**
- * SPI for controlling which eligible dispatch rules are selected for execution after their trigger
- * conditions have been evaluated.
+ * SPI for controlling which eligible bindings are selected for execution.
+ *
+ * <p>Returns {@code Uni<List<Binding>>} to allow non-blocking I/O during selection (e.g. EventLog
+ * queries, LLM scoring). See casehubio/engine#76.
  *
  * <p>The default implementation ({@link io.casehub.engine.internal.engine.ChoreographyLoopControl})
- * fires all eligible rules concurrently — pure choreography. Provide an alternative CDI bean
- * ({@code @Alternative @Priority} ) to introduce deliberate ordering, prioritisation, or sequential
- * execution.
+ * wraps with {@code Uni.createFrom().item(eligible)} — no behaviour change.
  */
 public interface LoopControl {
 
   /**
-   * Select the dispatch rules to fire from the set of rules whose trigger conditions have already
-   * been evaluated and matched.
+   * Select the bindings to fire from the set of bindings whose trigger conditions have already been
+   * evaluated and matched.
    *
    * @param context case identity, definition, and current case state — enables implementations to
    *     look up plan models without requiring access to internal engine structures
-   * @param eligible rules whose trigger conditions matched — may be empty, never null
-   * @return the subset to fire; may be empty, may be the full list, must not be null
+   * @param eligible bindings whose trigger conditions matched — may be empty, never null
+   * @return Uni that resolves to the subset to fire; may be empty, may be the full list, must not
+   *     be null
    */
-  List<Binding> select(PlanExecutionContext context, List<Binding> eligible);
+  Uni<List<Binding>> select(PlanExecutionContext context, List<Binding> eligible);
 }

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/PlanningStrategyLoopControl.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/strategy/PlanningStrategyLoopControl.java
@@ -25,6 +25,7 @@ import io.casehub.blackboard.plan.PlanItem;
 import io.casehub.blackboard.plan.PlanItemStatus;
 import io.casehub.blackboard.stage.Stage;
 import io.casehub.engine.internal.engine.ExpressionEngineRegistry;
+import io.smallrye.mutiny.Uni;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
@@ -64,10 +65,10 @@ public class PlanningStrategyLoopControl implements LoopControl {
   @Inject ExpressionEngineRegistry expressionEngineRegistry;
 
   @Override
-  public List<Binding> select(PlanExecutionContext context, List<Binding> eligible) {
+  public Uni<List<Binding>> select(PlanExecutionContext context, List<Binding> eligible) {
     Optional<CasePlanModel> planModel = registry.find(context.definition());
     if (planModel.isEmpty()) {
-      return eligible; // no plan model — pure choreography
+      return Uni.createFrom().item(eligible); // no plan model — pure choreography
     }
 
     UUID caseId = context.caseId();
@@ -143,7 +144,7 @@ public class PlanningStrategyLoopControl implements LoopControl {
       }
     }
 
-    return result;
+    return Uni.createFrom().item(result);
   }
 
   // ---- plan instance construction ----

--- a/engine/src/main/java/io/casehub/engine/internal/engine/ChoreographyLoopControl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/ChoreographyLoopControl.java
@@ -18,6 +18,7 @@ package io.casehub.engine.internal.engine;
 import io.casehub.api.engine.LoopControl;
 import io.casehub.api.engine.PlanExecutionContext;
 import io.casehub.api.model.Binding;
+import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
@@ -32,7 +33,8 @@ import java.util.List;
 public class ChoreographyLoopControl implements LoopControl {
 
   @Override
-  public List<Binding> select(final PlanExecutionContext context, final List<Binding> eligible) {
-    return eligible;
+  public Uni<List<Binding>> select(
+      final PlanExecutionContext context, final List<Binding> eligible) {
+    return Uni.createFrom().item(eligible);
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -119,21 +119,20 @@ public class CaseContextChangedEventHandler {
       eligible.add(binding);
     }
 
-    // LoopControl decides which eligible rules to fire (default: all of them)
     PlanExecutionContext planCtx =
         new PlanExecutionContext(caseInstance.getUuid(), definition, caseInstance.getCaseContext());
-    List<Binding> selected = loopControl.select(planCtx, eligible);
 
-    List<Uni<Void>> unis = new ArrayList<>(selected.size());
-    for (Binding b : selected) {
-      unis.add(publishWorkerSchedules(caseInstance, workers, b, b.getCapability()));
-    }
-
-    if (unis.isEmpty()) {
-      return Uni.createFrom().voidItem();
-    }
-
-    return Uni.combine().all().unis(unis).discardItems();
+    return loopControl
+        .select(planCtx, eligible)
+        .chain(
+            selected -> {
+              List<Uni<Void>> unis = new ArrayList<>(selected.size());
+              for (Binding b : selected) {
+                unis.add(publishWorkerSchedules(caseInstance, workers, b, b.getCapability()));
+              }
+              if (unis.isEmpty()) return Uni.createFrom().voidItem();
+              return Uni.combine().all().unis(unis).discardItems();
+            });
   }
 
   private Uni<Void> milestones(


### PR DESCRIPTION
## Summary

- Makes `LoopControl.select()` return `Uni<List<Binding>>` instead of `List<Binding>`
- `ChoreographyLoopControl` wraps with `Uni.createFrom().item(eligible)` — zero behaviour change
- `CaseContextChangedEventHandler.rules()` chains the Uni reactively

## Why

Enables `PlanningStrategy` implementations (coming in PRs 2/3) to perform non-blocking I/O during Binding selection — EventLog queries, LLM scoring — without blocking the Vert.x event loop. A synchronous control shell is a ceiling for what strategies can do. See the article [Four Things a Synchronous Blackboard Strategy Can't Do](https://mdproctor.github.io/casehub) for the motivation.

## Test plan

- [x] 386 engine + api tests pass (excluding pre-existing `SignalTest` class-load issue)
- [x] Zero behaviour change — `ChoreographyLoopControl` is a one-line wrapper

## Part of series
→ PR 2: `casehub-blackboard` data model  
→ PR 3: `casehub-blackboard` orchestration + integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)