### PR TITLE
fix(blackboard): nested stage activation gated on parent ACTIVE state [QE-C/5]

### DIFF
--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/control/PlanningStrategyLoopControl.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/control/PlanningStrategyLoopControl.java
@@ -65,13 +65,12 @@ public class PlanningStrategyLoopControl implements LoopControl {
     UUID caseId = ctx.caseId();
     CasePlanModel plan = registry.getOrCreate(caseId);
 
-    // Create a PlanItem for each eligible Binding and add to agenda, skipping duplicates
+    // Create a PlanItem for each eligible Binding and add to agenda, skipping duplicates.
+    // addPlanItemIfAbsent performs the check-and-insert atomically — no TOCTOU window.
     eligible.forEach(
         binding -> {
-          if (!plan.hasActivePlanItem(binding.getName())) {
-            String workerName = resolveWorkerName(binding, ctx);
-            plan.addPlanItem(PlanItem.create(binding.getName(), workerName, 0));
-          }
+          String workerName = resolveWorkerName(binding, ctx);
+          plan.addPlanItemIfAbsent(PlanItem.create(binding.getName(), workerName, 0));
         });
 
     return stageLifecycleEvaluator

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/control/StageLifecycleEvaluator.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/control/StageLifecycleEvaluator.java
@@ -83,6 +83,14 @@ public class StageLifecycleEvaluator {
   private void activatePendingStages(CasePlanModel plan, PlanExecutionContext ctx) {
     for (Stage stage : plan.getPendingStages()) {
       if (stage.isManualActivation()) continue;
+
+      // Nested stage: only evaluate if parent is ACTIVE
+      if (stage.getParentStageId().isPresent()) {
+        String parentId = stage.getParentStageId().get();
+        boolean parentActive = plan.getStage(parentId).map(Stage::isActive).orElse(false);
+        if (!parentActive) continue;
+      }
+
       boolean conditionMet = evaluateCondition(stage.getEntryCondition(), ctx.caseContext());
       if (conditionMet) {
         stage.activate();

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/handler/CaseEvictionHandler.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/handler/CaseEvictionHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.internal.event.CaseStatusChanged;
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Set;
+
+/**
+ * Evicts {@link io.casehub.blackboard.plan.CasePlanModel} from {@link BlackboardRegistry} when a
+ * case reaches a terminal state. Prevents unbounded memory growth. See casehubio/engine#76.
+ */
+@ApplicationScoped
+public class CaseEvictionHandler {
+
+  private static final Set<String> TERMINAL_STATUSES =
+      Set.of(CaseStatus.COMPLETED.name(), CaseStatus.FAULTED.name(), CaseStatus.CANCELLED.name());
+
+  private final BlackboardRegistry registry;
+
+  @Inject
+  public CaseEvictionHandler(BlackboardRegistry registry) {
+    this.registry = registry;
+  }
+
+  @ConsumeEvent(EventBusAddresses.CASE_STATUS_CHANGED)
+  public Uni<Void> onCaseStatusChanged(CaseStatusChanged event) {
+    if (TERMINAL_STATUSES.contains(event.newStatus())) {
+      registry.evict(event.instance().getUuid());
+    }
+    return Uni.createFrom().voidItem();
+  }
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemCompletionHandler.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemCompletionHandler.java
@@ -82,7 +82,9 @@ public class PlanItemCompletionHandler {
             item -> {
               item.setStatus(PlanItem.PlanItemStatus.COMPLETED);
               // activeByBinding self-cleans lazily in hasActivePlanItem() when it encounters a
-              // terminal item. itemsById retains completed items for post-completion observability.
+              // terminal item — so hasActivePlanItem("binding-x") returns false immediately after
+              // setStatus(COMPLETED). itemsById retains completed items for post-completion
+              // observability (e.g. integration-test assertions on PlanItem status).
               evaluateStageAutocomplete(caseId, plan, planItemId);
             });
 
@@ -100,7 +102,8 @@ public class PlanItemCompletionHandler {
                   itemId ->
                       plan.getPlanItem(itemId)
                           .map(pi -> pi.getStatus() == PlanItem.PlanItemStatus.COMPLETED)
-                          .orElse(false));
+                          .orElse(
+                              false)); // unregistered item — treat as not done, blocks autocomplete
 
       if (allDone) {
         stage.complete();

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/CasePlanModel.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/CasePlanModel.java
@@ -49,6 +49,15 @@ public interface CasePlanModel {
    */
   boolean hasActivePlanItem(String bindingName);
 
+  /**
+   * Atomically adds the given PlanItem only if no PENDING or RUNNING item exists for the same
+   * binding name. The check and insert are a single atomic operation via {@code
+   * ConcurrentHashMap.compute()} — no TOCTOU window.
+   *
+   * @return true if the item was added; false if a duplicate was detected
+   */
+  boolean addPlanItemIfAbsent(PlanItem planItem);
+
   /** Returns only PENDING items, sorted highest-priority first. */
   List<PlanItem> getAgenda();
 

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/DefaultCasePlanModel.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/DefaultCasePlanModel.java
@@ -161,7 +161,7 @@ public class DefaultCasePlanModel implements CasePlanModel {
 
   @Override
   public void achieveMilestone(String name) {
-    milestones.computeIfPresent(name, (k, v) -> Boolean.TRUE);
+    milestones.put(name, Boolean.TRUE);
   }
 
   @Override

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/DefaultCasePlanModel.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/DefaultCasePlanModel.java
@@ -62,6 +62,26 @@ public class DefaultCasePlanModel implements CasePlanModel {
   }
 
   @Override
+  public boolean addPlanItemIfAbsent(PlanItem item) {
+    boolean[] added = {false};
+    activeByBinding.compute(
+        item.getBindingName(),
+        (k, existing) -> {
+          if (existing != null) {
+            PlanItem.PlanItemStatus s = existing.getStatus();
+            if (s == PlanItem.PlanItemStatus.PENDING || s == PlanItem.PlanItemStatus.RUNNING) {
+              return existing; // active item present — reject
+            }
+          }
+          agenda.add(item);
+          itemsById.put(item.getPlanItemId(), item);
+          added[0] = true;
+          return item;
+        });
+    return added[0];
+  }
+
+  @Override
   public void removePlanItem(String planItemId) {
     PlanItem item = itemsById.remove(planItemId);
     if (item != null) {

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java
@@ -34,7 +34,7 @@ public class PlanItem implements Comparable<PlanItem> {
   private final String bindingName;
   private final String workerName;
   private final int priority;
-  private PlanItemStatus status;
+  private volatile PlanItemStatus status;
   private final Instant createdAt;
   private String parentStageId; // null means no parent stage
 

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 /**
@@ -41,10 +42,10 @@ public class Stage {
 
   private final String stageId;
   private final String name;
-  private StageStatus status;
+  private final AtomicReference<StageStatus> status = new AtomicReference<>(StageStatus.PENDING);
   private final Instant createdAt;
-  private Instant activatedAt;
-  private Instant completedAt;
+  private volatile Instant activatedAt;
+  private volatile Instant completedAt;
   private String parentStageId; // null means root stage
 
   // Conditions — null means "no condition"
@@ -65,7 +66,6 @@ public class Stage {
   private Stage(String name) {
     this.stageId = UUID.randomUUID().toString();
     this.name = name;
-    this.status = StageStatus.PENDING;
     this.createdAt = Instant.now();
   }
 
@@ -117,34 +117,37 @@ public class Stage {
     return this;
   }
 
-  // Lifecycle transitions
+  // Lifecycle transitions — all use CAS so concurrent callers race atomically; exactly one wins
   public void activate() {
-    if (status == StageStatus.PENDING) {
-      status = StageStatus.ACTIVE;
+    if (status.compareAndSet(StageStatus.PENDING, StageStatus.ACTIVE)) {
       activatedAt = Instant.now();
     }
   }
 
   public void complete() {
-    if (status == StageStatus.ACTIVE || status == StageStatus.SUSPENDED) {
-      status = StageStatus.COMPLETED;
-      completedAt = Instant.now();
-    }
+    StageStatus current;
+    do {
+      current = status.get();
+      if (current != StageStatus.ACTIVE && current != StageStatus.SUSPENDED) return;
+    } while (!status.compareAndSet(current, StageStatus.COMPLETED));
+    completedAt = Instant.now();
   }
 
   public void terminate() {
-    if (status == StageStatus.ACTIVE || status == StageStatus.SUSPENDED) {
-      status = StageStatus.TERMINATED;
-      completedAt = Instant.now();
-    }
+    StageStatus current;
+    do {
+      current = status.get();
+      if (current != StageStatus.ACTIVE && current != StageStatus.SUSPENDED) return;
+    } while (!status.compareAndSet(current, StageStatus.TERMINATED));
+    completedAt = Instant.now();
   }
 
   public void suspend() {
-    if (status == StageStatus.ACTIVE) status = StageStatus.SUSPENDED;
+    status.compareAndSet(StageStatus.ACTIVE, StageStatus.SUSPENDED);
   }
 
   public void resume() {
-    if (status == StageStatus.SUSPENDED) status = StageStatus.ACTIVE;
+    status.compareAndSet(StageStatus.SUSPENDED, StageStatus.ACTIVE);
   }
 
   /**
@@ -154,20 +157,24 @@ public class Stage {
    * that arrived out of order.
    */
   public void fault() {
-    if (!isTerminal()) {
-      status = StageStatus.FAULTED;
-      completedAt = Instant.now();
-    }
+    StageStatus current;
+    do {
+      current = status.get();
+      if (isTerminalStatus(current)) return;
+    } while (!status.compareAndSet(current, StageStatus.FAULTED));
+    completedAt = Instant.now();
   }
 
   public boolean isTerminal() {
-    return status == StageStatus.COMPLETED
-        || status == StageStatus.TERMINATED
-        || status == StageStatus.FAULTED;
+    return isTerminalStatus(status.get());
   }
 
   public boolean isActive() {
-    return status == StageStatus.ACTIVE;
+    return status.get() == StageStatus.ACTIVE;
+  }
+
+  private static boolean isTerminalStatus(StageStatus s) {
+    return s == StageStatus.COMPLETED || s == StageStatus.TERMINATED || s == StageStatus.FAULTED;
   }
 
   // Containment mutations — sets handle deduplication atomically; no contains-before-add guard
@@ -206,7 +213,7 @@ public class Stage {
   }
 
   public StageStatus getStatus() {
-    return status;
+    return status.get();
   }
 
   public Instant getCreatedAt() {

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/control/StageLifecycleEvaluatorTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/control/StageLifecycleEvaluatorTest.java
@@ -118,4 +118,52 @@ class StageLifecycleEvaluatorTest {
     assertThat(stage.getStatus()).isEqualTo(StageStatus.PENDING);
     verifyNoInteractions(mockBus);
   }
+
+  @Test
+  void nested_stage_stays_pending_while_parent_is_pending() {
+    Stage parent = Stage.create("parent").withEntryCondition(c -> false); // never activates
+    Stage child = Stage.create("child").withParentStage(parent.getStageId());
+
+    plan.addStage(parent);
+    plan.addStage(child);
+
+    evaluator.evaluate(plan, ctx).await().indefinitely();
+
+    assertThat(parent.getStatus()).isEqualTo(StageStatus.PENDING);
+    assertThat(child.getStatus())
+        .as("child stage must stay PENDING when parent is not ACTIVE")
+        .isEqualTo(StageStatus.PENDING);
+  }
+
+  @Test
+  void nested_stage_activates_after_parent_becomes_active() {
+    Stage parent = Stage.create("parent"); // no entry condition — activates immediately
+    Stage child = Stage.create("child").withParentStage(parent.getStageId());
+
+    plan.addStage(parent);
+    plan.addStage(child);
+
+    // First cycle: parent activates. Child is still PENDING this cycle
+    // because getPendingStages() snapshot was taken before parent activated.
+    evaluator.evaluate(plan, ctx).await().indefinitely();
+    assertThat(parent.getStatus()).isEqualTo(StageStatus.ACTIVE);
+
+    // Second cycle: parent is now ACTIVE, child can activate
+    evaluator.evaluate(plan, ctx).await().indefinitely();
+    assertThat(child.getStatus())
+        .as("child stage must activate once parent is ACTIVE")
+        .isEqualTo(StageStatus.ACTIVE);
+  }
+
+  @Test
+  void root_stage_without_parent_activates_normally() {
+    Stage root = Stage.create("root"); // no parentStageId
+    plan.addStage(root);
+
+    evaluator.evaluate(plan, ctx).await().indefinitely();
+
+    assertThat(root.getStatus())
+        .as("root stage (no parent) must not be affected by parent-active guard")
+        .isEqualTo(StageStatus.ACTIVE);
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/handler/CaseEvictionHandlerTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/handler/CaseEvictionHandlerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.internal.event.CaseStatusChanged;
+import io.casehub.engine.internal.model.CaseInstance;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for CaseEvictionHandler. See casehubio/engine#76. */
+class CaseEvictionHandlerTest {
+
+  @Test
+  void evicts_plan_model_on_completed_status() {
+    BlackboardRegistry registry = new BlackboardRegistry();
+    UUID caseId = UUID.randomUUID();
+    registry.getOrCreate(caseId);
+
+    CaseEvictionHandler handler = new CaseEvictionHandler(registry);
+    CaseInstance instance = mock(CaseInstance.class);
+    when(instance.getUuid()).thenReturn(caseId);
+
+    handler
+        .onCaseStatusChanged(
+            new CaseStatusChanged(instance, CaseStatus.RUNNING.name(), CaseStatus.COMPLETED.name()))
+        .await()
+        .indefinitely();
+
+    assertThat(registry.get(caseId)).isEmpty();
+  }
+
+  @Test
+  void evicts_on_faulted_status() {
+    BlackboardRegistry registry = new BlackboardRegistry();
+    UUID caseId = UUID.randomUUID();
+    registry.getOrCreate(caseId);
+    CaseEvictionHandler handler = new CaseEvictionHandler(registry);
+    CaseInstance instance = mock(CaseInstance.class);
+    when(instance.getUuid()).thenReturn(caseId);
+
+    handler
+        .onCaseStatusChanged(
+            new CaseStatusChanged(instance, CaseStatus.RUNNING.name(), CaseStatus.FAULTED.name()))
+        .await()
+        .indefinitely();
+
+    assertThat(registry.get(caseId)).isEmpty();
+  }
+
+  @Test
+  void evicts_on_cancelled_status() {
+    BlackboardRegistry registry = new BlackboardRegistry();
+    UUID caseId = UUID.randomUUID();
+    registry.getOrCreate(caseId);
+    CaseEvictionHandler handler = new CaseEvictionHandler(registry);
+    CaseInstance instance = mock(CaseInstance.class);
+    when(instance.getUuid()).thenReturn(caseId);
+
+    handler
+        .onCaseStatusChanged(
+            new CaseStatusChanged(instance, CaseStatus.RUNNING.name(), CaseStatus.CANCELLED.name()))
+        .await()
+        .indefinitely();
+
+    assertThat(registry.get(caseId)).isEmpty();
+  }
+
+  @Test
+  void does_not_evict_on_running_status() {
+    BlackboardRegistry registry = new BlackboardRegistry();
+    UUID caseId = UUID.randomUUID();
+    registry.getOrCreate(caseId);
+    CaseEvictionHandler handler = new CaseEvictionHandler(registry);
+    CaseInstance instance = mock(CaseInstance.class);
+    when(instance.getUuid()).thenReturn(caseId);
+
+    handler
+        .onCaseStatusChanged(
+            new CaseStatusChanged(instance, CaseStatus.RUNNING.name(), CaseStatus.RUNNING.name()))
+        .await()
+        .indefinitely();
+
+    assertThat(registry.get(caseId)).isPresent();
+  }
+
+  @Test
+  void no_plan_model_does_not_throw() {
+    BlackboardRegistry registry = new BlackboardRegistry();
+    CaseEvictionHandler handler = new CaseEvictionHandler(registry);
+    CaseInstance instance = mock(CaseInstance.class);
+    when(instance.getUuid()).thenReturn(UUID.randomUUID());
+
+    handler
+        .onCaseStatusChanged(
+            new CaseStatusChanged(instance, CaseStatus.RUNNING.name(), CaseStatus.COMPLETED.name()))
+        .await()
+        .indefinitely();
+    // no exception expected
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
@@ -123,6 +123,38 @@ class PlanItemCompletionHandlerTest {
   }
 
   @Test
+  void completed_plan_item_is_removed_from_active_tracking() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItem(item);
+    registry.indexWorkerForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler.onWorkerFinished(eventFor("worker-a")).await().indefinitely();
+
+    assertThat(plan.hasActivePlanItem("binding-a"))
+        .as("completed PlanItem must be removed from active tracking")
+        .isFalse();
+  }
+
+  @Test
+  void autocomplete_with_unregistered_required_item_does_not_complete_stage() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItem(item);
+    registry.indexWorkerForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    Stage stage = Stage.create("intake");
+    stage.addRequiredItem("non-existent-id"); // not in plan
+    stage.activate();
+    plan.addStage(stage);
+
+    handler.onWorkerFinished(eventFor("worker-a")).await().indefinitely();
+
+    assertThat(stage.isTerminal())
+        .as("stage must not autocomplete when required item is not registered")
+        .isFalse();
+    verifyNoInteractions(mockBus);
+  }
+
+  @Test
   void autocomplete_false_stage_does_not_complete_even_when_all_done() {
     PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
     plan.addPlanItem(item);

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/it/StageBlackboardTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/it/StageBlackboardTest.java
@@ -296,6 +296,47 @@ class StageBlackboardTest {
   }
 
   // ------------------------------------------------------------------ //
+  // Nested stage — child activates only after parent is ACTIVE           //
+  // ------------------------------------------------------------------ //
+
+  /**
+   * Verifies nested stage only activates after its parent is ACTIVE. Two evaluation cycles are
+   * required: cycle 1 activates parent, cycle 2 activates child.
+   */
+  @Test
+  void nested_stage_activates_only_after_parent_is_active() {
+    UUID caseId = signalCase.startCase(Map.of("ready", true)).toCompletableFuture().join();
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
+
+    Stage parent = Stage.create("parent-stage"); // no entry condition — activates immediately
+    Stage child = Stage.create("child-stage").withParentStage(parent.getStageId());
+
+    registry.get(caseId).get().addStage(parent);
+    registry.get(caseId).get().addStage(child);
+
+    // Trigger cycle 1 — parent activates, child stays PENDING
+    signalCase.signal(caseId, "probe", "tick-1");
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(parent.getStatus()).isEqualTo(StageStatus.ACTIVE));
+
+    // Trigger cycle 2 — child now activates because parent is ACTIVE
+    signalCase.signal(caseId, "probe", "tick-2");
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(child.getStatus())
+                    .as("child must activate on the cycle after parent becomes ACTIVE")
+                    .isEqualTo(StageStatus.ACTIVE));
+  }
+
+  // ------------------------------------------------------------------ //
   // Test beans                                                            //
   // ------------------------------------------------------------------ //
 

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
@@ -92,8 +92,23 @@ class DefaultCasePlanModelTest {
 
   @Test
   void achieve_untracked_milestone_does_not_throw() {
+    // achieveMilestone records regardless of prior trackMilestone — no exception expected
     plan.achieveMilestone("unknown");
-    assertThat(plan.isMilestoneAchieved("unknown")).isFalse();
+  }
+
+  @Test
+  void achieveMilestone_before_trackMilestone_still_records_achievement() {
+    plan.achieveMilestone("docs-received");
+    assertThat(plan.isMilestoneAchieved("docs-received"))
+        .as("achieveMilestone must record regardless of trackMilestone call order")
+        .isTrue();
+  }
+
+  @Test
+  void trackMilestone_after_achieve_sees_already_achieved() {
+    plan.achieveMilestone("docs-received");
+    plan.trackMilestone("docs-received");
+    assertThat(plan.isMilestoneAchieved("docs-received")).isTrue();
   }
 
   @Test

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
@@ -164,4 +164,72 @@ class DefaultCasePlanModelTest {
     assertThat(plan.getPendingStages()).containsExactly(pending);
     assertThat(plan.getActiveStages()).containsExactly(active);
   }
+
+  @Test
+  void addPlanItemIfAbsent_returns_true_when_no_active_item() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    assertThat(plan.addPlanItemIfAbsent(item)).isTrue();
+    assertThat(plan.getAgenda()).hasSize(1);
+  }
+
+  @Test
+  void addPlanItemIfAbsent_returns_false_when_pending_item_exists() {
+    PlanItem first = PlanItem.create("binding-a", "worker-a", 0);
+    PlanItem second = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItemIfAbsent(first);
+    assertThat(plan.addPlanItemIfAbsent(second)).isFalse();
+    assertThat(plan.getAgenda()).hasSize(1);
+  }
+
+  @Test
+  void addPlanItemIfAbsent_returns_false_when_running_item_exists() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItemIfAbsent(item);
+    item.setStatus(PlanItem.PlanItemStatus.RUNNING);
+    PlanItem second = PlanItem.create("binding-a", "worker-a", 0);
+    assertThat(plan.addPlanItemIfAbsent(second)).isFalse();
+  }
+
+  @Test
+  void addPlanItemIfAbsent_returns_true_when_prior_item_is_completed() {
+    PlanItem first = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItemIfAbsent(first);
+    first.setStatus(PlanItem.PlanItemStatus.COMPLETED);
+    PlanItem second = PlanItem.create("binding-a", "worker-a", 0);
+    assertThat(plan.addPlanItemIfAbsent(second)).isTrue();
+  }
+
+  @Test
+  void concurrent_addPlanItemIfAbsent_for_same_binding_adds_exactly_one() throws Exception {
+    int threads = 10;
+    java.util.concurrent.CountDownLatch start = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(threads);
+    java.util.concurrent.atomic.AtomicInteger addedCount =
+        new java.util.concurrent.atomic.AtomicInteger(0);
+
+    for (int i = 0; i < threads; i++) {
+      int idx = i;
+      Thread t =
+          new Thread(
+              () -> {
+                try {
+                  start.await();
+                  PlanItem item = PlanItem.create("binding-a", "worker-" + idx, 0);
+                  if (plan.addPlanItemIfAbsent(item)) addedCount.incrementAndGet();
+                } catch (InterruptedException ignored) {
+                } finally {
+                  done.countDown();
+                }
+              });
+      t.start();
+    }
+
+    start.countDown();
+    done.await(5, java.util.concurrent.TimeUnit.SECONDS);
+
+    assertThat(addedCount.get())
+        .as("Exactly one thread should have added the PlanItem")
+        .isEqualTo(1);
+    assertThat(plan.getAgenda()).hasSize(1);
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java
@@ -72,4 +72,12 @@ class PlanItemTest {
     item.setStatus(PlanItem.PlanItemStatus.CANCELLED);
     assertThat(item.getStatus()).isEqualTo(PlanItem.PlanItemStatus.CANCELLED);
   }
+
+  @Test
+  void status_field_is_volatile() throws NoSuchFieldException {
+    java.lang.reflect.Field field = PlanItem.class.getDeclaredField("status");
+    assertThat(java.lang.reflect.Modifier.isVolatile(field.getModifiers()))
+        .as("PlanItem.status must be volatile for cross-thread visibility")
+        .isTrue();
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
@@ -139,4 +139,13 @@ class StageTest {
     s.fault();
     assertThat(s.isTerminal()).isTrue();
   }
+
+  @Test
+  void status_field_is_atomic_reference() throws NoSuchFieldException {
+    java.lang.reflect.Field field = Stage.class.getDeclaredField("status");
+    field.setAccessible(true);
+    assertThat(field.getType())
+        .as("Stage.status must be AtomicReference to prevent concurrent transition races")
+        .isEqualTo(java.util.concurrent.atomic.AtomicReference.class);
+  }
 }


### PR DESCRIPTION
Stacks on QE-B. StageLifecycleEvaluator now skips nested stages whose parent is not yet ACTIVE. Unit tests + @QuarkusTest integration test (two-cycle behaviour documented).