### PR TITLE
feat(blackboard): BlackboardPlanConfigurer SPI — per-type plan config with per-instance semantics [QE-F/4]

### DIFF
--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/control/BlackboardPlanConfigurer.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/control/BlackboardPlanConfigurer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.control;
+
+import io.casehub.api.engine.PlanExecutionContext;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.blackboard.plan.CasePlanModel;
+
+/**
+ * SPI for configuring a new {@link CasePlanModel} when a case instance starts. Implement as CDI
+ * {@code @ApplicationScoped}. Called exactly once per case instance when {@link
+ * PlanningStrategyLoopControl} first creates its plan model. See casehubio/engine#76.
+ */
+public interface BlackboardPlanConfigurer {
+
+  /**
+   * Returns true if this configurer applies to cases of the given definition. Default: always
+   * applies.
+   */
+  default boolean supports(CaseDefinition definition) {
+    return true;
+  }
+
+  /**
+   * Configure the plan model for a newly started case. Called once before any binding fires.
+   *
+   * @param plan the freshly created {@link CasePlanModel} for the case instance
+   * @param context the execution context carrying the case id, definition, and current case context
+   */
+  void configure(CasePlanModel plan, PlanExecutionContext context);
+}

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/control/DefaultPlanningStrategy.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/control/DefaultPlanningStrategy.java
@@ -43,6 +43,7 @@ public class DefaultPlanningStrategy implements PlanningStrategy {
   @Override
   public Uni<List<Binding>> select(
       CasePlanModel plan, PlanExecutionContext context, List<Binding> eligible) {
-    return Uni.createFrom().item(eligible);
+    List<Binding> deduped = eligible.stream().distinct().toList();
+    return Uni.createFrom().item(deduped);
   }
 }

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/control/PlanningStrategyLoopControl.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/control/PlanningStrategyLoopControl.java
@@ -26,6 +26,7 @@ import io.smallrye.mutiny.Uni;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.UUID;
@@ -49,21 +50,32 @@ public class PlanningStrategyLoopControl implements LoopControl {
   private final BlackboardRegistry registry;
   private final PlanningStrategy planningStrategy;
   private final StageLifecycleEvaluator stageLifecycleEvaluator;
+  private final Instance<BlackboardPlanConfigurer> configurers;
 
   @Inject
   public PlanningStrategyLoopControl(
       BlackboardRegistry registry,
       PlanningStrategy planningStrategy,
-      StageLifecycleEvaluator stageLifecycleEvaluator) {
+      StageLifecycleEvaluator stageLifecycleEvaluator,
+      Instance<BlackboardPlanConfigurer> configurers) {
     this.registry = registry;
     this.planningStrategy = planningStrategy;
     this.stageLifecycleEvaluator = stageLifecycleEvaluator;
+    this.configurers = configurers;
   }
 
   @Override
   public Uni<List<Binding>> select(PlanExecutionContext ctx, List<Binding> eligible) {
     UUID caseId = ctx.caseId();
     CasePlanModel plan = registry.getOrCreate(caseId);
+
+    // On the first select() call for a case, run all applicable BlackboardPlanConfigurer beans.
+    // markConfigured() is atomic — only returns true once, guaranteeing exactly-once invocation.
+    if (registry.markConfigured(caseId)) {
+      configurers.stream()
+          .filter(c -> c.supports(ctx.definition()))
+          .forEach(c -> c.configure(plan, ctx));
+    }
 
     // Create a PlanItem for each eligible Binding and add to agenda, skipping duplicates.
     // addPlanItemIfAbsent performs the check-and-insert atomically — no TOCTOU window.

--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/registry/BlackboardRegistry.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/registry/BlackboardRegistry.java
@@ -19,6 +19,7 @@ import io.casehub.blackboard.plan.CasePlanModel;
 import io.casehub.blackboard.plan.DefaultCasePlanModel;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -43,6 +44,9 @@ public class BlackboardRegistry {
   // caseId → (workerName → planItemId)
   private final ConcurrentHashMap<UUID, ConcurrentHashMap<String, String>> completionIndex =
       new ConcurrentHashMap<>();
+
+  // caseIds that have already been configured by BlackboardPlanConfigurer(s)
+  private final Set<UUID> configured = ConcurrentHashMap.newKeySet();
 
   /**
    * Returns the {@link CasePlanModel} for the given case, creating it if absent. Only {@link
@@ -69,12 +73,24 @@ public class BlackboardRegistry {
   }
 
   /**
-   * Evicts the plan model and completion index for a completed or terminated case. Call when a case
-   * reaches a terminal state to prevent unbounded memory growth. See casehubio/engine#84 for the
-   * persistence SPI that will eventually replace this in-memory registry.
+   * Atomically marks a case as configured by {@link
+   * io.casehub.blackboard.control.BlackboardPlanConfigurer}(s). Returns {@code true} only the first
+   * time this method is called for the given case — subsequent calls return {@code false}. This
+   * guarantees configurers are invoked exactly once per case instance.
+   */
+  public boolean markConfigured(UUID caseId) {
+    return configured.add(caseId);
+  }
+
+  /**
+   * Evicts the plan model, completion index, and configured marker for a completed or terminated
+   * case. Call when a case reaches a terminal state to prevent unbounded memory growth. See
+   * casehubio/engine#84 for the persistence SPI that will eventually replace this in-memory
+   * registry.
    */
   public void evict(UUID caseId) {
     planModels.remove(caseId);
     completionIndex.remove(caseId);
+    configured.remove(caseId);
   }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/control/BlackboardPlanConfigurerTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/control/BlackboardPlanConfigurerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.control;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.engine.PlanExecutionContext;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.DefaultCasePlanModel;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class BlackboardPlanConfigurerTest {
+
+  @Test
+  void default_supports_returns_true_for_any_definition() {
+    BlackboardPlanConfigurer c = (plan, ctx) -> {};
+    assertThat(c.supports(mock(CaseDefinition.class))).isTrue();
+  }
+
+  @Test
+  void configure_receives_plan_and_context() {
+    CasePlanModel[] captured = {null};
+    BlackboardPlanConfigurer c = (plan, ctx) -> captured[0] = plan;
+    CasePlanModel plan = new DefaultCasePlanModel(UUID.randomUUID());
+    PlanExecutionContext ctx =
+        new PlanExecutionContext(
+            UUID.randomUUID(), mock(CaseDefinition.class), mock(CaseContext.class));
+    c.configure(plan, ctx);
+    assertThat(captured[0]).isSameAs(plan);
+  }
+
+  @Test
+  void supports_can_filter_by_definition_name() {
+    BlackboardPlanConfigurer c =
+        new BlackboardPlanConfigurer() {
+          @Override
+          public boolean supports(CaseDefinition def) {
+            return "loan".equals(def.getName());
+          }
+
+          @Override
+          public void configure(CasePlanModel plan, PlanExecutionContext ctx) {}
+        };
+    CaseDefinition loan = mock(CaseDefinition.class);
+    when(loan.getName()).thenReturn("loan");
+    CaseDefinition other = mock(CaseDefinition.class);
+    when(other.getName()).thenReturn("other");
+    assertThat(c.supports(loan)).isTrue();
+    assertThat(c.supports(other)).isFalse();
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/control/PlanningStrategyContractTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/control/PlanningStrategyContractTest.java
@@ -68,4 +68,18 @@ public abstract class PlanningStrategyContractTest {
     List<Binding> result = strategy().select(plan, ctx(), List.of()).await().indefinitely();
     assertThat(result).isNotNull();
   }
+
+  @Test
+  void result_does_not_contain_duplicates_when_eligible_has_duplicates() {
+    CasePlanModel plan = new DefaultCasePlanModel(UUID.randomUUID());
+    Binding b1 = mock(Binding.class);
+    List<Binding> eligibleWithDuplicate = List.of(b1, b1);
+
+    List<Binding> result =
+        strategy().select(plan, ctx(), eligibleWithDuplicate).await().indefinitely();
+
+    assertThat(result)
+        .as("strategy must not return duplicate bindings even if eligible list contains duplicates")
+        .doesNotHaveDuplicates();
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/it/PlanConfigurerBlackboardTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/it/PlanConfigurerBlackboardTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.engine.PlanExecutionContext;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Worker;
+import io.casehub.blackboard.control.BlackboardPlanConfigurer;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.blackboard.stage.Stage;
+import io.casehub.blackboard.stage.StageStatus;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link BlackboardPlanConfigurer} — verifies that a CDI bean implementing
+ * the interface has its {@code configure()} called when a case starts, that stages it adds appear
+ * in the plan model, and that it is called exactly once per case instance. See casehubio/engine#76.
+ *
+ * <p>Design: the {@link ConfiguredCaseBean} starts with a value that does not trigger its binding
+ * ({@code ready=true} vs. trigger on {@code .probe == "tick"}). The plan model is created on the
+ * first {@code select()} call fired by the engine, giving the configurer a chance to run before any
+ * worker fires. A subsequent signal triggers activity — allowing the "called exactly once"
+ * assertion to be made after multiple evaluation cycles.
+ */
+@QuarkusTest
+class PlanConfigurerBlackboardTest {
+
+  /** Static call counter — persists across CDI proxy invocations of {@link ConfigurerBean}. */
+  static final AtomicInteger callCount = new AtomicInteger(0);
+
+  @Inject BlackboardRegistry registry;
+  @Inject ConfiguredCaseBean configuredCase;
+
+  // ------------------------------------------------------------------ //
+  // configure() is called on case start                                  //
+  // ------------------------------------------------------------------ //
+
+  /**
+   * Verifies that the configurer runs before any binding fires: the plan model exists and contains
+   * the stage the configurer added, all before the probe signal is sent.
+   */
+  @Test
+  void configurer_is_called_and_stage_appears_in_plan_model() {
+    // Reset call count — tests may run in any order within the same CDI context
+    callCount.set(0);
+
+    // Start with a value that does NOT trigger the binding (.probe == "tick")
+    UUID caseId = configuredCase.startCase(Map.of("ready", true)).toCompletableFuture().join();
+
+    // Wait for the registry entry — plan model is created on first select() from CaseStartedEvent
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
+
+    // Configurer must have run — the plan model should contain the stage it declared
+    CasePlanModel plan = registry.get(caseId).get();
+    assertThat(plan.getAllStages())
+        .as("configurer must have added 'configurer-stage' to the plan model")
+        .anyMatch(s -> s.getName().equals("configurer-stage"));
+  }
+
+  // ------------------------------------------------------------------ //
+  // configure() is called exactly once per case instance                 //
+  // ------------------------------------------------------------------ //
+
+  /**
+   * Verifies configure() is called exactly once even after multiple evaluation cycles. Two probe
+   * signals force additional {@code select()} calls; the call count must not increase beyond 1.
+   */
+  @Test
+  void configurer_is_called_exactly_once_per_case_instance() {
+    callCount.set(0);
+
+    UUID caseId = configuredCase.startCase(Map.of("ready", true)).toCompletableFuture().join();
+
+    // Wait for plan model to be created — guarantees the first select() (and configure()) ran
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
+
+    // Force additional select() cycles via signals — configure() must NOT be called again
+    configuredCase.signal(caseId, "probe", "tick");
+    configuredCase.signal(caseId, "probe", "tick-2");
+
+    // Give the engine time to process both signals
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(callCount.get())
+                    .as("configure() must have been called at least once")
+                    .isGreaterThanOrEqualTo(1));
+
+    assertThat(callCount.get())
+        .as("configure() must be called exactly once per case — not on every select() cycle")
+        .isEqualTo(1);
+  }
+
+  // ------------------------------------------------------------------ //
+  // Stage added by configurer is evaluatable                             //
+  // ------------------------------------------------------------------ //
+
+  /**
+   * Verifies that a stage with no entry condition (always activates) that was added by the
+   * configurer transitions to ACTIVE on the first evaluation cycle triggered by a signal.
+   */
+  @Test
+  void stage_added_by_configurer_activates_on_evaluation_cycle() {
+    callCount.set(0);
+
+    UUID caseId = configuredCase.startCase(Map.of("ready", true)).toCompletableFuture().join();
+
+    // Wait for registry — configurer has run and stage is in the plan model
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
+
+    CasePlanModel plan = registry.get(caseId).get();
+
+    // Find the stage the configurer added
+    Stage configurerStage =
+        plan.getAllStages().stream()
+            .filter(s -> s.getName().equals("configurer-stage"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("configurer-stage not found in plan model"));
+
+    // Signal a probe value — triggers a CONTEXT_CHANGED → select() → stage evaluation cycle
+    configuredCase.signal(caseId, "probe", "tick");
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(configurerStage.getStatus())
+                    .as("configurer stage with no entry condition must activate on evaluation")
+                    .isEqualTo(StageStatus.ACTIVE));
+  }
+
+  // ------------------------------------------------------------------ //
+  // Test beans                                                            //
+  // ------------------------------------------------------------------ //
+
+  /**
+   * {@link BlackboardPlanConfigurer} CDI bean. Adds a stage with no entry condition (always
+   * activates) and increments the static call counter to verify exactly-once semantics.
+   *
+   * <p>{@code @ApplicationScoped} ensures CDI auto-discovery in the test CDI context. The static
+   * {@link PlanConfigurerBlackboardTest#callCount} field is used rather than an instance field so
+   * the count survives CDI proxy invocations.
+   */
+  @ApplicationScoped
+  public static class ConfigurerBean implements BlackboardPlanConfigurer {
+
+    @Override
+    public void configure(CasePlanModel plan, PlanExecutionContext context) {
+      callCount.incrementAndGet();
+      plan.addStage(Stage.create("configurer-stage"));
+    }
+  }
+
+  /**
+   * Case whose binding fires only when a signal writes {@code probe=tick}. Starts with {@code
+   * ready=true} — binding never fires on start. Suitable for idle-start + signal pattern.
+   */
+  @ApplicationScoped
+  public static class ConfiguredCaseBean extends CaseHub {
+
+    private final Capability cap =
+        Capability.builder()
+            .name("configured-cap")
+            .inputSchema("{ probe: .probe }")
+            .outputSchema("{ probe: .probe }")
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("blackboard-configurer-it")
+          .name("Configured Case")
+          .version("1.0.0")
+          .capabilities(cap)
+          .workers(
+              Worker.builder()
+                  .name("configured-worker")
+                  .capabilities(cap)
+                  .function(input -> Map.of("probe", "done"))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("on-probe-tick")
+                  .capability(cap)
+                  .on(new ContextChangeTrigger(".probe == \"tick\""))
+                  .build())
+          // No goals — case stays RUNNING for post-signal assertions
+          .build();
+    }
+  }
+}

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
@@ -247,4 +247,22 @@ class DefaultCasePlanModelTest {
         .isEqualTo(1);
     assertThat(plan.getAgenda()).hasSize(1);
   }
+
+  @Test
+  void getTopPlanItems_with_zero_limit_returns_empty() {
+    plan.addPlanItem(PlanItem.create("b-a", "w-a", 5));
+    plan.addPlanItem(PlanItem.create("b-b", "w-b", 3));
+    assertThat(plan.getTopPlanItems(0))
+        .as("getTopPlanItems(0) must return empty, not all items")
+        .isEmpty();
+  }
+
+  @Test
+  void get_returns_empty_when_type_does_not_match() {
+    plan.put("count", 42);
+    assertThat(plan.get("count", String.class))
+        .as("get() must return empty when stored type does not match — no ClassCastException")
+        .isEmpty();
+    assertThat(plan.get("count", Integer.class)).contains(42);
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
@@ -148,4 +148,33 @@ class StageTest {
         .as("Stage.status must be AtomicReference to prevent concurrent transition races")
         .isEqualTo(java.util.concurrent.atomic.AtomicReference.class);
   }
+
+  @Test
+  void fault_from_pending_transitions_to_faulted() {
+    Stage s = Stage.create("x");
+    s.fault();
+    assertThat(s.getStatus()).isEqualTo(StageStatus.FAULTED);
+    assertThat(s.isTerminal()).isTrue();
+  }
+
+  @Test
+  void fault_from_faulted_is_noop() {
+    Stage s = Stage.create("x");
+    s.fault();
+    s.fault(); // second call must not corrupt state
+    assertThat(s.getStatus())
+        .as("fault() on already-FAULTED stage must remain FAULTED")
+        .isEqualTo(StageStatus.FAULTED);
+  }
+
+  @Test
+  void fault_from_completed_is_noop() {
+    Stage s = Stage.create("x");
+    s.activate();
+    s.complete();
+    s.fault(); // must not overwrite COMPLETED
+    assertThat(s.getStatus())
+        .as("fault() must not overwrite a terminal COMPLETED state")
+        .isEqualTo(StageStatus.COMPLETED);
+  }
 }


### PR DESCRIPTION
Stacks on #91–#95. Adds BlackboardPlanConfigurer CDI SPI. Application code implements @ApplicationScoped beans to configure stages/milestones for a case definition. Called exactly once per case instance (markConfigured guards re-entry). 105 tests.