### PR TITLE
fix+test(blackboard): edge cases — dedup contract, getTopPlanItems(0), fault() guards [QE-E/5]

### DIFF
--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/control/DefaultPlanningStrategy.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/control/DefaultPlanningStrategy.java
@@ -43,6 +43,7 @@ public class DefaultPlanningStrategy implements PlanningStrategy {
   @Override
   public Uni<List<Binding>> select(
       CasePlanModel plan, PlanExecutionContext context, List<Binding> eligible) {
-    return Uni.createFrom().item(eligible);
+    List<Binding> deduped = eligible.stream().distinct().toList();
+    return Uni.createFrom().item(deduped);
   }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/control/PlanningStrategyContractTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/control/PlanningStrategyContractTest.java
@@ -68,4 +68,18 @@ public abstract class PlanningStrategyContractTest {
     List<Binding> result = strategy().select(plan, ctx(), List.of()).await().indefinitely();
     assertThat(result).isNotNull();
   }
+
+  @Test
+  void result_does_not_contain_duplicates_when_eligible_has_duplicates() {
+    CasePlanModel plan = new DefaultCasePlanModel(UUID.randomUUID());
+    Binding b1 = mock(Binding.class);
+    List<Binding> eligibleWithDuplicate = List.of(b1, b1);
+
+    List<Binding> result =
+        strategy().select(plan, ctx(), eligibleWithDuplicate).await().indefinitely();
+
+    assertThat(result)
+        .as("strategy must not return duplicate bindings even if eligible list contains duplicates")
+        .doesNotHaveDuplicates();
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
@@ -247,4 +247,22 @@ class DefaultCasePlanModelTest {
         .isEqualTo(1);
     assertThat(plan.getAgenda()).hasSize(1);
   }
+
+  @Test
+  void getTopPlanItems_with_zero_limit_returns_empty() {
+    plan.addPlanItem(PlanItem.create("b-a", "w-a", 5));
+    plan.addPlanItem(PlanItem.create("b-b", "w-b", 3));
+    assertThat(plan.getTopPlanItems(0))
+        .as("getTopPlanItems(0) must return empty, not all items")
+        .isEmpty();
+  }
+
+  @Test
+  void get_returns_empty_when_type_does_not_match() {
+    plan.put("count", 42);
+    assertThat(plan.get("count", String.class))
+        .as("get() must return empty when stored type does not match — no ClassCastException")
+        .isEmpty();
+    assertThat(plan.get("count", Integer.class)).contains(42);
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
@@ -148,4 +148,33 @@ class StageTest {
         .as("Stage.status must be AtomicReference to prevent concurrent transition races")
         .isEqualTo(java.util.concurrent.atomic.AtomicReference.class);
   }
+
+  @Test
+  void fault_from_pending_transitions_to_faulted() {
+    Stage s = Stage.create("x");
+    s.fault();
+    assertThat(s.getStatus()).isEqualTo(StageStatus.FAULTED);
+    assertThat(s.isTerminal()).isTrue();
+  }
+
+  @Test
+  void fault_from_faulted_is_noop() {
+    Stage s = Stage.create("x");
+    s.fault();
+    s.fault(); // second call must not corrupt state
+    assertThat(s.getStatus())
+        .as("fault() on already-FAULTED stage must remain FAULTED")
+        .isEqualTo(StageStatus.FAULTED);
+  }
+
+  @Test
+  void fault_from_completed_is_noop() {
+    Stage s = Stage.create("x");
+    s.activate();
+    s.complete();
+    s.fault(); // must not overwrite COMPLETED
+    assertThat(s.getStatus())
+        .as("fault() must not overwrite a terminal COMPLETED state")
+        .isEqualTo(StageStatus.COMPLETED);
+  }
 }


### PR DESCRIPTION
Stacks on QE-D. DefaultPlanningStrategy deduplicates eligible list; contract test verifies. getTopPlanItems(0) returns empty. Type-mismatch get() returns empty. fault() from terminal states confirmed no-op.