### PR TITLE
fix(blackboard): thread safety — volatile, AtomicReference CAS, atomic addPlanItemIfAbsent [QE-A/5]

### DIFF
--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/control/PlanningStrategyLoopControl.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/control/PlanningStrategyLoopControl.java
@@ -65,13 +65,12 @@ public class PlanningStrategyLoopControl implements LoopControl {
     UUID caseId = ctx.caseId();
     CasePlanModel plan = registry.getOrCreate(caseId);
 
-    // Create a PlanItem for each eligible Binding and add to agenda, skipping duplicates
+    // Create a PlanItem for each eligible Binding and add to agenda, skipping duplicates.
+    // addPlanItemIfAbsent performs the check-and-insert atomically — no TOCTOU window.
     eligible.forEach(
         binding -> {
-          if (!plan.hasActivePlanItem(binding.getName())) {
-            String workerName = resolveWorkerName(binding, ctx);
-            plan.addPlanItem(PlanItem.create(binding.getName(), workerName, 0));
-          }
+          String workerName = resolveWorkerName(binding, ctx);
+          plan.addPlanItemIfAbsent(PlanItem.create(binding.getName(), workerName, 0));
         });
 
     return stageLifecycleEvaluator

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/CasePlanModel.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/CasePlanModel.java
@@ -49,6 +49,15 @@ public interface CasePlanModel {
    */
   boolean hasActivePlanItem(String bindingName);
 
+  /**
+   * Atomically adds the given PlanItem only if no PENDING or RUNNING item exists for the same
+   * binding name. The check and insert are a single atomic operation via {@code
+   * ConcurrentHashMap.compute()} — no TOCTOU window.
+   *
+   * @return true if the item was added; false if a duplicate was detected
+   */
+  boolean addPlanItemIfAbsent(PlanItem planItem);
+
   /** Returns only PENDING items, sorted highest-priority first. */
   List<PlanItem> getAgenda();
 

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/DefaultCasePlanModel.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/DefaultCasePlanModel.java
@@ -62,6 +62,26 @@ public class DefaultCasePlanModel implements CasePlanModel {
   }
 
   @Override
+  public boolean addPlanItemIfAbsent(PlanItem item) {
+    boolean[] added = {false};
+    activeByBinding.compute(
+        item.getBindingName(),
+        (k, existing) -> {
+          if (existing != null) {
+            PlanItem.PlanItemStatus s = existing.getStatus();
+            if (s == PlanItem.PlanItemStatus.PENDING || s == PlanItem.PlanItemStatus.RUNNING) {
+              return existing; // active item present — reject
+            }
+          }
+          agenda.add(item);
+          itemsById.put(item.getPlanItemId(), item);
+          added[0] = true;
+          return item;
+        });
+    return added[0];
+  }
+
+  @Override
   public void removePlanItem(String planItemId) {
     PlanItem item = itemsById.remove(planItemId);
     if (item != null) {

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java
@@ -34,7 +34,7 @@ public class PlanItem implements Comparable<PlanItem> {
   private final String bindingName;
   private final String workerName;
   private final int priority;
-  private PlanItemStatus status;
+  private volatile PlanItemStatus status;
   private final Instant createdAt;
   private String parentStageId; // null means no parent stage
 

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 /**
@@ -41,10 +42,10 @@ public class Stage {
 
   private final String stageId;
   private final String name;
-  private StageStatus status;
+  private final AtomicReference<StageStatus> status = new AtomicReference<>(StageStatus.PENDING);
   private final Instant createdAt;
-  private Instant activatedAt;
-  private Instant completedAt;
+  private volatile Instant activatedAt;
+  private volatile Instant completedAt;
   private String parentStageId; // null means root stage
 
   // Conditions — null means "no condition"
@@ -65,7 +66,6 @@ public class Stage {
   private Stage(String name) {
     this.stageId = UUID.randomUUID().toString();
     this.name = name;
-    this.status = StageStatus.PENDING;
     this.createdAt = Instant.now();
   }
 
@@ -117,34 +117,37 @@ public class Stage {
     return this;
   }
 
-  // Lifecycle transitions
+  // Lifecycle transitions — all use CAS so concurrent callers race atomically; exactly one wins
   public void activate() {
-    if (status == StageStatus.PENDING) {
-      status = StageStatus.ACTIVE;
+    if (status.compareAndSet(StageStatus.PENDING, StageStatus.ACTIVE)) {
       activatedAt = Instant.now();
     }
   }
 
   public void complete() {
-    if (status == StageStatus.ACTIVE || status == StageStatus.SUSPENDED) {
-      status = StageStatus.COMPLETED;
-      completedAt = Instant.now();
-    }
+    StageStatus current;
+    do {
+      current = status.get();
+      if (current != StageStatus.ACTIVE && current != StageStatus.SUSPENDED) return;
+    } while (!status.compareAndSet(current, StageStatus.COMPLETED));
+    completedAt = Instant.now();
   }
 
   public void terminate() {
-    if (status == StageStatus.ACTIVE || status == StageStatus.SUSPENDED) {
-      status = StageStatus.TERMINATED;
-      completedAt = Instant.now();
-    }
+    StageStatus current;
+    do {
+      current = status.get();
+      if (current != StageStatus.ACTIVE && current != StageStatus.SUSPENDED) return;
+    } while (!status.compareAndSet(current, StageStatus.TERMINATED));
+    completedAt = Instant.now();
   }
 
   public void suspend() {
-    if (status == StageStatus.ACTIVE) status = StageStatus.SUSPENDED;
+    status.compareAndSet(StageStatus.ACTIVE, StageStatus.SUSPENDED);
   }
 
   public void resume() {
-    if (status == StageStatus.SUSPENDED) status = StageStatus.ACTIVE;
+    status.compareAndSet(StageStatus.SUSPENDED, StageStatus.ACTIVE);
   }
 
   /**
@@ -154,20 +157,24 @@ public class Stage {
    * that arrived out of order.
    */
   public void fault() {
-    if (!isTerminal()) {
-      status = StageStatus.FAULTED;
-      completedAt = Instant.now();
-    }
+    StageStatus current;
+    do {
+      current = status.get();
+      if (isTerminalStatus(current)) return;
+    } while (!status.compareAndSet(current, StageStatus.FAULTED));
+    completedAt = Instant.now();
   }
 
   public boolean isTerminal() {
-    return status == StageStatus.COMPLETED
-        || status == StageStatus.TERMINATED
-        || status == StageStatus.FAULTED;
+    return isTerminalStatus(status.get());
   }
 
   public boolean isActive() {
-    return status == StageStatus.ACTIVE;
+    return status.get() == StageStatus.ACTIVE;
+  }
+
+  private static boolean isTerminalStatus(StageStatus s) {
+    return s == StageStatus.COMPLETED || s == StageStatus.TERMINATED || s == StageStatus.FAULTED;
   }
 
   // Containment mutations — sets handle deduplication atomically; no contains-before-add guard
@@ -206,7 +213,7 @@ public class Stage {
   }
 
   public StageStatus getStatus() {
-    return status;
+    return status.get();
   }
 
   public Instant getCreatedAt() {

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
@@ -164,4 +164,72 @@ class DefaultCasePlanModelTest {
     assertThat(plan.getPendingStages()).containsExactly(pending);
     assertThat(plan.getActiveStages()).containsExactly(active);
   }
+
+  @Test
+  void addPlanItemIfAbsent_returns_true_when_no_active_item() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    assertThat(plan.addPlanItemIfAbsent(item)).isTrue();
+    assertThat(plan.getAgenda()).hasSize(1);
+  }
+
+  @Test
+  void addPlanItemIfAbsent_returns_false_when_pending_item_exists() {
+    PlanItem first = PlanItem.create("binding-a", "worker-a", 0);
+    PlanItem second = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItemIfAbsent(first);
+    assertThat(plan.addPlanItemIfAbsent(second)).isFalse();
+    assertThat(plan.getAgenda()).hasSize(1);
+  }
+
+  @Test
+  void addPlanItemIfAbsent_returns_false_when_running_item_exists() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItemIfAbsent(item);
+    item.setStatus(PlanItem.PlanItemStatus.RUNNING);
+    PlanItem second = PlanItem.create("binding-a", "worker-a", 0);
+    assertThat(plan.addPlanItemIfAbsent(second)).isFalse();
+  }
+
+  @Test
+  void addPlanItemIfAbsent_returns_true_when_prior_item_is_completed() {
+    PlanItem first = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItemIfAbsent(first);
+    first.setStatus(PlanItem.PlanItemStatus.COMPLETED);
+    PlanItem second = PlanItem.create("binding-a", "worker-a", 0);
+    assertThat(plan.addPlanItemIfAbsent(second)).isTrue();
+  }
+
+  @Test
+  void concurrent_addPlanItemIfAbsent_for_same_binding_adds_exactly_one() throws Exception {
+    int threads = 10;
+    java.util.concurrent.CountDownLatch start = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(threads);
+    java.util.concurrent.atomic.AtomicInteger addedCount =
+        new java.util.concurrent.atomic.AtomicInteger(0);
+
+    for (int i = 0; i < threads; i++) {
+      int idx = i;
+      Thread t =
+          new Thread(
+              () -> {
+                try {
+                  start.await();
+                  PlanItem item = PlanItem.create("binding-a", "worker-" + idx, 0);
+                  if (plan.addPlanItemIfAbsent(item)) addedCount.incrementAndGet();
+                } catch (InterruptedException ignored) {
+                } finally {
+                  done.countDown();
+                }
+              });
+      t.start();
+    }
+
+    start.countDown();
+    done.await(5, java.util.concurrent.TimeUnit.SECONDS);
+
+    assertThat(addedCount.get())
+        .as("Exactly one thread should have added the PlanItem")
+        .isEqualTo(1);
+    assertThat(plan.getAgenda()).hasSize(1);
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java
@@ -72,4 +72,12 @@ class PlanItemTest {
     item.setStatus(PlanItem.PlanItemStatus.CANCELLED);
     assertThat(item.getStatus()).isEqualTo(PlanItem.PlanItemStatus.CANCELLED);
   }
+
+  @Test
+  void status_field_is_volatile() throws NoSuchFieldException {
+    java.lang.reflect.Field field = PlanItem.class.getDeclaredField("status");
+    assertThat(java.lang.reflect.Modifier.isVolatile(field.getModifiers()))
+        .as("PlanItem.status must be volatile for cross-thread visibility")
+        .isTrue();
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
@@ -139,4 +139,13 @@ class StageTest {
     s.fault();
     assertThat(s.isTerminal()).isTrue();
   }
+
+  @Test
+  void status_field_is_atomic_reference() throws NoSuchFieldException {
+    java.lang.reflect.Field field = Stage.class.getDeclaredField("status");
+    field.setAccessible(true);
+    assertThat(field.getType())
+        .as("Stage.status must be AtomicReference to prevent concurrent transition races")
+        .isEqualTo(java.util.concurrent.atomic.AtomicReference.class);
+  }
 }


### PR DESCRIPTION
Stacks on #88/#89/#90 (merge those first). Thread safety: PlanItem.status volatile, Stage.status AtomicReference CAS, addPlanItemIfAbsent via ConcurrentHashMap.compute(). 99 tests.