### PR TITLE
feat(blackboard): Stage.builder() requires entryCondition; Stage.alwaysActivate() makes intent explicit [QE-I/4]

### DIFF
--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
@@ -69,8 +69,99 @@ public class Stage {
     this.createdAt = Instant.now();
   }
 
+  /**
+   * Creates a Stage with null entry condition (activates on every cycle).
+   *
+   * @deprecated Prefer {@link #alwaysActivate(String)} for explicit intent, or {@link
+   *     #builder(String)} when an entry condition is required.
+   */
+  @Deprecated(since = "1.0", forRemoval = false)
   public static Stage create(String name) {
     return new Stage(name);
+  }
+
+  /**
+   * Creates a Stage that activates on every evaluation cycle (null entry condition). Prefer this
+   * over {@link #create(String)} — the name makes the intent explicit.
+   */
+  public static Stage alwaysActivate(String name) {
+    return new Stage(name);
+  }
+
+  /**
+   * Returns a Builder requiring an explicit entry condition. Use {@link #alwaysActivate(String)}
+   * for always-on stages.
+   */
+  public static Builder builder(String name) {
+    return new Builder(name);
+  }
+
+  /** Builder requiring an explicit entry condition. */
+  public static final class Builder {
+    private final String name;
+    private ExpressionEvaluator entryCondition;
+    private ExpressionEvaluator exitCondition;
+    private boolean manualActivation = false;
+    private boolean autocomplete = true;
+    private String parentStageId;
+
+    private Builder(String name) {
+      this.name = java.util.Objects.requireNonNull(name, "name must not be null");
+    }
+
+    public Builder entryCondition(ExpressionEvaluator condition) {
+      this.entryCondition = condition;
+      return this;
+    }
+
+    public Builder entryCondition(Predicate<CaseContext> predicate) {
+      this.entryCondition = new LambdaExpressionEvaluator(predicate);
+      return this;
+    }
+
+    public Builder exitCondition(ExpressionEvaluator condition) {
+      this.exitCondition = condition;
+      return this;
+    }
+
+    public Builder exitCondition(Predicate<CaseContext> predicate) {
+      this.exitCondition = new LambdaExpressionEvaluator(predicate);
+      return this;
+    }
+
+    public Builder withManualActivation(boolean v) {
+      this.manualActivation = v;
+      return this;
+    }
+
+    public Builder withAutocomplete(boolean v) {
+      this.autocomplete = v;
+      return this;
+    }
+
+    public Builder withParentStage(String parentStageId) {
+      this.parentStageId = parentStageId;
+      return this;
+    }
+
+    public Stage build() {
+      if (entryCondition == null) {
+        throw new IllegalStateException(
+            "Stage.builder(\""
+                + name
+                + "\") requires entryCondition to be set. "
+                + "Use Stage.alwaysActivate(\""
+                + name
+                + "\") if the stage should activate on every cycle.");
+      }
+      Stage stage = new Stage(name);
+      stage.entryCondition = this.entryCondition;
+      stage.exitCondition = this.exitCondition;
+      stage.manualActivation = this.manualActivation;
+      stage.autocomplete = this.autocomplete;
+      if (this.parentStageId != null) stage.parentStageId = this.parentStageId;
+      return stage;
+    }
   }
 
   // Fluent builder-style configuration (called before adding to CasePlanModel)

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/control/StageLifecycleEvaluatorTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/control/StageLifecycleEvaluatorTest.java
@@ -54,7 +54,7 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void pending_stage_activates_when_entry_condition_met() {
-    Stage stage = Stage.create("intake").withEntryCondition(c -> true);
+    Stage stage = Stage.builder("intake").entryCondition(c -> true).build();
     plan.addStage(stage);
 
     evaluator.evaluate(plan, ctx).await().indefinitely();
@@ -65,7 +65,7 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void pending_stage_stays_pending_when_entry_condition_not_met() {
-    Stage stage = Stage.create("intake").withEntryCondition(c -> false);
+    Stage stage = Stage.builder("intake").entryCondition(c -> false).build();
     plan.addStage(stage);
 
     evaluator.evaluate(plan, ctx).await().indefinitely();
@@ -76,7 +76,7 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void pending_stage_with_no_entry_condition_activates() {
-    Stage stage = Stage.create("intake"); // no entry condition
+    Stage stage = Stage.alwaysActivate("intake"); // no entry condition
     plan.addStage(stage);
 
     evaluator.evaluate(plan, ctx).await().indefinitely();
@@ -86,7 +86,8 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void active_stage_terminates_when_exit_condition_met() {
-    Stage stage = Stage.create("intake").withExitCondition(c -> true);
+    Stage stage =
+        Stage.builder("intake").entryCondition(c -> true).exitCondition(c -> true).build();
     stage.activate();
     plan.addStage(stage);
 
@@ -98,7 +99,8 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void active_stage_stays_active_when_exit_condition_not_met() {
-    Stage stage = Stage.create("intake").withExitCondition(c -> false);
+    Stage stage =
+        Stage.builder("intake").entryCondition(c -> true).exitCondition(c -> false).build();
     stage.activate();
     plan.addStage(stage);
 
@@ -110,7 +112,8 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void manual_activation_stage_stays_pending_even_when_entry_met() {
-    Stage stage = Stage.create("intake").withEntryCondition(c -> true).withManualActivation(true);
+    Stage stage =
+        Stage.builder("intake").entryCondition(c -> true).withManualActivation(true).build();
     plan.addStage(stage);
 
     evaluator.evaluate(plan, ctx).await().indefinitely();
@@ -121,8 +124,8 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void nested_stage_stays_pending_while_parent_is_pending() {
-    Stage parent = Stage.create("parent").withEntryCondition(c -> false); // never activates
-    Stage child = Stage.create("child").withParentStage(parent.getStageId());
+    Stage parent = Stage.builder("parent").entryCondition(c -> false).build(); // never activates
+    Stage child = Stage.alwaysActivate("child").withParentStage(parent.getStageId());
 
     plan.addStage(parent);
     plan.addStage(child);
@@ -137,8 +140,8 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void nested_stage_activates_after_parent_becomes_active() {
-    Stage parent = Stage.create("parent"); // no entry condition — activates immediately
-    Stage child = Stage.create("child").withParentStage(parent.getStageId());
+    Stage parent = Stage.alwaysActivate("parent"); // no entry condition — activates immediately
+    Stage child = Stage.alwaysActivate("child").withParentStage(parent.getStageId());
 
     plan.addStage(parent);
     plan.addStage(child);
@@ -157,7 +160,7 @@ class StageLifecycleEvaluatorTest {
 
   @Test
   void root_stage_without_parent_activates_normally() {
-    Stage root = Stage.create("root"); // no parentStageId
+    Stage root = Stage.alwaysActivate("root"); // no parentStageId
     plan.addStage(root);
 
     evaluator.evaluate(plan, ctx).await().indefinitely();

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
@@ -90,7 +90,7 @@ class PlanItemCompletionHandlerTest {
     item.markRunning(); // simulates indexSelectedForCompletion in PlanningStrategyLoopControl
     registry.indexWorkerForCompletion(caseId, "worker-a", item.getPlanItemId());
 
-    Stage stage = Stage.create("intake");
+    Stage stage = Stage.alwaysActivate("intake");
     stage.addPlanItem(item.getPlanItemId());
     stage.addRequiredItem(item.getPlanItemId());
     stage.activate();
@@ -111,7 +111,7 @@ class PlanItemCompletionHandlerTest {
     item1.markRunning(); // simulates indexSelectedForCompletion in PlanningStrategyLoopControl
     registry.indexWorkerForCompletion(caseId, "worker-a", item1.getPlanItemId());
 
-    Stage stage = Stage.create("intake");
+    Stage stage = Stage.alwaysActivate("intake");
     stage.addPlanItem(item1.getPlanItemId());
     stage.addPlanItem(item2.getPlanItemId());
     stage.addRequiredItem(item1.getPlanItemId());
@@ -146,7 +146,7 @@ class PlanItemCompletionHandlerTest {
     item.markRunning(); // simulates indexSelectedForCompletion in PlanningStrategyLoopControl
     registry.indexWorkerForCompletion(caseId, "worker-a", item.getPlanItemId());
 
-    Stage stage = Stage.create("intake");
+    Stage stage = Stage.alwaysActivate("intake");
     stage.addRequiredItem("non-existent-id"); // not in plan
     stage.activate();
     plan.addStage(stage);
@@ -166,7 +166,7 @@ class PlanItemCompletionHandlerTest {
     item.markRunning(); // simulates indexSelectedForCompletion in PlanningStrategyLoopControl
     registry.indexWorkerForCompletion(caseId, "worker-a", item.getPlanItemId());
 
-    Stage stage = Stage.create("intake").withAutocomplete(false);
+    Stage stage = Stage.alwaysActivate("intake").withAutocomplete(false);
     stage.addRequiredItem(item.getPlanItemId());
     stage.activate();
     plan.addStage(stage);

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/it/ExitConditionBlackboardTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/it/ExitConditionBlackboardTest.java
@@ -62,8 +62,10 @@ class ExitConditionBlackboardTest {
 
     // Pre-activate the stage — StageLifecycleEvaluator only checks ACTIVE stages for exit
     Stage stage =
-        Stage.create("active-stage")
-            .withExitCondition(ctx -> "exited".equals(ctx.getPath("phase")));
+        Stage.builder("active-stage")
+            .entryCondition(ctx -> true)
+            .exitCondition(ctx -> "exited".equals(ctx.getPath("phase")))
+            .build();
     stage.activate();
     registry.get(caseId).get().addStage(stage);
 

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/it/LambdaEntryConditionBlackboardTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/it/LambdaEntryConditionBlackboardTest.java
@@ -56,8 +56,9 @@ class LambdaEntryConditionBlackboardTest {
         .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
 
     Stage stage =
-        Stage.create("lambda-stage")
-            .withEntryCondition(ctx -> Integer.valueOf(42).equals(ctx.getPath("value")));
+        Stage.builder("lambda-stage")
+            .entryCondition(ctx -> Integer.valueOf(42).equals(ctx.getPath("value")))
+            .build();
     registry.get(caseId).get().addStage(stage);
 
     lambdaCase.signal(caseId, "probe", "tick");
@@ -81,8 +82,9 @@ class LambdaEntryConditionBlackboardTest {
         .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
 
     Stage stage =
-        Stage.create("lambda-stage")
-            .withEntryCondition(ctx -> Integer.valueOf(42).equals(ctx.getPath("value")));
+        Stage.builder("lambda-stage")
+            .entryCondition(ctx -> Integer.valueOf(42).equals(ctx.getPath("value")))
+            .build();
     registry.get(caseId).get().addStage(stage);
 
     lambdaCase.signal(caseId, "probe", "tick");

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/it/PlanConfigurerBlackboardTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/it/PlanConfigurerBlackboardTest.java
@@ -182,7 +182,7 @@ class PlanConfigurerBlackboardTest {
     @Override
     public void configure(CasePlanModel plan, PlanExecutionContext context) {
       callCount.incrementAndGet();
-      plan.addStage(Stage.create("configurer-stage"));
+      plan.addStage(Stage.alwaysActivate("configurer-stage"));
     }
   }
 

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/it/SequentialStagesBlackboardTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/it/SequentialStagesBlackboardTest.java
@@ -63,9 +63,13 @@ class SequentialStagesBlackboardTest {
     // stage-one: entry condition satisfied when phase=start (written by signal below)
     // stage-two: entry condition satisfied when phase=two (written by worker)
     Stage stage1 =
-        Stage.create("stage-one").withEntryCondition(ctx -> "start".equals(ctx.getPath("phase")));
+        Stage.builder("stage-one")
+            .entryCondition(ctx -> "start".equals(ctx.getPath("phase")))
+            .build();
     Stage stage2 =
-        Stage.create("stage-two").withEntryCondition(ctx -> "two".equals(ctx.getPath("phase")));
+        Stage.builder("stage-two")
+            .entryCondition(ctx -> "two".equals(ctx.getPath("phase")))
+            .build();
 
     registry.get(caseId).get().addStage(stage1);
     registry.get(caseId).get().addStage(stage2);

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/it/StageBlackboardTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/it/StageBlackboardTest.java
@@ -75,7 +75,7 @@ class StageBlackboardTest {
         .atMost(10, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
 
-    Stage stage = Stage.create("unconditional-stage");
+    Stage stage = Stage.alwaysActivate("unconditional-stage");
     registry.get(caseId).get().addStage(stage);
 
     // Signal a probe value — triggers another CONTEXT_CHANGED → select() → stage evaluation
@@ -102,7 +102,7 @@ class StageBlackboardTest {
         .atMost(10, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
 
-    Stage stage = Stage.create("conditional-stage").withEntryCondition(ctx -> true);
+    Stage stage = Stage.builder("conditional-stage").entryCondition(ctx -> true).build();
     registry.get(caseId).get().addStage(stage);
 
     signalCase.signal(caseId, "probe", "tick");
@@ -128,7 +128,7 @@ class StageBlackboardTest {
         .atMost(10, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
 
-    Stage stage = Stage.create("blocked-stage").withEntryCondition(ctx -> false);
+    Stage stage = Stage.builder("blocked-stage").entryCondition(ctx -> false).build();
     registry.get(caseId).get().addStage(stage);
 
     signalCase.signal(caseId, "probe", "tick");
@@ -161,7 +161,8 @@ class StageBlackboardTest {
         .atMost(10, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
 
-    Stage stage = Stage.create("exit-stage").withExitCondition(ctx -> true);
+    Stage stage =
+        Stage.builder("exit-stage").entryCondition(ctx -> true).exitCondition(ctx -> true).build();
     stage.activate(); // pre-activate — evaluator checks ACTIVE stages for exit condition
     registry.get(caseId).get().addStage(stage);
 
@@ -208,7 +209,7 @@ class StageBlackboardTest {
     CasePlanModel plan = registry.get(caseId).get();
 
     // Create an autocomplete stage — we'll link it to the real PlanItem after the worker is indexed
-    Stage stage = Stage.create("autocomplete-stage");
+    Stage stage = Stage.alwaysActivate("autocomplete-stage");
     stage.activate(); // must be ACTIVE for autocomplete to evaluate
     plan.addStage(stage);
 
@@ -272,7 +273,7 @@ class StageBlackboardTest {
     PlanItem syntheticItem = PlanItem.create("synthetic-binding", "synthetic-worker", 0);
     plan.addPlanItem(syntheticItem);
 
-    Stage stage = Stage.create("no-autocomplete-stage").withAutocomplete(false);
+    Stage stage = Stage.alwaysActivate("no-autocomplete-stage").withAutocomplete(false);
     stage.addPlanItem(syntheticItem.getPlanItemId());
     stage.addRequiredItem(syntheticItem.getPlanItemId());
     stage.activate();
@@ -312,8 +313,9 @@ class StageBlackboardTest {
         .atMost(10, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(registry.get(caseId)).isPresent());
 
-    Stage parent = Stage.create("parent-stage"); // no entry condition — activates immediately
-    Stage child = Stage.create("child-stage").withParentStage(parent.getStageId());
+    Stage parent =
+        Stage.alwaysActivate("parent-stage"); // no entry condition — activates immediately
+    Stage child = Stage.alwaysActivate("child-stage").withParentStage(parent.getStageId());
 
     registry.get(caseId).get().addStage(parent);
     registry.get(caseId).get().addStage(child);

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/plan/DefaultCasePlanModelTest.java
@@ -164,7 +164,7 @@ class DefaultCasePlanModelTest {
 
   @Test
   void stage_management_add_and_retrieve() {
-    Stage stage = Stage.create("intake");
+    Stage stage = Stage.alwaysActivate("intake");
     plan.addStage(stage);
     assertThat(plan.getStage(stage.getStageId())).contains(stage);
     assertThat(plan.getAllStages()).containsExactly(stage);
@@ -172,8 +172,8 @@ class DefaultCasePlanModelTest {
 
   @Test
   void getPendingStages_and_getActiveStages_filter_by_status() {
-    Stage pending = Stage.create("pending-stage");
-    Stage active = Stage.create("active-stage");
+    Stage pending = Stage.alwaysActivate("pending-stage");
+    Stage active = Stage.alwaysActivate("active-stage");
     active.activate();
     plan.addStage(pending);
     plan.addStage(active);

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
@@ -16,6 +16,7 @@
 package io.casehub.blackboard.stage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -176,5 +177,43 @@ class StageTest {
     assertThat(s.getStatus())
         .as("fault() must not overwrite a terminal COMPLETED state")
         .isEqualTo(StageStatus.COMPLETED);
+  }
+
+  @Test
+  void builder_without_entry_condition_throws() {
+    assertThatThrownBy(() -> Stage.builder("intake").build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("entryCondition");
+  }
+
+  @Test
+  void builder_with_entry_condition_creates_stage() {
+    Stage stage = Stage.builder("intake").entryCondition(ctx -> true).build();
+    assertThat(stage.getName()).isEqualTo("intake");
+    assertThat(stage.getEntryCondition()).isNotNull();
+    assertThat(stage.getStatus()).isEqualTo(StageStatus.PENDING);
+  }
+
+  @Test
+  void builder_fluent_options_retained() {
+    Stage stage =
+        Stage.builder("intake")
+            .entryCondition(ctx -> true)
+            .exitCondition(ctx -> false)
+            .withManualActivation(true)
+            .withAutocomplete(false)
+            .build();
+    assertThat(stage.getEntryCondition()).isNotNull();
+    assertThat(stage.getExitCondition()).isNotNull();
+    assertThat(stage.isManualActivation()).isTrue();
+    assertThat(stage.isAutocomplete()).isFalse();
+  }
+
+  @Test
+  void alwaysActivate_creates_stage_with_null_entry_condition() {
+    Stage stage = Stage.alwaysActivate("intake");
+    assertThat(stage.getName()).isEqualTo("intake");
+    assertThat(stage.getEntryCondition()).isNull();
+    assertThat(stage.getStatus()).isEqualTo(StageStatus.PENDING);
   }
 }


### PR DESCRIPTION
Stacks on QE-H. Stage.builder(name).entryCondition(...).build() throws IllegalStateException if entryCondition omitted. Stage.alwaysActivate(name) replaces silent Stage.create() for always-on stages. 16 alwaysActivate + 13 builder call sites migrated. 120 tests.