### PR TITLE
feat(resilience): wire PropagationContext budget into CaseTimeoutEnforcer

### DIFF
--- a/casehub-resilience/src/main/java/io/casehub/resilience/timeout/CaseTimeoutEnforcer.java
+++ b/casehub-resilience/src/main/java/io/casehub/resilience/timeout/CaseTimeoutEnforcer.java
@@ -29,30 +29,18 @@ import io.quarkus.scheduler.Scheduled;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
-import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
 /**
- * Scheduled scanner that faults RUNNING cases whose wall-clock age has exceeded the configured
- * budget.
+ * Scheduled scanner that faults RUNNING cases whose {@link
+ * io.casehub.api.context.PropagationContext} budget is exhausted.
  *
- * <p>Timeout detection is based on wall-clock time because {@code PropagationContext} (which will
- * carry a structured budget field) has not yet been merged into the {@code api} module. Once PR
- * #119 lands, replace the wall-clock tracking here with {@code
- * PropagationContext#isBudgetExhausted()}.
- *
- * <p>Start times are recorded lazily: the first time the scanner observes a case in RUNNING state
- * it records that instant as the effective start. This avoids competing with the engine's
- * request-reply {@code CASE_STARTED} event bus consumer ({@code CaseStartedEventHandler}), which
- * uses point-to-point {@code request()} semantics and must not have additional consumers competing
- * to handle the message.
+ * <p>The budget deadline is set at case creation time by {@code CaseHubReactor} using the {@code
+ * casehub.resilience.timeout.max-duration} config property. Cases without a propagation context
+ * (e.g. restored from persistence before this feature was introduced) are skipped — no budget means
+ * no timeout.
  *
  * <p>Cases that exceed the budget are transitioned to {@link CaseStatus#FAULTED}. A {@link
  * EventBusAddresses#CASE_STATUS_CHANGED} event is published, which causes {@code
@@ -64,124 +52,65 @@ public class CaseTimeoutEnforcer {
 
   private static final Logger LOG = Logger.getLogger(CaseTimeoutEnforcer.class);
 
-  /** Default max run time — override with {@code casehub.resilience.timeout.max-duration}. */
-  static final Duration DEFAULT_MAX_DURATION = Duration.ofMinutes(5);
-
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final CaseInstanceCache cache;
   private final EventBus eventBus;
   private final CaseInstanceRepository caseInstanceRepository;
-  private final Duration maxDuration;
-  private final Clock clock;
 
