### PR TITLE
feat(engine): add ScheduleTrigger support for time-based worker execu…

### DIFF
--- a/api/src/main/java/io/casehub/api/model/ScheduleTrigger.java
+++ b/api/src/main/java/io/casehub/api/model/ScheduleTrigger.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Time-based trigger for scheduling worker execution. Supports cron-based periodic scheduling and
+ * delay-based one-shot scheduling. Use {@link Binding#getWhen()} to add conditions for conditional
+ * execution.
+ */
+public class ScheduleTrigger implements Trigger {
+
+  private final String cron;
+  private final Duration delay;
+
+  private ScheduleTrigger(String cron, Duration delay) {
+    this.cron = cron;
+    this.delay = delay;
+  }
+
+  /**
+   * Create a cron-based periodic trigger.
+   *
+   * @param cronExpression Quartz cron expression
+   * @return ScheduleTrigger configured for periodic execution
+   */
+  public static ScheduleTrigger cron(String cronExpression) {
+    Objects.requireNonNull(cronExpression, "cronExpression must not be null");
+    return new ScheduleTrigger(cronExpression, null);
+  }
+
+  /**
+   * Create a delay-based one-shot trigger.
+   *
+   * @param delay Duration to wait before execution
+   * @return ScheduleTrigger configured for delayed one-shot execution
+   */
+  public static ScheduleTrigger delay(Duration delay) {
+    Objects.requireNonNull(delay, "delay must not be null");
+    if (delay.isNegative() || delay.isZero()) {
+      throw new IllegalArgumentException("delay must be positive");
+    }
+    return new ScheduleTrigger(null, delay);
+  }
+
+  /**
+   * Returns the cron expression if this is a cron-based trigger.
+   *
+   * @return cron expression, or null if this is a delay-based trigger
+   */
+  public String getCron() {
+    return cron;
+  }
+
+  /**
+   * Returns the delay duration if this is a delay-based trigger.
+   *
+   * @return delay duration, or null if this is a cron-based trigger
+   */
+  public Duration getDelay() {
+    return delay;
+  }
+
+  /**
+   * Returns true if this is a cron-based periodic trigger.
+   *
+   * @return true if cron expression is set
+   */
+  public boolean isCron() {
+    return cron != null;
+  }
+
+  /**
+   * Returns true if this is a delay-based one-shot trigger.
+   *
+   * @return true if delay duration is set
+   */
+  public boolean isDelay() {
+    return delay != null;
+  }
+
+  @Override
+  public String toString() {
+    if (isCron()) {
+      return "ScheduleTrigger{cron='" + cron + "'}";
+    } else {
+      return "ScheduleTrigger{delay=" + delay + "}";
+    }
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ScheduleTriggerTest.java
+++ b/api/src/test/java/io/casehub/api/model/ScheduleTriggerTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ScheduleTrigger")
+class ScheduleTriggerTest {
+
+  @Nested
+  @DisplayName("cron() factory")
+  class CronFactory {
+
+    @Test
+    @DisplayName("creates cron-based trigger with valid expression")
+    void createsCronTrigger() {
+      ScheduleTrigger trigger = ScheduleTrigger.cron("0 */5 * * * ?");
+
+      assertThat(trigger.getCron()).isEqualTo("0 */5 * * * ?");
+      assertThat(trigger.getDelay()).isNull();
+      assertThat(trigger.isCron()).isTrue();
+      assertThat(trigger.isDelay()).isFalse();
+    }
+
+    @Test
+    @DisplayName("rejects null cron expression")
+    void rejectsNullCron() {
+      assertThatThrownBy(() -> ScheduleTrigger.cron(null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("cronExpression must not be null");
+    }
+
+    @Test
+    @DisplayName("toString() includes cron expression")
+    void toStringIncludesCron() {
+      ScheduleTrigger trigger = ScheduleTrigger.cron("0 */5 * * * ?");
+
+      assertThat(trigger.toString()).contains("cron='0 */5 * * * ?'");
+    }
+  }
+
+  @Nested
+  @DisplayName("delay() factory")
+  class DelayFactory {
+
+    @Test
+    @DisplayName("creates delay-based trigger with valid duration")
+    void createsDelayTrigger() {
+      ScheduleTrigger trigger = ScheduleTrigger.delay(Duration.ofMinutes(30));
+
+      assertThat(trigger.getDelay()).isEqualTo(Duration.ofMinutes(30));
+      assertThat(trigger.getCron()).isNull();
+      assertThat(trigger.isDelay()).isTrue();
+      assertThat(trigger.isCron()).isFalse();
+    }
+
+    @Test
+    @DisplayName("rejects null delay")
+    void rejectsNullDelay() {
+      assertThatThrownBy(() -> ScheduleTrigger.delay(null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("delay must not be null");
+    }
+
+    @Test
+    @DisplayName("rejects negative delay")
+    void rejectsNegativeDelay() {
+      assertThatThrownBy(() -> ScheduleTrigger.delay(Duration.ofMinutes(-1)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("delay must be positive");
+    }
+
+    @Test
+    @DisplayName("rejects zero delay")
+    void rejectsZeroDelay() {
+      assertThatThrownBy(() -> ScheduleTrigger.delay(Duration.ZERO))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("delay must be positive");
+    }
+
+    @Test
+    @DisplayName("toString() includes delay duration")
+    void toStringIncludesDelay() {
+      ScheduleTrigger trigger = ScheduleTrigger.delay(Duration.ofMinutes(30));
+
+      assertThat(trigger.toString()).contains("delay=PT30M");
+    }
+  }
+
+  @Nested
+  @DisplayName("type checking")
+  class TypeChecking {
+
+    @Test
+    @DisplayName("isCron() returns true only for cron triggers")
+    void isCronOnlyForCronTriggers() {
+      ScheduleTrigger cronTrigger = ScheduleTrigger.cron("0 0 * * * ?");
+      ScheduleTrigger delayTrigger = ScheduleTrigger.delay(Duration.ofSeconds(10));
+
+      assertThat(cronTrigger.isCron()).isTrue();
+      assertThat(delayTrigger.isCron()).isFalse();
+    }
+
+    @Test
+    @DisplayName("isDelay() returns true only for delay triggers")
+    void isDelayOnlyForDelayTriggers() {
+      ScheduleTrigger cronTrigger = ScheduleTrigger.cron("0 0 * * * ?");
+      ScheduleTrigger delayTrigger = ScheduleTrigger.delay(Duration.ofSeconds(10));
+
+      assertThat(cronTrigger.isDelay()).isFalse();
+      assertThat(delayTrigger.isDelay()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("common use cases")
+  class CommonUseCases {
+
+    @Test
+    @DisplayName("every 5 minutes cron expression")
+    void everyFiveMinutes() {
+      ScheduleTrigger trigger = ScheduleTrigger.cron("0 */5 * * * ?");
+
+      assertThat(trigger.isCron()).isTrue();
+      assertThat(trigger.getCron()).isEqualTo("0 */5 * * * ?");
+    }
+
+    @Test
+    @DisplayName("30 minute delay")
+    void thirtyMinuteDelay() {
+      ScheduleTrigger trigger = ScheduleTrigger.delay(Duration.ofMinutes(30));
+
+      assertThat(trigger.isDelay()).isTrue();
+      assertThat(trigger.getDelay()).isEqualTo(Duration.ofMinutes(30));
+    }
+
+    @Test
+    @DisplayName("2 hour deadline")
+    void twoHourDeadline() {
+      ScheduleTrigger trigger = ScheduleTrigger.delay(Duration.ofHours(2));
+
+      assertThat(trigger.isDelay()).isTrue();
+      assertThat(trigger.getDelay()).isEqualTo(Duration.ofHours(2));
+    }
+
+    @Test
+    @DisplayName("daily at midnight cron")
+    void dailyAtMidnight() {
+      ScheduleTrigger trigger = ScheduleTrigger.cron("0 0 0 * * ?");
+
+      assertThat(trigger.isCron()).isTrue();
+      assertThat(trigger.getCron()).isEqualTo("0 0 0 * * ?");
+    }
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
@@ -23,6 +23,7 @@ import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.history.EventStreamType;
 import io.casehub.engine.internal.model.CaseInstance;
+import io.casehub.engine.internal.scheduler.SchedulerService;
 import io.casehub.engine.spi.EventLogRepository;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
@@ -42,6 +43,8 @@ public class CaseStartedEventHandler {
 
   @Inject EventLogRepository eventLogRepository;
 
+  @Inject SchedulerService schedulerService;
+
   @ConsumeEvent(value = EventBusAddresses.CASE_STARTED)
   public Uni<Void> onCaseStarted(CaseStartedEvent event) {
     CaseInstance instance = event.instance();
@@ -56,6 +59,7 @@ public class CaseStartedEventHandler {
 
     return eventLogRepository
         .append(eventLog)
+        .chain(() -> schedulerService.registerScheduledTriggers(instance))
         .invoke(
             () ->
                 eventBus.publish(

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
@@ -23,6 +23,7 @@ import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.history.EventStreamType;
 import io.casehub.engine.internal.model.CaseInstance;
+import io.casehub.engine.internal.scheduler.SchedulerService;
 import io.casehub.engine.spi.CaseInstanceRepository;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
@@ -45,6 +46,8 @@ public class CaseStatusChangedHandler {
   @Inject EventBus eventBus;
 
   @Inject CaseInstanceRepository caseInstanceRepository;
+
+  @Inject SchedulerService schedulerService;
 
   @ConsumeEvent(value = EventBusAddresses.CASE_STATUS_CHANGED)
   public Uni<Void> onCaseStatusChangedHandler(CaseStatusChanged event) {
@@ -71,6 +74,14 @@ public class CaseStatusChangedHandler {
 
     return caseInstanceRepository
         .updateStateAndAppendEvent(caseInstance, eventLog)
+        .chain(
+            () -> {
+              // Cancel all scheduled triggers when case reaches terminal state
+              if (isTerminalState(newState)) {
+                return schedulerService.cancelAllTriggers(caseInstance.getUuid());
+              }
+              return Uni.createFrom().voidItem();
+            })
         .invoke(
             () -> {
               String eventBusAddress = resolveStateAsString(newState);
@@ -78,6 +89,12 @@ public class CaseStatusChangedHandler {
                 eventBus.publish(eventBusAddress, caseInstance);
               }
             });
+  }
+
+  private boolean isTerminalState(CaseStatus state) {
+    return state == CaseStatus.COMPLETED
+        || state == CaseStatus.FAULTED
+        || state == CaseStatus.CANCELLED;
   }
 
   private CaseHubEventType resolveState(CaseStatus state) {

--- a/engine/src/main/java/io/casehub/engine/internal/scheduler/ConditionalScheduledTriggerJob.java
+++ b/engine/src/main/java/io/casehub/engine/internal/scheduler/ConditionalScheduledTriggerJob.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.scheduler;
+
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
+import io.casehub.engine.internal.engine.ExpressionEngineRegistry;
+import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerScheduleEvent;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+/**
+ * Quartz job for conditional scheduled triggers.
+ *
+ * <p>When this job fires, it:
+ *
+ * <ol>
+ *   <li>Loads the case instance
+ *   <li>Verifies the case is still RUNNING
+ *   <li>Retrieves the binding from {@link CaseDefinition} and evaluates the condition from {@link
+ *       Binding#getWhen()}
+ *   <li>If condition is true, publishes a {@link WorkerScheduleEvent}
+ *   <li>If condition is false, skips worker execution
+ * </ol>
+ *
+ * <p>This job is used for time-based triggers with conditions (e.g., "escalate if order not
+ * processed within 2 hours"). The condition is retrieved from the original {@link Binding}
+ * definition, supporting any {@link ExpressionEvaluator} type including Java lambdas.
+ */
+@DisallowConcurrentExecution
+@ApplicationScoped
+public class ConditionalScheduledTriggerJob implements Job {
+
+  private static final Logger LOG = Logger.getLogger(ConditionalScheduledTriggerJob.class);
+
+  @Inject CaseDefinitionRegistry caseDefinitionRegistry;
+
+  @Inject ExpressionEngineRegistry expressionEngineRegistry;
+
+  @Inject EventBus eventBus;
+
+  @Inject WorkerExecutionRecoveryService recoveryService;
+
+  @Override
+  public void execute(JobExecutionContext context) throws JobExecutionException {
+    JobDataMap data = context.getJobDetail().getJobDataMap();
+
+    String caseIdStr = data.getString("caseId");
+    String bindingName = data.getString("bindingName");
+    String capabilityName = data.getString("capabilityName");
+    String workerName = data.getString("workerName");
+
+    LOG.infof(
+        "Executing conditional scheduled trigger: caseId=%s, binding=%s, capability=%s",
+        caseIdStr, bindingName, capabilityName);
+
+    UUID caseId;
+    try {
+      caseId = UUID.fromString(caseIdStr);
+    } catch (IllegalArgumentException e) {
+      throw new JobExecutionException("Invalid caseId format: " + caseIdStr, e);
+    }
+
+    CaseInstance caseInstance;
+    try {
+      caseInstance =
+          recoveryService.loadOrRestoreCaseInstance(caseId).await().atMost(Duration.ofSeconds(10));
+    } catch (Exception e) {
+      LOG.warnf(e, "Failed to load case instance: %s, skipping scheduled trigger", caseId);
+      return;
+    }
+
+    if (caseInstance.getState() != CaseStatus.RUNNING) {
+      LOG.infof(
+          "Case %s is %s (not RUNNING), skipping scheduled trigger",
+          caseId, caseInstance.getState());
+      return;
+    }
+
+    // Load CaseDefinition to get the Binding
+    CaseDefinition definition =
+        caseDefinitionRegistry.getCaseDefinition(caseInstance.getCaseMetaModel());
+    if (definition == null) {
+      throw new JobExecutionException(
+          "CaseDefinition not found for case: " + caseInstance.getUuid());
+    }
+
+    // Find Binding by name and get the original condition
+    Binding binding =
+        definition.getBindings().stream()
+            .filter(b -> b.getName().equals(bindingName))
+            .findFirst()
+            .orElseThrow(() -> new JobExecutionException("Binding not found: " + bindingName));
+
+    ExpressionEvaluator condition = binding.getWhen();
+    if (condition == null) {
+      throw new JobExecutionException(
+          "Binding '" + bindingName + "' has no condition (when clause)");
+    }
+
+    // Evaluate condition
+    boolean conditionMet =
+        expressionEngineRegistry.evaluate(condition, caseInstance.getCaseContext());
+
+    if (!conditionMet) {
+      LOG.infof(
+          "Condition not met for binding=%s, case=%s, skipping worker execution",
+          bindingName, caseId);
+      return;
+    }
+
+    LOG.infof(
+        "Condition met for binding=%s, case=%s, proceeding with worker execution",
+        bindingName, caseId);
+
+    Worker worker = findWorker(definition, workerName);
+    if (worker == null) {
+      throw new JobExecutionException("Worker not found: " + workerName);
+    }
+
+    Capability capability = findCapability(definition, capabilityName);
+    if (capability == null) {
+      throw new JobExecutionException("Capability not found: " + capabilityName);
+    }
+
+    LOG.infof(
+        "Publishing WorkerScheduleEvent for case=%s, worker=%s, capability=%s",
+        caseId, workerName, capabilityName);
+
+    eventBus.publish(
+        EventBusAddresses.WORKER_SCHEDULE,
+        new WorkerScheduleEvent(caseInstance, worker, capability));
+  }
+
+  private Worker findWorker(CaseDefinition definition, String workerName) {
+    return definition.getWorkers().stream()
+        .filter(w -> w.getName().equals(workerName))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private Capability findCapability(CaseDefinition definition, String capabilityName) {
+    return definition.getCapabilities().stream()
+        .filter(c -> c.getName().equals(capabilityName))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/scheduler/ScheduledTriggerJob.java
+++ b/engine/src/main/java/io/casehub/engine/internal/scheduler/ScheduledTriggerJob.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.scheduler;
+
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
+import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerScheduleEvent;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+/**
+ * Quartz job for unconditional scheduled triggers.
+ *
+ * <p>When this job fires, it:
+ *
+ * <ol>
+ *   <li>Loads the case instance
+ *   <li>Verifies the case is still RUNNING
+ *   <li>Publishes a {@link WorkerScheduleEvent} to schedule worker execution
+ * </ol>
+ *
+ * <p>This job is used for time-based triggers without conditions (e.g., "send reminder after 30
+ * minutes"). For conditional triggers, use {@link ConditionalScheduledTriggerJob}.
+ */
+@DisallowConcurrentExecution
+@ApplicationScoped
+public class ScheduledTriggerJob implements Job {
+
+  private static final Logger LOG = Logger.getLogger(ScheduledTriggerJob.class);
+
+  @Inject CaseDefinitionRegistry caseDefinitionRegistry;
+
+  @Inject EventBus eventBus;
+
+  @Inject WorkerExecutionRecoveryService recoveryService;
+
+  @Override
+  public void execute(JobExecutionContext context) throws JobExecutionException {
+    JobDataMap data = context.getJobDetail().getJobDataMap();
+
+    String caseIdStr = data.getString("caseId");
+    String bindingName = data.getString("bindingName");
+    String capabilityName = data.getString("capabilityName");
+    String workerName = data.getString("workerName");
+
+    LOG.infof(
+        "Executing scheduled trigger: caseId=%s, binding=%s, capability=%s",
+        caseIdStr, bindingName, capabilityName);
+
+    UUID caseId;
+    try {
+      caseId = UUID.fromString(caseIdStr);
+    } catch (IllegalArgumentException e) {
+      throw new JobExecutionException("Invalid caseId format: " + caseIdStr, e);
+    }
+
+    CaseInstance caseInstance;
+    try {
+      caseInstance =
+          recoveryService.loadOrRestoreCaseInstance(caseId).await().atMost(Duration.ofSeconds(10));
+    } catch (Exception e) {
+      LOG.warnf(e, "Failed to load case instance: %s, skipping scheduled trigger", caseId);
+      return;
+    }
+
+    if (caseInstance.getState() != CaseStatus.RUNNING) {
+      LOG.infof(
+          "Case %s is %s (not RUNNING), skipping scheduled trigger",
+          caseId, caseInstance.getState());
+      return;
+    }
+
+    CaseDefinition definition =
+        caseDefinitionRegistry.getCaseDefinition(caseInstance.getCaseMetaModel());
+    if (definition == null) {
+      throw new JobExecutionException(
+          "CaseDefinition not found for case: " + caseInstance.getUuid());
+    }
+
+    Worker worker = findWorker(definition, workerName);
+    if (worker == null) {
+      throw new JobExecutionException("Worker not found: " + workerName);
+    }
+
+    Capability capability = findCapability(definition, capabilityName);
+    if (capability == null) {
+      throw new JobExecutionException("Capability not found: " + capabilityName);
+    }
+
+    LOG.infof(
+        "Publishing WorkerScheduleEvent for case=%s, worker=%s, capability=%s",
+        caseId, workerName, capabilityName);
+
+    eventBus.publish(
+        EventBusAddresses.WORKER_SCHEDULE,
+        new WorkerScheduleEvent(caseInstance, worker, capability));
+  }
+
+  private Worker findWorker(CaseDefinition definition, String workerName) {
+    return definition.getWorkers().stream()
+        .filter(w -> w.getName().equals(workerName))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private Capability findCapability(CaseDefinition definition, String capabilityName) {
+    return definition.getCapabilities().stream()
+        .filter(c -> c.getName().equals(capabilityName))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/engine/src/main/java/io/casehub/engine/internal/scheduler/SchedulerService.java
+++ b/engine/src/main/java/io/casehub/engine/internal/scheduler/SchedulerService.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.scheduler;
+
+import static org.quartz.CronScheduleBuilder.cronSchedule;
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
+import static org.quartz.TriggerBuilder.newTrigger;
+
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.ScheduleTrigger;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.evaluator.ExpressionEvaluator;
+import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.unchecked.Unchecked;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+import org.quartz.CronTrigger;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleTrigger;
+import org.quartz.Trigger;
+import org.quartz.impl.matchers.GroupMatcher;
+
+/**
+ * Service for scheduling time-based triggers for Case Hub bindings.
+ *
+ * <p>This service manages Quartz jobs that fire when scheduled triggers activate. It supports:
+ *
+ * <ul>
+ *   <li><b>Unconditional scheduling</b> - worker executes when trigger fires
+ *   <li><b>Conditional scheduling</b> - worker executes only if condition evaluates to true
+ *   <li><b>Cancellation</b> - remove all scheduled triggers when a case completes
+ * </ul>
+ *
+ * <p><b>Lifecycle:</b>
+ *
+ * <ul>
+ *   <li>Register triggers when a case is created: {@link #registerScheduledTriggers(CaseInstance)}
+ *   <li>Cancel all triggers when a case completes: {@link #cancelAllTriggers(UUID)}
+ * </ul>
+ *
+ * @see ScheduleTrigger
+ * @see ScheduledTriggerJob
+ * @see ConditionalScheduledTriggerJob
+ */
+@ApplicationScoped
+public class SchedulerService {
+
+  private static final Logger LOG = Logger.getLogger(SchedulerService.class);
+
+  @Inject Scheduler quartz;
+
+  @Inject CaseDefinitionRegistry caseDefinitionRegistry;
+
+  /**
+   * Register all scheduled triggers for a case instance.
+   *
+   * <p>Scans the case definition for bindings with {@link ScheduleTrigger} and creates Quartz jobs
+   * for each. Jobs are grouped by case ID for easy bulk cancellation.
+   *
+   * @param caseInstance the case instance to register triggers for
+   * @return Uni that completes when all triggers are registered
+   */
+  public Uni<Void> registerScheduledTriggers(CaseInstance caseInstance) {
+    CaseDefinition definition =
+        caseDefinitionRegistry.getCaseDefinition(caseInstance.getCaseMetaModel());
+
+    if (definition == null) {
+      return Uni.createFrom()
+          .failure(
+              new IllegalStateException(
+                  "CaseDefinition not found for case: " + caseInstance.getUuid()));
+    }
+
+    List<Binding> bindings = definition.getBindings();
+    if (bindings == null || bindings.isEmpty()) {
+      return Uni.createFrom().voidItem();
+    }
+
+    List<Uni<Void>> scheduleOps = new ArrayList<>();
+
+    for (Binding binding : bindings) {
+      if (!(binding.getOn() instanceof ScheduleTrigger trigger)) {
+        continue;
+      }
+
+      // Find worker that provides the capability
+      Worker worker = findWorkerForCapability(definition, binding.getCapability());
+      if (worker == null) {
+        LOG.warnf(
+            "No worker found for capability '%s' in binding '%s', skipping",
+            binding.getCapability().getName(), binding.getName());
+        continue;
+      }
+
+      if (binding.getWhen() != null) {
+        // Conditional scheduling
+        scheduleOps.add(
+            scheduleConditionalWorker(
+                caseInstance.getUuid(), binding, trigger, binding.getWhen(), worker));
+      } else {
+        // Unconditional scheduling
+        scheduleOps.add(scheduleWorker(caseInstance.getUuid(), binding, trigger, worker));
+      }
+    }
+
+    if (scheduleOps.isEmpty()) {
+      return Uni.createFrom().voidItem();
+    }
+
+    return Uni.combine().all().unis(scheduleOps).discardItems();
+  }
+
+  /**
+   * Schedule unconditional worker execution when the trigger fires.
+   *
+   * @param caseId the case ID
+   * @param binding the binding configuration
+   * @param trigger the schedule trigger
+   * @param worker the worker to execute
+   * @return Uni that completes when the job is scheduled
+   */
+  public Uni<Void> scheduleWorker(
+      UUID caseId, Binding binding, ScheduleTrigger trigger, Worker worker) {
+
+    return Uni.createFrom()
+        .item(
+            () -> {
+              JobKey jobKey = createJobKey(caseId, binding.getName());
+              JobDetail job = createJobDetail(jobKey, caseId, binding, worker, null);
+              Trigger quartzTrigger = createQuartzTrigger(jobKey, trigger);
+
+              try {
+                quartz.scheduleJob(job, quartzTrigger);
+                LOG.infof(
+                    "Scheduled unconditional trigger: case=%s, binding=%s, trigger=%s",
+                    caseId, binding.getName(), trigger);
+              } catch (SchedulerException e) {
+                throw new RuntimeException(
+                    "Failed to schedule trigger for binding: " + binding.getName(), e);
+              }
+
+              return null;
+            })
+        .replaceWithVoid();
+  }
+
+  /**
+   * Schedule conditional worker execution. The worker executes only if the condition evaluates to
+   * true when the trigger fires.
+   *
+   * @param caseId the case ID
+   * @param binding the binding configuration
+   * @param trigger the schedule trigger
+   * @param condition the condition to evaluate
+   * @param worker the worker to execute if condition is true
+   * @return Uni that completes when the job is scheduled
+   */
+  public Uni<Void> scheduleConditionalWorker(
+      UUID caseId,
+      Binding binding,
+      ScheduleTrigger trigger,
+      ExpressionEvaluator condition,
+      Worker worker) {
+
+    return Uni.createFrom()
+        .item(
+            Unchecked.supplier(
+                () -> {
+                  JobKey jobKey = createJobKey(caseId, binding.getName());
+                  JobDetail job = createJobDetail(jobKey, caseId, binding, worker, condition);
+                  Trigger quartzTrigger = createQuartzTrigger(jobKey, trigger);
+
+                  try {
+                    quartz.scheduleJob(job, quartzTrigger);
+                    LOG.infof(
+                        "Scheduled conditional trigger: case=%s, binding=%s, trigger=%s, condition=%s",
+                        caseId, binding.getName(), trigger, condition);
+                  } catch (SchedulerException e) {
+                    throw new RuntimeException(
+                        "Failed to schedule conditional trigger for binding: " + binding.getName(),
+                        e);
+                  }
+
+                  return null;
+                }))
+        .replaceWithVoid();
+  }
+
+  /**
+   * Cancel all scheduled triggers for a case.
+   *
+   * <p>This should be called when a case completes (COMPLETED, CLOSED, or FAULTED state).
+   *
+   * @param caseId the case ID
+   * @return Uni that completes when all triggers are cancelled
+   */
+  public Uni<Void> cancelAllTriggers(UUID caseId) {
+    return Uni.createFrom()
+        .item(
+            Unchecked.supplier(
+                () -> {
+                  try {
+                    String groupName = "case-" + caseId;
+                    GroupMatcher<JobKey> matcher = GroupMatcher.jobGroupEquals(groupName);
+                    Set<JobKey> jobKeys = quartz.getJobKeys(matcher);
+
+                    if (!jobKeys.isEmpty()) {
+                      quartz.deleteJobs(new ArrayList<>(jobKeys));
+                      LOG.infof(
+                          "Cancelled %d scheduled triggers for case %s", jobKeys.size(), caseId);
+                    } else {
+                      LOG.debugf("No scheduled triggers to cancel for case %s", caseId);
+                    }
+                  } catch (SchedulerException e) {
+                    throw new RuntimeException("Failed to cancel triggers for case: " + caseId, e);
+                  }
+
+                  return null;
+                }))
+        .replaceWithVoid();
+  }
+
+  /**
+   * Cancel a specific scheduled trigger for a case.
+   *
+   * @param caseId the case ID
+   * @param bindingName the binding name
+   * @return Uni that completes when the trigger is cancelled
+   */
+  public Uni<Void> cancelTrigger(UUID caseId, String bindingName) {
+    return Uni.createFrom()
+        .item(
+            Unchecked.supplier(
+                () -> {
+                  try {
+                    JobKey jobKey = createJobKey(caseId, bindingName);
+                    boolean deleted = quartz.deleteJob(jobKey);
+
+                    if (deleted) {
+                      LOG.infof(
+                          "Cancelled scheduled trigger: case=%s, binding=%s", caseId, bindingName);
+                    } else {
+                      LOG.debugf(
+                          "No trigger found to cancel: case=%s, binding=%s", caseId, bindingName);
+                    }
+                  } catch (SchedulerException e) {
+                    throw new RuntimeException(
+                        "Failed to cancel trigger for binding: " + bindingName, e);
+                  }
+
+                  return null;
+                }))
+        .replaceWithVoid();
+  }
+
+  private JobKey createJobKey(UUID caseId, String bindingName) {
+    return new JobKey("binding-" + bindingName, "case-" + caseId);
+  }
+
+  private JobDetail createJobDetail(
+      JobKey jobKey, UUID caseId, Binding binding, Worker worker, ExpressionEvaluator condition) {
+
+    Class<? extends org.quartz.Job> jobClass =
+        (condition != null) ? ConditionalScheduledTriggerJob.class : ScheduledTriggerJob.class;
+
+    return newJob(jobClass)
+        .withIdentity(jobKey)
+        .storeDurably(false)
+        .usingJobData("caseId", caseId.toString())
+        .usingJobData("bindingName", binding.getName())
+        .usingJobData("capabilityName", binding.getCapability().getName())
+        .usingJobData("workerName", worker.getName())
+        .build();
+  }
+
+  private Trigger createQuartzTrigger(JobKey jobKey, ScheduleTrigger trigger) {
+    if (trigger.isCron()) {
+      return createCronTrigger(jobKey, trigger.getCron());
+    } else if (trigger.isDelay()) {
+      return createDelayTrigger(jobKey, trigger.getDelay().toMillis());
+    } else {
+      throw new IllegalArgumentException("ScheduleTrigger must have either cron or delay set");
+    }
+  }
+
+  private CronTrigger createCronTrigger(JobKey jobKey, String cronExpression) {
+    return newTrigger()
+        .withIdentity("trigger-" + jobKey.getName(), jobKey.getGroup())
+        .withSchedule(cronSchedule(cronExpression))
+        .build();
+  }
+
+  private SimpleTrigger createDelayTrigger(JobKey jobKey, long delayMillis) {
+    Date startTime = new Date(System.currentTimeMillis() + delayMillis);
+
+    return newTrigger()
+        .withIdentity("trigger-" + jobKey.getName(), jobKey.getGroup())
+        .startAt(startTime)
+        .withSchedule(simpleSchedule().withRepeatCount(0)) // one-shot
+        .build();
+  }
+
+  private Worker findWorkerForCapability(CaseDefinition definition, Capability capability) {
+    return definition.getWorkers().stream()
+        .filter(
+            w ->
+                w.getCapabilities().stream()
+                    .anyMatch(c -> c.getName().equals(capability.getName())))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/ScheduleTriggerSimpleTest.java
+++ b/engine/src/test/java/io/casehub/engine/ScheduleTriggerSimpleTest.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.ScheduleTrigger;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class ScheduleTriggerSimpleTest {
+
+  @Inject ScheduleTriggerTestBean delayBean;
+  @Inject CronTriggerTestBean cronBean;
+  @Inject ConditionalTriggerTestBean conditionalBean;
+  @Inject ConditionalTriggerNotMetTestBean conditionalNotMetBean;
+  @Inject MultipleTriggerTestBean multipleTriggersBean;
+  @Inject CancellationTestBean cancellationBean;
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @BeforeEach
+  void setUp() {
+    ScheduleTriggerTestBean.executionCount.set(0);
+    CronTriggerTestBean.executionCount.set(0);
+    ConditionalTriggerTestBean.executionCount.set(0);
+    ConditionalTriggerNotMetTestBean.executionCount.set(0);
+    MultipleTriggerTestBean.worker1Count.set(0);
+    MultipleTriggerTestBean.worker2Count.set(0);
+    CancellationTestBean.executionCount.set(0);
+  }
+
+  @Test
+  void delayTriggerExecutesWorkerAfterDuration() {
+    delayBean.startCase(Map.of("started", true));
+
+    // Should NOT execute immediately
+    assertThat(ScheduleTriggerTestBean.executionCount.get()).isEqualTo(0);
+
+    // Wait for trigger (2s delay + buffer)
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(ScheduleTriggerTestBean.executionCount.get()).isEqualTo(1));
+  }
+
+  @Test
+  void cronTriggerExecutesWorker() {
+    cronBean.startCase(Map.of("started", true));
+
+    // Should NOT execute immediately
+    assertThat(CronTriggerTestBean.executionCount.get()).isEqualTo(0);
+
+    // Wait for first execution (cron runs every 2 seconds: "*/2 * * * * ?")
+    // Note: worker deduplication prevents repeated execution of the same worker
+    // Testing periodic execution would require different workers or idempotency keys
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> assertThat(CronTriggerTestBean.executionCount.get()).isGreaterThanOrEqualTo(1));
+  }
+
+  @Test
+  void conditionalTriggerExecutesWhenConditionMet() {
+    conditionalBean.startCase(Map.of("status", "ready"));
+
+    // Should NOT execute immediately
+    assertThat(ConditionalTriggerTestBean.executionCount.get()).isEqualTo(0);
+
+    // Wait for trigger (condition .status == "ready" should be true)
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> assertThat(ConditionalTriggerTestBean.executionCount.get()).isEqualTo(1));
+  }
+
+  @Test
+  void conditionalTriggerDoesNotExecuteWhenConditionNotMet() {
+    conditionalNotMetBean.startCase(Map.of("status", "not-ready"));
+
+    // Should NOT execute immediately
+    assertThat(ConditionalTriggerNotMetTestBean.executionCount.get()).isEqualTo(0);
+
+    // Wait for trigger - should NOT execute because condition is not met
+    // Condition checks .status == "ready", but we set it to "not-ready"
+    try {
+      await()
+          .atMost(5, TimeUnit.SECONDS)
+          .pollInterval(100, TimeUnit.MILLISECONDS)
+          .untilAsserted(
+              () ->
+                  assertThat(ConditionalTriggerNotMetTestBean.executionCount.get())
+                      .isGreaterThan(0));
+
+      // If we reach here, test should fail
+      throw new AssertionError("Worker should not have executed when condition is not met");
+    } catch (org.awaitility.core.ConditionTimeoutException e) {
+      // Expected - condition was not met, so worker never executed
+      assertThat(ConditionalTriggerNotMetTestBean.executionCount.get()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  void multipleTriggersExecuteIndependently() {
+    multipleTriggersBean.startCase(Map.of("started", true));
+
+    // Should NOT execute immediately
+    assertThat(MultipleTriggerTestBean.worker1Count.get()).isEqualTo(0);
+    assertThat(MultipleTriggerTestBean.worker2Count.get()).isEqualTo(0);
+
+    // Wait for both triggers (2s and 3s delays)
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(MultipleTriggerTestBean.worker1Count.get()).isEqualTo(1));
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(MultipleTriggerTestBean.worker2Count.get()).isEqualTo(1));
+  }
+
+  @Test
+  void triggersAreCancelledWhenCaseCompletes() {
+    java.util.UUID caseId =
+        cancellationBean.startCase(Map.of("started", true)).toCompletableFuture().join();
+
+    // Should NOT execute immediately
+    assertThat(CancellationTestBean.executionCount.get()).isEqualTo(0);
+
+    // Complete the case before trigger fires (trigger has 5s delay)
+    CaseInstance instance = caseInstanceCache.get(caseId);
+    instance.setState(CaseStatus.COMPLETED);
+
+    // Wait to ensure trigger does NOT fire
+    try {
+      await()
+          .atMost(7, TimeUnit.SECONDS)
+          .pollInterval(100, TimeUnit.MILLISECONDS)
+          .untilAsserted(
+              () -> assertThat(CancellationTestBean.executionCount.get()).isGreaterThan(0));
+
+      // If we reach here, test should fail
+      throw new AssertionError("Worker should not have executed after case completed");
+    } catch (org.awaitility.core.ConditionTimeoutException e) {
+      // Expected - trigger should be cancelled or lazy-cancelled
+      assertThat(CancellationTestBean.executionCount.get()).isEqualTo(0);
+    }
+  }
+
+  @ApplicationScoped
+  static class ScheduleTriggerTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("doWork")
+              .inputSchema("{ }")
+              .outputSchema("{ workDone: .workDone }")
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("worker")
+              .capabilities(cap)
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    return Map.of("workDone", true);
+                  })
+              .build();
+
+      Binding binding =
+          Binding.builder()
+              .name("delayed-work")
+              .capability(cap)
+              .on(ScheduleTrigger.delay(Duration.ofSeconds(2)))
+              .build();
+
+      return CaseDefinition.builder()
+          .name("schedule-test-delay")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(binding)
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  static class CronTriggerTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("doWork")
+              .inputSchema("{ }")
+              .outputSchema("{ workDone: .workDone }")
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("worker")
+              .capabilities(cap)
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    return Map.of("workDone", true);
+                  })
+              .build();
+
+      Binding binding =
+          Binding.builder()
+              .name("cron-work")
+              .capability(cap)
+              .on(ScheduleTrigger.cron("*/2 * * * * ?")) // Every 2 seconds
+              .build();
+
+      return CaseDefinition.builder()
+          .name("schedule-test-cron")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(binding)
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  static class ConditionalTriggerTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("doWork")
+              .inputSchema("{ }")
+              .outputSchema("{ workDone: .workDone }")
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("worker")
+              .capabilities(cap)
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    return Map.of("workDone", true);
+                  })
+              .build();
+
+      Binding binding =
+          Binding.builder()
+              .name("conditional-work")
+              .capability(cap)
+              .on(ScheduleTrigger.delay(Duration.ofSeconds(2)))
+              .when(new JQExpressionEvaluator(".status == \"ready\""))
+              .build();
+
+      return CaseDefinition.builder()
+          .name("schedule-test-conditional")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(binding)
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  static class ConditionalTriggerNotMetTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("doWork")
+              .inputSchema("{ }")
+              .outputSchema("{ workDone: .workDone }")
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("worker")
+              .capabilities(cap)
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    return Map.of("workDone", true);
+                  })
+              .build();
+
+      Binding binding =
+          Binding.builder()
+              .name("conditional-not-met-work")
+              .capability(cap)
+              .on(ScheduleTrigger.delay(Duration.ofSeconds(2)))
+              .when(new JQExpressionEvaluator(".status == \"ready\""))
+              .build();
+
+      return CaseDefinition.builder()
+          .name("schedule-test-conditional-not-met")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(binding)
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  static class MultipleTriggerTestBean extends CaseHub {
+    static final AtomicInteger worker1Count = new AtomicInteger(0);
+    static final AtomicInteger worker2Count = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap1 =
+          Capability.builder()
+              .name("doWork1")
+              .inputSchema("{ }")
+              .outputSchema("{ work1Done: .work1Done }")
+              .build();
+
+      Capability cap2 =
+          Capability.builder()
+              .name("doWork2")
+              .inputSchema("{ }")
+              .outputSchema("{ work2Done: .work2Done }")
+              .build();
+
+      Worker worker1 =
+          Worker.builder()
+              .name("worker1")
+              .capabilities(cap1)
+              .function(
+                  ctx -> {
+                    worker1Count.incrementAndGet();
+                    return Map.of("work1Done", true);
+                  })
+              .build();
+
+      Worker worker2 =
+          Worker.builder()
+              .name("worker2")
+              .capabilities(cap2)
+              .function(
+                  ctx -> {
+                    worker2Count.incrementAndGet();
+                    return Map.of("work2Done", true);
+                  })
+              .build();
+
+      Binding binding1 =
+          Binding.builder()
+              .name("trigger1")
+              .capability(cap1)
+              .on(ScheduleTrigger.delay(Duration.ofSeconds(2)))
+              .build();
+
+      Binding binding2 =
+          Binding.builder()
+              .name("trigger2")
+              .capability(cap2)
+              .on(ScheduleTrigger.delay(Duration.ofSeconds(3)))
+              .build();
+
+      return CaseDefinition.builder()
+          .name("schedule-test-multiple")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap1, cap2)
+          .workers(worker1, worker2)
+          .bindings(binding1, binding2)
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  static class CancellationTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("doWork")
+              .inputSchema("{ }")
+              .outputSchema("{ workDone: .workDone }")
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("worker")
+              .capabilities(cap)
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    return Map.of("workDone", true);
+                  })
+              .build();
+
+      Binding binding =
+          Binding.builder()
+              .name("delayed-work")
+              .capability(cap)
+              .on(ScheduleTrigger.delay(Duration.ofSeconds(5)))
+              .build();
+
+      Goal goal =
+          Goal.builder()
+              .name("complete")
+              .kind(GoalKind.SUCCESS)
+              .condition(new JQExpressionEvaluator(".workDone == true"))
+              .build();
+
+      return CaseDefinition.builder()
+          .name("schedule-test-cancellation")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(binding)
+          .goals(goal)
+          .build();
+    }
+  }
+}


### PR DESCRIPTION
…tion

  Implements time-based trigger support via Quartz scheduler:
  - Delay triggers (one-shot execution after duration)
  - Cron triggers (periodic execution via cron expression)
  - Conditional triggers (evaluate Binding.when before execution)
  - Lazy cancellation (check case state when trigger fires)

  Triggers are registered when case starts and cancelled when case
  completes (COMPLETED/FAULTED/CANCELLED states). Condition is retrieved
  from Binding definition at runtime, supporting any ExpressionEvaluator
  type including Java lambdas.

  New components:
  - ScheduleTrigger API with factory methods (cron/delay)
  - SchedulerService - manages Quartz job lifecycle
  - ScheduledTriggerJob - unconditional scheduled execution
  - ConditionalScheduledTriggerJob - conditional scheduled execution

  Tests: 6 integration tests covering delay, cron, conditional,
  multiple triggers, and cancellation scenarios

  Closes #21