-  /**
-   * Key: caseId. Value: the instant the enforcer first observed the case in RUNNING state. Used as
-   * a conservative wall-clock start time until PropagationContext is available (PR #119).
-   */
-  private final ConcurrentHashMap<UUID, Instant> runningStartTimes = new ConcurrentHashMap<>();
-
-  /** Production constructor — injected by CDI. */
   @Inject
   public CaseTimeoutEnforcer(
       CaseInstanceCache cache, EventBus eventBus, CaseInstanceRepository caseInstanceRepository) {
-    this(cache, eventBus, caseInstanceRepository, DEFAULT_MAX_DURATION, Clock.systemUTC());
-  }
-
-  /**
-   * Test constructor — allows injecting a custom {@link Clock} and {@link Duration} without
-   * starting a Quarkus container.
-   */
-  CaseTimeoutEnforcer(
-      CaseInstanceCache cache,
-      EventBus eventBus,
-      CaseInstanceRepository caseInstanceRepository,
-      Duration maxDuration,
-      Clock clock) {
     this.cache = cache;
     this.eventBus = eventBus;
     this.caseInstanceRepository = caseInstanceRepository;
-    this.maxDuration = maxDuration;
-    this.clock = clock;
   }
 
   /**
-   * Scheduled scan. Iterates all cached RUNNING cases and faults any whose elapsed wall-clock time
-   * exceeds {@link #maxDuration}.
+   * Scheduled scan. Iterates all cached RUNNING cases and faults any whose {@code
+   * PropagationContext} budget is exhausted.
    *
    * <p>Called every second by default; override with {@code
    * casehub.resilience.timeout.check-interval}.
    */
   @Scheduled(every = "${casehub.resilience.timeout.check-interval:1s}")
   public void scanForTimeouts() {
-    Instant now = Instant.now(clock);
-    java.util.List<CaseInstance> snapshot = cache.getAll();
-
-    for (CaseInstance instance : snapshot) {
+    Instant now = Instant.now();
+    for (CaseInstance instance : cache.getAll()) {
       if (instance.getState() != CaseStatus.RUNNING) {
         continue;
       }
-      UUID caseId = instance.getUuid();
-
-      // Record start time lazily on first observation of a RUNNING case.
-      Instant startedAt = runningStartTimes.computeIfAbsent(caseId, id -> now);
-
-      Duration elapsed = Duration.between(startedAt, now);
-      if (elapsed.compareTo(maxDuration) > 0) {
-        LOG.warnf(
-            "Case %s has been RUNNING for %s (limit: %s) — transitioning to FAULTED",
-            caseId, elapsed, maxDuration);
-
-        String oldStatus = instance.getState().name();
-        instance.setState(CaseStatus.FAULTED);
-        runningStartTimes.remove(caseId);
-
-        EventLog eventLog = new EventLog();
-        eventLog.setEventType(CaseHubEventType.CASE_FAULTED);
-        eventLog.setCaseId(caseId);
-        eventLog.setStreamType(EventStreamType.CASE);
-        eventLog.setTimestamp(now);
-        eventLog.setMetadata(
-            OBJECT_MAPPER
-                .createObjectNode()
-                .put("reason", "timeout")
-                .put("elapsed", elapsed.toString()));
-
-        caseInstanceRepository
-            .updateStateAndAppendEvent(instance, eventLog)
-            .subscribe()
-            .with(
-                ignored ->
-                    eventBus.publish(
-                        EventBusAddresses.CASE_STATUS_CHANGED,
-                        new CaseStatusChanged(instance, oldStatus, CaseStatus.FAULTED.name())),
-                error ->
-                    LOG.errorf(
-                        error,
-                        "Failed to persist FAULTED state for case %s — state is already mutated in cache",
-                        caseId));
+      if (instance.getPropagationContext() == null
+          || !instance.getPropagationContext().isBudgetExhausted()) {
+        continue;
       }
+
+      UUID caseId = instance.getUuid();
+      LOG.warnf("Case %s budget exhausted — transitioning to FAULTED", caseId);
+
+      String oldStatus = instance.getState().name();
+      instance.setState(CaseStatus.FAULTED);
+
+      EventLog eventLog = new EventLog();
+      eventLog.setEventType(CaseHubEventType.CASE_FAULTED);
+      eventLog.setCaseId(caseId);
+      eventLog.setStreamType(EventStreamType.CASE);
+      eventLog.setTimestamp(now);
+      eventLog.setMetadata(OBJECT_MAPPER.createObjectNode().put("reason", "timeout"));
+
+      caseInstanceRepository
+          .updateStateAndAppendEvent(instance, eventLog)
+          .subscribe()
+          .with(
+              ignored ->
+                  eventBus.publish(
+                      EventBusAddresses.CASE_STATUS_CHANGED,
+                      new CaseStatusChanged(instance, oldStatus, CaseStatus.FAULTED.name())),
+              error ->
+                  LOG.errorf(
+                      error,
+                      "Failed to persist FAULTED state for case %s — state is already mutated in cache",
+                      caseId));
     }
-
-    // Remove start-time entries for cases no longer tracked as RUNNING in the cache.
-    Set<UUID> activeIds =
-        snapshot.stream()
-            .filter(i -> i.getState() == CaseStatus.RUNNING)
-            .map(CaseInstance::getUuid)
-            .collect(Collectors.toSet());
-    runningStartTimes.keySet().retainAll(activeIds);
-  }
-
-  /**
-   * Records a start time for a case directly. Used in tests that bypass the normal scheduled scan
-   * flow to set a back-dated start time that will trigger timeout detection.
-   */
-  void recordStartTime(UUID caseId, Instant startedAt) {
-    runningStartTimes.put(caseId, startedAt);
-  }
-
-  /** Returns the recorded start time for a case, or {@link Optional#empty()} if not yet seen. */
-  Optional<Instant> getStartTime(UUID caseId) {
-    return Optional.ofNullable(runningStartTimes.get(caseId));
   }
 }

--- a/casehub-resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerIntegrationTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerIntegrationTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.resilience.timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.BackoffStrategy;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link CaseTimeoutEnforcer}.
+ *
+ * <p>Runs with {@code casehub.resilience.timeout.max-duration=PT1S} (set in test
+ * application.properties) so the PropagationContext budget expires in 1 second. The scheduler scans
+ * every 1 second by default, so hanging cases reach FAULTED within ~2 seconds.
+ *
+ * <p>Existing integration tests in this module complete well under 1 second (retry exhaustion in
+ * ~150ms) and are unaffected by the short budget.
+ */
+@QuarkusTest
+class CaseTimeoutEnforcerIntegrationTest {
+
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject HangingCaseHub hangingCase;
+
+  @BeforeEach
+  void clearCache() {
+    caseInstanceCache.clear();
+  }
+
+  // ---- Wiring correctness ---------------------------------------------------
+
+  /**
+   * Verifies that {@code CaseHubReactor} sets a {@link io.casehub.api.context.PropagationContext}
+   * with a deadline on every new {@link CaseInstance}. The deadline comes from {@code
+   * casehub.resilience.timeout.max-duration} (PT1S in test config).
+   */
+  @Test
+  void startedCase_hasPropagationContextWithBudget() throws Exception {
+    UUID caseId = startCase();
+
+    CaseInstance instance = caseInstanceCache.get(caseId);
+    assertThat(instance).isNotNull();
+    assertThat(instance.getPropagationContext()).isNotNull();
+    assertThat(instance.getPropagationContext().getDeadline()).isPresent();
+    assertThat(instance.getPropagationContext().getRemainingBudget()).isPresent();
+  }
+
+  // ---- End-to-end timeout ---------------------------------------------------
+
+  /**
+   * End-to-end: a case whose worker blocks indefinitely is faulted by the {@link
+   * CaseTimeoutEnforcer} once the PropagationContext budget (1s) is exhausted. The scheduler
+   * detects the exhausted budget within the next scan cycle and transitions the case to FAULTED.
+   */
+  @Test
+  void hangingCase_budgetExhausted_isTransitionedToFaulted() throws Exception {
+    UUID caseId = startCase();
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              CaseInstance instance = caseInstanceCache.get(caseId);
+              assertThat(instance).isNotNull();
+              assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
+            });
+  }
+
+  // ---- Helper ---------------------------------------------------------------
+
+  private UUID startCase() throws Exception {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    AtomicReference<Throwable> err = new AtomicReference<>();
+
+    hangingCase
+        .startCase(Map.of("trigger", "go"))
+        .thenAccept(caseIdRef::set)
+        .exceptionally(
+            ex -> {
+              err.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (err.get() != null) throw new AssertionError(err.get());
+              assertThat(caseIdRef.get()).isNotNull();
+            });
+
+    return caseIdRef.get();
+  }
+
+  // ---- Case bean ------------------------------------------------------------
+
+  @ApplicationScoped
+  public static class HangingCaseHub extends CaseHub {
+
+    private final Capability capability =
+        Capability.builder()
+            .name("hang")
+            .inputSchema("{ trigger: .trigger }")
+            .outputSchema("{ trigger: .trigger }")
+            .build();
+
+    private final Goal goal =
+        Goal.builder()
+            .name("done")
+            .condition(".trigger == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-timeout-it")
+          .name("Hanging Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("hanging-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        try {
+                          Thread.sleep(60_000); // 60s — far exceeds the 1s budget
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                        }
+                        return Map.of();
+                      })
+                  .executionPolicy(
+                      // 30s per-execution timeout, 1 retry — budget expires at 1s, long before
+                      // either execution timeout or retry kicks in.
+                      new ExecutionPolicy(30_000, new RetryPolicy(1, 100, BackoffStrategy.FIXED)))
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("hang-trigger")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+}

--- a/casehub-resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerTest.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerTest.java
@@ -19,9 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.casehub.api.context.PropagationContext;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.event.CaseStatusChanged;
@@ -30,28 +32,23 @@ import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.spi.CaseInstanceRepository;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
-import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.ZoneOffset;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Pure unit tests — no Quarkus, no CDI. CaseTimeoutEnforcer is testable without a container because
- * it exposes a package-private constructor that accepts a {@link Clock} and {@link Duration}.
- *
- * <p>Note: PropagationContext (PR #119) is not yet merged into api/. Timeout detection falls back
- * to wall-clock elapsed time tracked internally by the enforcer. Once PR #119 lands, update these
- * tests to set an exhausted PropagationContext budget instead.
+ * Pure unit tests — no Quarkus, no CDI. Timeout detection is driven by {@link
+ * PropagationContext#isBudgetExhausted()}. Tests set an exhausted or healthy context directly on
+ * the instance rather than manipulating wall-clock time.
  */
 class CaseTimeoutEnforcerTest {
 
   private CaseInstanceCache cache;
   private EventBus eventBus;
   private CaseInstanceRepository repository;
-  private Clock fixedClock;
+  private CaseTimeoutEnforcer enforcer;
 
   @BeforeEach
   void setUp() {
@@ -60,70 +57,65 @@ class CaseTimeoutEnforcerTest {
     repository = mock(CaseInstanceRepository.class);
     when(repository.updateStateAndAppendEvent(any(), any()))
         .thenReturn(Uni.createFrom().voidItem());
-    fixedClock = Clock.fixed(Instant.parse("2026-04-21T10:00:00Z"), ZoneOffset.UTC);
+    enforcer = new CaseTimeoutEnforcer(cache, eventBus, repository);
   }
 
-  // ---- Helper ---------------------------------------------------------------
+  // ---- Helpers ---------------------------------------------------------------
 
   private CaseInstance runningInstance() {
     CaseInstance instance = new CaseInstance();
     instance.setUuid(UUID.randomUUID());
     instance.setState(CaseStatus.RUNNING);
+    instance.setPropagationContext(healthyContext());
     return instance;
   }
 
-  private CaseTimeoutEnforcer enforcerWithMaxDuration(Duration maxDuration) {
-    return new CaseTimeoutEnforcer(cache, eventBus, repository, maxDuration, fixedClock);
+  private PropagationContext healthyContext() {
+    return PropagationContext.createRoot(Map.of(), Duration.ofHours(1));
+  }
+
+  private PropagationContext exhaustedContext() {
+    return PropagationContext.createRoot(Map.of(), Duration.ZERO);
   }
 
   // ---- No-op cases ----------------------------------------------------------
 
   @Test
   void emptyCache_scanForTimeouts_doesNothing() {
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
     enforcer.scanForTimeouts(); // must not throw
   }
 
   @Test
-  void runningCase_firstObservation_recordsStartAndRemainRunning() {
-    CaseInstance instance = runningInstance();
+  void runningCase_withinBudget_remainsRunning() {
+    CaseInstance instance = runningInstance(); // healthy context with 1h budget
     cache.put(instance);
 
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    // First scan: start time is recorded lazily as "now" (fixedClock = 10:00:00).
-    // Elapsed = 0 — well within the 5-minute budget.
     enforcer.scanForTimeouts();
 
     assertThat(instance.getState()).isEqualTo(CaseStatus.RUNNING);
-    assertThat(enforcer.getStartTime(instance.getUuid())).isPresent();
   }
 
   @Test
-  void runningCase_withinBudget_remainsRunning() {
-    CaseInstance instance = runningInstance();
+  void runningCase_noPropagationContext_isSkipped() {
+    CaseInstance instance = new CaseInstance();
+    instance.setUuid(UUID.randomUUID());
+    instance.setState(CaseStatus.RUNNING);
+    // no PropagationContext — simulates a case restored from persistence before this feature
     cache.put(instance);
-
-    // Start time is 1 minute before "now"; max is 5 minutes → within budget
-    Instant startedAt = Instant.parse("2026-04-21T09:59:00Z");
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(instance.getUuid(), startedAt);
 
     enforcer.scanForTimeouts();
 
     assertThat(instance.getState()).isEqualTo(CaseStatus.RUNNING);
+    verify(repository, never()).updateStateAndAppendEvent(any(), any());
   }
 
   // ---- Timeout cases --------------------------------------------------------
 
   @Test
-  void runningCase_exceededBudget_isTransitionedToFaulted() {
+  void runningCase_exhaustedBudget_isTransitionedToFaulted() {
     CaseInstance instance = runningInstance();
+    instance.setPropagationContext(exhaustedContext());
     cache.put(instance);
-
-    // Start time is 10 minutes before "now"; max is 5 minutes → exceeded
-    Instant startedAt = Instant.parse("2026-04-21T09:50:00Z");
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(instance.getUuid(), startedAt);
 
     enforcer.scanForTimeouts();
 
@@ -133,16 +125,11 @@ class CaseTimeoutEnforcerTest {
   @Test
   void timedOutCase_statusChangedEventIsPublished() {
     CaseInstance instance = runningInstance();
-    UUID caseId = instance.getUuid();
+    instance.setPropagationContext(exhaustedContext());
     cache.put(instance);
-
-    Instant startedAt = Instant.parse("2026-04-21T09:50:00Z");
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(caseId, startedAt);
 
     enforcer.scanForTimeouts();
 
-    // Enforcer publishes CASE_STATUS_CHANGED; CaseStatusChangedHandler then emits CASE_FAULTED.
     verify(eventBus)
         .publish(eq(EventBusAddresses.CASE_STATUS_CHANGED), any(CaseStatusChanged.class));
   }
@@ -150,30 +137,12 @@ class CaseTimeoutEnforcerTest {
   @Test
   void timedOutCase_persistenceIsInvoked() {
     CaseInstance instance = runningInstance();
+    instance.setPropagationContext(exhaustedContext());
     cache.put(instance);
-
-    Instant startedAt = Instant.parse("2026-04-21T09:50:00Z");
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(instance.getUuid(), startedAt);
 
     enforcer.scanForTimeouts();
 
     verify(repository).updateStateAndAppendEvent(any(), any());
-  }
-
-  @Test
-  void timedOutCase_startTimeIsRemovedAfterFault() {
-    CaseInstance instance = runningInstance();
-    UUID caseId = instance.getUuid();
-    cache.put(instance);
-
-    Instant startedAt = Instant.parse("2026-04-21T09:50:00Z");
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(caseId, startedAt);
-
-    enforcer.scanForTimeouts();
-
-    assertThat(enforcer.getStartTime(caseId)).isEmpty();
   }
 
   // ---- Non-RUNNING cases are ignored ----------------------------------------
@@ -181,12 +150,9 @@ class CaseTimeoutEnforcerTest {
   @Test
   void completedCase_isNeverFaulted() {
     CaseInstance instance = runningInstance();
+    instance.setPropagationContext(exhaustedContext());
     instance.setState(CaseStatus.COMPLETED);
     cache.put(instance);
-
-    Instant startedAt = Instant.parse("2026-04-21T09:00:00Z"); // 1 hour ago
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(instance.getUuid(), startedAt);
 
     enforcer.scanForTimeouts();
 
@@ -196,37 +162,13 @@ class CaseTimeoutEnforcerTest {
   @Test
   void waitingCase_isNeverFaulted() {
     CaseInstance instance = runningInstance();
+    instance.setPropagationContext(exhaustedContext());
     instance.setState(CaseStatus.WAITING);
     cache.put(instance);
-
-    Instant startedAt = Instant.parse("2026-04-21T09:00:00Z");
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(instance.getUuid(), startedAt);
 
     enforcer.scanForTimeouts();
 
     assertThat(instance.getState()).isEqualTo(CaseStatus.WAITING);
-  }
-
-  // ---- Memory-leak fix: stale runningStartTimes entries are pruned -----------
-
-  @Test
-  void completedCase_staleStartTimeIsRemovedOnNextScan() {
-    CaseInstance instance = runningInstance();
-    UUID caseId = instance.getUuid();
-    cache.put(instance);
-
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    // Manually record a start time (simulating a previously RUNNING case).
-    enforcer.recordStartTime(caseId, Instant.parse("2026-04-21T09:59:00Z"));
-
-    // Case completes outside the enforcer (normal engine path).
-    instance.setState(CaseStatus.COMPLETED);
-
-    // Next scan: case is COMPLETED, not RUNNING — stale entry must be pruned.
-    enforcer.scanForTimeouts();
-
-    assertThat(enforcer.getStartTime(caseId)).isEmpty();
   }
 
   // ---- Multiple cases -------------------------------------------------------
@@ -234,13 +176,13 @@ class CaseTimeoutEnforcerTest {
   @Test
   void multipleCases_onlyExhaustedOnesAreFaulted() {
     CaseInstance overdue = runningInstance();
+    overdue.setPropagationContext(exhaustedContext());
+
     CaseInstance healthy = runningInstance();
+    // healthy context already set by runningInstance()
+
     cache.put(overdue);
     cache.put(healthy);
-
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(overdue.getUuid(), Instant.parse("2026-04-21T09:50:00Z")); // 10m ago
-    enforcer.recordStartTime(healthy.getUuid(), Instant.parse("2026-04-21T09:59:00Z")); // 1m ago
 
     enforcer.scanForTimeouts();
 
@@ -251,17 +193,13 @@ class CaseTimeoutEnforcerTest {
   @Test
   void secondScan_alreadyFaultedCase_isNotProcessedAgain() {
     CaseInstance instance = runningInstance();
-    UUID caseId = instance.getUuid();
+    instance.setPropagationContext(exhaustedContext());
     cache.put(instance);
 
-    CaseTimeoutEnforcer enforcer = enforcerWithMaxDuration(Duration.ofMinutes(5));
-    enforcer.recordStartTime(caseId, Instant.parse("2026-04-21T09:50:00Z"));
-
-    enforcer.scanForTimeouts(); // faults the case, removes start time
+    enforcer.scanForTimeouts(); // faults the case
     assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
 
-    // Second scan: state is FAULTED (not RUNNING), enforcer must skip it
-    enforcer.scanForTimeouts();
+    enforcer.scanForTimeouts(); // state is FAULTED (not RUNNING) — must be skipped
     assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
   }
 }

--- a/casehub-resilience/src/test/resources/application.properties
+++ b/casehub-resilience/src/test/resources/application.properties
@@ -13,3 +13,7 @@ quarkus.arc.selected-alternatives=\
 
 # Lower threshold for faster integration tests (default is 5)
 casehub.resilience.poison-pill.threshold=3
+
+# Short budget so CaseTimeoutEnforcerIntegrationTest faults quickly.
+# Existing integration tests complete in well under 1s so they are unaffected.
+casehub.resilience.timeout.max-duration=PT1S

--- a/engine-model/src/main/java/io/casehub/engine/internal/model/CaseInstance.java
+++ b/engine-model/src/main/java/io/casehub/engine/internal/model/CaseInstance.java
@@ -16,6 +16,7 @@
 package io.casehub.engine.internal.model;
 
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.PropagationContext;
 import io.casehub.api.model.CaseStatus;
 import java.util.UUID;
 
@@ -29,6 +30,7 @@ public class CaseInstance {
   private UUID uuid;
   private long version = 0L;
   private CaseContext caseContext;
+  private PropagationContext propagationContext;
   private UUID parentPlanItemId;
   private CaseStatus state;
 
@@ -62,6 +64,14 @@ public class CaseInstance {
 
   public void setCaseContext(CaseContext caseContext) {
     this.caseContext = caseContext;
+  }
+
+  public PropagationContext getPropagationContext() {
+    return propagationContext;
+  }
+
+  public void setPropagationContext(PropagationContext propagationContext) {
+    this.propagationContext = propagationContext;
   }
 
   public UUID getParentPlanItemId() {

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -19,6 +19,7 @@ import static io.casehub.engine.internal.event.EventBusAddresses.CASE_STARTED;
 import static io.casehub.engine.internal.event.EventBusAddresses.SIGNAL_RECEIVED;
 
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.PropagationContext;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
@@ -31,15 +32,22 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
 class CaseHubReactor {
 
   private static final Logger LOG = Logger.getLogger(CaseHubReactor.class);
+
+  @ConfigProperty(name = "casehub.resilience.timeout.max-duration")
+  Optional<Duration> maxDuration;
 
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
 
@@ -71,12 +79,18 @@ class CaseHubReactor {
   private Uni<CaseInstance> getCaseInstance(CaseDefinition definition, CaseContext context) {
     CaseMetaModel model = caseDefinitionRegistry.getCaseMetaModel(definition);
 
+    PropagationContext propagationContext =
+        maxDuration
+            .map(budget -> PropagationContext.createRoot(Map.of(), budget))
+            .orElse(PropagationContext.createRoot());
+
     CaseInstance instance = new CaseInstance();
     instance.setUuid(UUID.randomUUID());
     instance.setCaseMetaModel(model);
     instance.setVersion(0L);
     instance.setState(CaseStatus.RUNNING);
     instance.setCaseContext(context);
+    instance.setPropagationContext(propagationContext);
 
     caseInstanceCache.put(instance);
     return caseInstanceRepository.save(instance);


### PR DESCRIPTION
## Summary

- Wires the `PropagationContext` budget allowance into `CaseTimeoutEnforcer` so timeout enforcement respects propagation-level budget constraints.

## Context

This is PR 1/6 in the WorkBroker integration series. It is fully independent and can be merged on its own.

**Merge order:** #1 (this) → #2 → #3 → #4 → #5 → #6

## Test plan

- [ ] Existing resilience tests pass