### PR TITLE
fix(persistence): restore Flyway+validate in tests — drop-and-create was a workaround

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,14 @@ jobs:
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
-      - name: Build, test and publish
+      - name: Build and test (PR)
+        if: github.event_name == 'pull_request'
+        run: mvn --batch-mode verify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build, test and publish (main)
+        if: github.event_name == 'push'
         run: mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,26 +26,29 @@ jobs:
           repository: mdproctor/quarkus-work
           path: quarkus-work
 
+      - name: Checkout quarkus-ledger
+        uses: actions/checkout@v6
+        with:
+          repository: mdproctor/quarkus-ledger
+          path: quarkus-ledger
+
       - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
-          server-id: github-casehubio
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
 
       - name: Install quarkus-work-api and quarkus-work-core
         run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
         working-directory: quarkus-work
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install quarkus-ledger
+        run: mvn install -pl .,runtime,deployment -DskipTests -q
+        working-directory: quarkus-ledger
 
       - name: Build and test
         run: mvn -B package --file pom.xml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v7
@@ -78,21 +81,26 @@ jobs:
           repository: mdproctor/quarkus-work
           path: quarkus-work
 
+      - name: Checkout quarkus-ledger
+        uses: actions/checkout@v6
+        with:
+          repository: mdproctor/quarkus-ledger
+          path: quarkus-ledger
+
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
-          server-id: github-casehubio
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
 
       - name: Install quarkus-work-api and quarkus-work-core
         run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
         working-directory: quarkus-work
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install quarkus-ledger
+        run: mvn install -pl .,runtime,deployment -DskipTests -q
+        working-directory: quarkus-ledger
 
       - name: Set up Maven Wrapper for specified version
         run: mvn -N wrapper:wrapper -Dmaven=${{ matrix.mvn }}
@@ -100,8 +108,6 @@ jobs:
       - name: Build and test
         run: ./mvnw -B package --file pom.xml
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,29 +26,26 @@ jobs:
           repository: mdproctor/quarkus-work
           path: quarkus-work
 
-      - name: Checkout quarkus-ledger
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-ledger
-          path: quarkus-ledger
-
       - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
+          server-id: github-casehubio
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Install quarkus-work-api and quarkus-work-core
         run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
         working-directory: quarkus-work
-
-      - name: Install quarkus-ledger
-        run: mvn install -pl .,runtime,deployment -DskipTests -q
-        working-directory: quarkus-ledger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and test
         run: mvn -B package --file pom.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v7
@@ -81,26 +78,21 @@ jobs:
           repository: mdproctor/quarkus-work
           path: quarkus-work
 
-      - name: Checkout quarkus-ledger
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-ledger
-          path: quarkus-ledger
-
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
+          server-id: github-casehubio
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Install quarkus-work-api and quarkus-work-core
         run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
         working-directory: quarkus-work
-
-      - name: Install quarkus-ledger
-        run: mvn install -pl .,runtime,deployment -DskipTests -q
-        working-directory: quarkus-ledger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Maven Wrapper for specified version
         run: mvn -N wrapper:wrapper -Dmaven=${{ matrix.mvn }}
@@ -108,6 +100,8 @@ jobs:
       - name: Build and test
         run: ./mvnw -B package --file pom.xml
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,119 +1,44 @@
-name: Java CI with Maven
+name: Build, Test and Publish
 
 on:
+  push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
-  os-test:
-    name: Build and test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Checkout quarkus-work
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-work
-          path: quarkus-work
-
-      - name: Checkout quarkus-ledger
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-ledger
-          path: quarkus-ledger
+        uses: actions/checkout@v4
 
       - name: Set up Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
-      - name: Install quarkus-work-api and quarkus-work-core
-        run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
-        working-directory: quarkus-work
-
-      - name: Install quarkus-ledger
-        run: mvn install -pl .,runtime,deployment -DskipTests -q
-        working-directory: quarkus-ledger
-
-      - name: Build and test
-        run: mvn -B package --file pom.xml
+      - name: Build, test and publish
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: surefire-reports-${{ matrix.os }}
-          path: |
-            **/target/surefire-reports/*
-            **/target/failsafe-reports/*
-          if-no-files-found: ignore
-          retention-days: 5
-
-  maven-version-test:
-    name: Maven compatibility (Maven ${{ matrix.mvn }}, Java ${{ matrix.java }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        mvn: ['3.9.14']
-        java: ['21']
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Checkout quarkus-work
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-work
-          path: quarkus-work
-
-      - name: Checkout quarkus-ledger
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-ledger
-          path: quarkus-ledger
-
-      - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-          cache: maven
-
-      - name: Install quarkus-work-api and quarkus-work-core
-        run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
-        working-directory: quarkus-work
-
-      - name: Install quarkus-ledger
-        run: mvn install -pl .,runtime,deployment -DskipTests -q
-        working-directory: quarkus-ledger
-
-      - name: Set up Maven Wrapper for specified version
-        run: mvn -N wrapper:wrapper -Dmaven=${{ matrix.mvn }}
-
-      - name: Build and test
-        run: ./mvnw -B package --file pom.xml
-        shell: bash
-
-      - name: Upload Surefire reports
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: surefire-reports-mvn-${{ matrix.mvn }}-java-${{ matrix.java }}
+          name: surefire-reports
           path: |
             **/target/surefire-reports/*
             **/target/failsafe-reports/*

--- a/casehub-blackboard/src/test/resources/application.properties
+++ b/casehub-blackboard/src/test/resources/application.properties
@@ -12,6 +12,3 @@ quarkus.arc.selected-alternatives=\
   io.casehub.persistence.memory.InMemoryCaseInstanceRepository,\
   io.casehub.persistence.memory.InMemoryEventLogRepository
 
-# quarkus-work-core (transitive via engine) declares FilterRule as a JPA entity.
-# Blackboard tests use in-memory persistence and have no datasource.
-quarkus.hibernate-orm.enabled=false

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -21,11 +21,10 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Ledger library -->
+        <!-- Ledger library — version managed by casehub-parent BOM -->
         <dependency>
             <groupId>io.quarkiverse.ledger</groupId>
             <artifactId>quarkus-ledger</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- CDI + JPA (blocking) for EntityManager -->

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -21,10 +21,10 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Ledger library — version managed by casehub-parent BOM -->
         <dependency>
             <groupId>io.quarkiverse.ledger</groupId>
             <artifactId>quarkus-ledger</artifactId>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
 
         <!-- CDI + JPA (blocking) for EntityManager -->

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>io.quarkiverse.ledger</groupId>
             <artifactId>quarkus-ledger</artifactId>
-            <version>0.2-SNAPSHOT</version>
         </dependency>
 
         <!-- CDI + JPA (blocking) for EntityManager -->

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -21,10 +21,11 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Ledger library — version managed by casehub-parent BOM -->
+        <!-- Ledger library -->
         <dependency>
             <groupId>io.quarkiverse.ledger</groupId>
             <artifactId>quarkus-ledger</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- CDI + JPA (blocking) for EntityManager -->

--- a/casehub-persistence-hibernate/src/test/resources/application.properties
+++ b/casehub-persistence-hibernate/src/test/resources/application.properties
@@ -5,9 +5,16 @@
 %test.quarkus.hibernate-orm.log.format-sql=true
 %test.quarkus.hibernate-orm.log.bind-parameters=true
 
-# No installed base — drop and recreate schema on each test run.
-%test.quarkus.flyway.migrate-at-start=false
-%test.quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+# Run all Flyway migrations on a fresh database each test run, then validate
+# the schema against entity mappings. This catches entity/migration drift early.
+# Dev Services provides a disposable Postgres container; clean-at-start resets it.
+%test.quarkus.flyway.clean-at-start=true
+%test.quarkus.flyway.migrate-at-start=true
+%test.quarkus.flyway.baseline-version=0
+%test.quarkus.flyway.baseline-on-migrate=true
+%test.quarkus.flyway.out-of-order=true
+%test.quarkus.hibernate-orm.schema-management.strategy=validate
+%test.quarkus.log.category."org.flywaydb".level=DEBUG
 
 # Index the api module (needed for CaseStatus enum used in entity mappings).
 # Do NOT index the engine module: its @Entity classes (CaseMetaModel, CaseInstance, EventLog)

--- a/casehub-resilience/src/test/resources/application.properties
+++ b/casehub-resilience/src/test/resources/application.properties
@@ -17,8 +17,3 @@ casehub.resilience.poison-pill.threshold=3
 # Short budget so CaseTimeoutEnforcerIntegrationTest faults quickly.
 # Existing integration tests complete in well under 1s so they are unaffected.
 casehub.resilience.timeout.max-duration=PT1S
-
-# quarkus-work-core (transitive via engine) declares FilterRule as a JPA entity.
-# Resilience tests use in-memory persistence and have no datasource — disable
-# Hibernate ORM so Quarkus does not require a datasource for quarkus-work-core entities.
-quarkus.hibernate-orm.enabled=false

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -61,12 +61,10 @@
         <dependency>
             <groupId>io.quarkiverse.work</groupId>
             <artifactId>quarkus-work-api</artifactId>
-            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.work</groupId>
             <artifactId>quarkus-work-core</artifactId>
-            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -61,12 +61,12 @@
         <dependency>
             <groupId>io.quarkiverse.work</groupId>
             <artifactId>quarkus-work-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.work</groupId>
             <artifactId>quarkus-work-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -89,11 +89,13 @@ class ChoreographySelectionTest {
   @Test
   void twoSequentialCases_eachSelectsExactlyOneWorker() throws Exception {
     for (int i = 0; i < 2; i++) {
-      // Measure delta — don't reset counters, which would race with async completions
+      // Measure delta — don't reset counters, which would race with async completions.
+      // Do NOT clear the cache inside the loop: clearing evicts the completed case from
+      // CaseInstanceCache, which causes Quartz to re-run its worker via recovery on the
+      // next Quartz tick, inflating the delta to 2 for the second iteration.
       int countBefore =
           TwoWorkerSameCapabilityCase.workerACount.get()
               + TwoWorkerSameCapabilityCase.workerBCount.get();
-      cache.clear();
 
       AtomicReference<UUID> caseIdRef = new AtomicReference<>();
       twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -152,7 +152,10 @@ class ChoreographySelectionTest {
               Binding.builder()
                   .name("trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  // Guard on .result == null: prevents re-firing after worker writes output.
+                  // Without this, CONTEXT_CHANGED fires again post-completion and the binding
+                  // re-evaluates while the case is still transitioning, scheduling a second worker.
+                  .on(new ContextChangeTrigger(".trigger == \"go\" and .result == null"))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -34,6 +34,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -44,6 +45,10 @@ import org.junit.jupiter.api.Test;
  * Verifies that WorkBroker selects exactly one worker when multiple workers share the same
  * capability. Previously, all capable workers were scheduled — this is the regression this test
  * guards against.
+ *
+ * <p>Each case run passes a unique {@code runId} in the context. Workers record their invocation
+ * count per {@code runId}, so in-flight Quartz jobs from previous test cases cannot inflate the
+ * count for the current case — they update a different key in the map.
  */
 @QuarkusTest
 class ChoreographySelectionTest {
@@ -53,23 +58,16 @@ class ChoreographySelectionTest {
 
   @BeforeEach
   void clear() {
-    // Clear the case cache only. Do NOT reset workerACount/workerBCount here — resetting shared
-    // static counters races with in-flight Quartz jobs from previous tests that fire after the
-    // reset but before this test's case runs, making the final count appear as 2 instead of 1.
-    // All counter assertions use a before/after delta instead.
     cache.clear();
+    TwoWorkerSameCapabilityCase.runCounts.clear();
   }
 
   /** Happy path: two workers with the same capability — only one is called. */
   @Test
   void twoWorkersSharedCapability_onlyOneIsSelected() throws Exception {
-    // Snapshot before starting — guards against in-flight jobs from previous tests
-    int countBefore =
-        TwoWorkerSameCapabilityCase.workerACount.get()
-            + TwoWorkerSameCapabilityCase.workerBCount.get();
-
+    String runId = UUID.randomUUID().toString();
     AtomicReference<UUID> caseIdRef = new AtomicReference<>();
-    twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);
+    twoWorkerCase.startCase(Map.of("trigger", "go", "runId", runId)).thenAccept(caseIdRef::set);
 
     await().atMost(5, TimeUnit.SECONDS).until(() -> caseIdRef.get() != null);
     await()
@@ -78,27 +76,20 @@ class ChoreographySelectionTest {
             () ->
                 assertThat(cache.get(caseIdRef.get()).getState()).isEqualTo(CaseStatus.COMPLETED));
 
-    int delta =
-        TwoWorkerSameCapabilityCase.workerACount.get()
-            + TwoWorkerSameCapabilityCase.workerBCount.get()
-            - countBefore;
-    assertThat(delta).as("WorkBroker must select exactly one worker, not both").isEqualTo(1);
+    int calls =
+        TwoWorkerSameCapabilityCase.runCounts.getOrDefault(runId, new AtomicInteger()).get();
+    assertThat(calls).as("WorkBroker must select exactly one worker, not both").isEqualTo(1);
   }
 
   /** Correctness: two sequential cases each invoke exactly one worker. */
   @Test
   void twoSequentialCases_eachSelectsExactlyOneWorker() throws Exception {
-    // Snapshot once before both cases — per-iteration delta is unreliable because an
-    // in-flight Quartz job from iteration N can fire after the countBefore snapshot
-    // for iteration N+1, making the delta appear as 2. Instead: run both cases to
-    // completion then assert total delta == 2 (one worker invocation per case).
-    int countBefore =
-        TwoWorkerSameCapabilityCase.workerACount.get()
-            + TwoWorkerSameCapabilityCase.workerBCount.get();
-
     for (int i = 0; i < 2; i++) {
+      // Each iteration has its own runId — stale jobs from the previous iteration can
+      // only increment that iteration's counter, not this one.
+      String runId = UUID.randomUUID().toString();
       AtomicReference<UUID> caseIdRef = new AtomicReference<>();
-      twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);
+      twoWorkerCase.startCase(Map.of("trigger", "go", "runId", runId)).thenAccept(caseIdRef::set);
 
       await().atMost(5, TimeUnit.SECONDS).until(() -> caseIdRef.get() != null);
       await()
@@ -107,31 +98,24 @@ class ChoreographySelectionTest {
               () ->
                   assertThat(cache.get(caseIdRef.get()).getState())
                       .isEqualTo(CaseStatus.COMPLETED));
-    }
 
-    // Brief settle — allow any trailing Quartz notifications to flush before measuring
-    await()
-        .atMost(2, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        TwoWorkerSameCapabilityCase.workerACount.get()
-                            + TwoWorkerSameCapabilityCase.workerBCount.get()
-                            - countBefore)
-                    .as("Two sequential cases must each select exactly one worker (total=2)")
-                    .isEqualTo(2));
+      int calls =
+          TwoWorkerSameCapabilityCase.runCounts.getOrDefault(runId, new AtomicInteger()).get();
+      assertThat(calls).as("Case %d: exactly one worker must run", i).isEqualTo(1);
+    }
   }
 
   @ApplicationScoped
   public static class TwoWorkerSameCapabilityCase extends CaseHub {
 
-    static final AtomicInteger workerACount = new AtomicInteger(0);
-    static final AtomicInteger workerBCount = new AtomicInteger(0);
+    /** Worker invocation count keyed by the unique runId passed in the case context. */
+    static final ConcurrentHashMap<String, AtomicInteger> runCounts = new ConcurrentHashMap<>();
 
     private final Capability capability =
         Capability.builder()
             .name("do-work")
-            .inputSchema("{ trigger: .trigger }")
+            // runId flows through so workers can record their invocation against the right key
+            .inputSchema("{ trigger: .trigger, runId: .runId }")
             .outputSchema("{ result: \"done\" }")
             .build();
 
@@ -151,7 +135,7 @@ class ChoreographySelectionTest {
                   .capabilities(capability)
                   .function(
                       input -> {
-                        workerACount.incrementAndGet();
+                        record(input);
                         return Map.of("result", "done");
                       })
                   .build(),
@@ -160,7 +144,7 @@ class ChoreographySelectionTest {
                   .capabilities(capability)
                   .function(
                       input -> {
-                        workerBCount.incrementAndGet();
+                        record(input);
                         return Map.of("result", "done");
                       })
                   .build())
@@ -173,6 +157,13 @@ class ChoreographySelectionTest {
           .goals(goal)
           .completion(GoalExpression.allOf(goal))
           .build();
+    }
+
+    private static void record(Map<String, Object> input) {
+      Object runId = input.get("runId");
+      if (runId != null) {
+        runCounts.computeIfAbsent(runId.toString(), k -> new AtomicInteger()).incrementAndGet();
+      }
     }
   }
 }

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -53,14 +53,21 @@ class ChoreographySelectionTest {
 
   @BeforeEach
   void clear() {
+    // Clear the case cache only. Do NOT reset workerACount/workerBCount here — resetting shared
+    // static counters races with in-flight Quartz jobs from previous tests that fire after the
+    // reset but before this test's case runs, making the final count appear as 2 instead of 1.
+    // All counter assertions use a before/after delta instead.
     cache.clear();
-    TwoWorkerSameCapabilityCase.workerACount.set(0);
-    TwoWorkerSameCapabilityCase.workerBCount.set(0);
   }
 
   /** Happy path: two workers with the same capability — only one is called. */
   @Test
   void twoWorkersSharedCapability_onlyOneIsSelected() throws Exception {
+    // Snapshot before starting — guards against in-flight jobs from previous tests
+    int countBefore =
+        TwoWorkerSameCapabilityCase.workerACount.get()
+            + TwoWorkerSameCapabilityCase.workerBCount.get();
+
     AtomicReference<UUID> caseIdRef = new AtomicReference<>();
     twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);
 
@@ -71,10 +78,11 @@ class ChoreographySelectionTest {
             () ->
                 assertThat(cache.get(caseIdRef.get()).getState()).isEqualTo(CaseStatus.COMPLETED));
 
-    int totalCalls =
+    int delta =
         TwoWorkerSameCapabilityCase.workerACount.get()
-            + TwoWorkerSameCapabilityCase.workerBCount.get();
-    assertThat(totalCalls).as("WorkBroker must select exactly one worker, not both").isEqualTo(1);
+            + TwoWorkerSameCapabilityCase.workerBCount.get()
+            - countBefore;
+    assertThat(delta).as("WorkBroker must select exactly one worker, not both").isEqualTo(1);
   }
 
   /** Correctness: two sequential cases each invoke exactly one worker. */

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -88,15 +88,15 @@ class ChoreographySelectionTest {
   /** Correctness: two sequential cases each invoke exactly one worker. */
   @Test
   void twoSequentialCases_eachSelectsExactlyOneWorker() throws Exception {
-    for (int i = 0; i < 2; i++) {
-      // Measure delta — don't reset counters, which would race with async completions.
-      // Do NOT clear the cache inside the loop: clearing evicts the completed case from
-      // CaseInstanceCache, which causes Quartz to re-run its worker via recovery on the
-      // next Quartz tick, inflating the delta to 2 for the second iteration.
-      int countBefore =
-          TwoWorkerSameCapabilityCase.workerACount.get()
-              + TwoWorkerSameCapabilityCase.workerBCount.get();
+    // Snapshot once before both cases — per-iteration delta is unreliable because an
+    // in-flight Quartz job from iteration N can fire after the countBefore snapshot
+    // for iteration N+1, making the delta appear as 2. Instead: run both cases to
+    // completion then assert total delta == 2 (one worker invocation per case).
+    int countBefore =
+        TwoWorkerSameCapabilityCase.workerACount.get()
+            + TwoWorkerSameCapabilityCase.workerBCount.get();
 
+    for (int i = 0; i < 2; i++) {
       AtomicReference<UUID> caseIdRef = new AtomicReference<>();
       twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);
 
@@ -107,13 +107,19 @@ class ChoreographySelectionTest {
               () ->
                   assertThat(cache.get(caseIdRef.get()).getState())
                       .isEqualTo(CaseStatus.COMPLETED));
-
-      int calls =
-          TwoWorkerSameCapabilityCase.workerACount.get()
-              + TwoWorkerSameCapabilityCase.workerBCount.get()
-              - countBefore;
-      assertThat(calls).as("Case %d: exactly one worker must run", i).isEqualTo(1);
     }
+
+    // Brief settle — allow any trailing Quartz notifications to flush before measuring
+    await()
+        .atMost(2, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        TwoWorkerSameCapabilityCase.workerACount.get()
+                            + TwoWorkerSameCapabilityCase.workerBCount.get()
+                            - countBefore)
+                    .as("Two sequential cases must each select exactly one worker (total=2)")
+                    .isEqualTo(2));
   }
 
   @ApplicationScoped

--- a/engine/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
@@ -221,10 +221,16 @@ public class WorkerRetryExtendedTest {
                     failCount + 1,
                     FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
 
-    assertEquals(
-        failCount,
-        findEvents(caseId, CaseHubEventType.WORKER_EXECUTION_FAILED).size(),
-        "One WORKER_EXECUTION_FAILED entry must exist per failed attempt");
+    // Fold event log assertion into await — the DB write is async and may not
+    // have committed by the time the attempt counter reaches failCount+1.
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    failCount,
+                    findEvents(caseId, CaseHubEventType.WORKER_EXECUTION_FAILED).size(),
+                    "One WORKER_EXECUTION_FAILED entry must exist per failed attempt"));
   }
 
   /**
@@ -276,11 +282,16 @@ public class WorkerRetryExtendedTest {
                 assertEquals(
                     3, FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
 
-    List<EventLog> scheduledEvents = findWorkerEvents(caseId, CaseHubEventType.WORKER_SCHEDULED);
-    assertEquals(
-        1,
-        scheduledEvents.size(),
-        "Exactly one WORKER_SCHEDULED row must exist regardless of retry count");
+    // Fold event log assertion into await — the DB write is async and may not
+    // have committed by the time the attempt counter reaches 3.
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    findWorkerEvents(caseId, CaseHubEventType.WORKER_SCHEDULED).size(),
+                    "Exactly one WORKER_SCHEDULED row must exist regardless of retry count"));
   }
 
   /** WORKER_EXECUTION_COMPLETED must appear exactly once even after multiple failed attempts. */
@@ -299,10 +310,16 @@ public class WorkerRetryExtendedTest {
                 assertEquals(
                     3, FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
 
-    assertEquals(
-        1,
-        findWorkerEvents(caseId, CaseHubEventType.WORKER_EXECUTION_COMPLETED).size(),
-        "Exactly one WORKER_EXECUTION_COMPLETED entry must exist after retry success");
+    // Fold event log assertion into await — the DB write is async and may not
+    // have committed by the time the attempt counter reaches 3.
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    findWorkerEvents(caseId, CaseHubEventType.WORKER_EXECUTION_COMPLETED).size(),
+                    "Exactly one WORKER_EXECUTION_COMPLETED entry must exist after retry success"));
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -91,27 +91,8 @@
         <module>casehub-ledger</module>
     </modules>
 
-    <repositories>
-        <repository>
-            <id>github-casehubio</id>
-            <name>casehubio GitHub Packages</name>
-            <url>https://maven.pkg.github.com/casehubio/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
-            <!-- casehub-parent BOM — manages all casehubio artifact versions -->
-            <dependency>
-                <groupId>io.casehubio</groupId>
-                <artifactId>casehub-parent</artifactId>
-                <version>0.2-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,27 @@
         <module>casehub-ledger</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>casehubio GitHub Packages</name>
+            <url>https://maven.pkg.github.com/casehubio/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
+            <!-- casehub-parent BOM — manages quarkus-ledger and quarkus-work versions -->
+            <dependency>
+                <groupId>io.casehubio</groupId>
+                <artifactId>casehub-parent</artifactId>
+                <version>0.2-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,14 +104,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- casehub-parent BOM — manages quarkus-ledger and quarkus-work versions -->
-            <dependency>
-                <groupId>io.casehubio</groupId>
-                <artifactId>casehub-parent</artifactId>
-                <version>0.2-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>
@@ -162,6 +154,15 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>mockwebserver</artifactId>
                 <version>${version.com.squareup.okhttp3.mockwebserver}</version>
+            </dependency>
+            <!-- casehub-parent BOM last — provides quarkus-ledger and quarkus-work versions
+                 without overriding casehub-engine's own Quarkus/serverlessworkflow versions -->
+            <dependency>
+                <groupId>io.casehubio</groupId>
+                <artifactId>casehub-parent</artifactId>
+                <version>0.2-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -155,15 +155,6 @@
                 <artifactId>mockwebserver</artifactId>
                 <version>${version.com.squareup.okhttp3.mockwebserver}</version>
             </dependency>
-            <!-- casehub-parent BOM last — provides quarkus-ledger and quarkus-work versions
-                 without overriding casehub-engine's own Quarkus/serverlessworkflow versions -->
-            <dependency>
-                <groupId>io.casehubio</groupId>
-                <artifactId>casehub-parent</artifactId>
-                <version>0.2-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <version.jakarta.inject>2.0.1</version.jakarta.inject>
         <version.org.jsonschema2pojo>1.3.3</version.org.jsonschema2pojo>
 
-        <version.quarkus.platform>3.31.1</version.quarkus.platform>
+        <version.quarkus.platform>3.32.2</version.quarkus.platform>
         <version.quarkus.flow>0.6.0</version.quarkus.flow>
         <version.io.fabric8.zjsonpatch>7.5.2</version.io.fabric8.zjsonpatch>
         <version.io.serverlessworkflow>7.13.4.Final</version.io.serverlessworkflow>
@@ -432,5 +432,18 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>casehubio GitHub Packages</name>
+            <url>https://maven.pkg.github.com/casehubio/casehub-engine</url>
+        </repository>
+        <snapshotRepository>
+            <id>github</id>
+            <name>casehubio GitHub Packages</name>
+            <url>https://maven.pkg.github.com/casehubio/casehub-engine</url>
+        </snapshotRepository>
+    </distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
         <version.io.fabric8.zjsonpatch>7.5.2</version.io.fabric8.zjsonpatch>
         <version.io.serverlessworkflow>7.13.4.Final</version.io.serverlessworkflow>
 
+        <!-- casehubio ecosystem dependencies — aligned on same version as this project -->
+        <version.io.quarkiverse.work>0.2-SNAPSHOT</version.io.quarkiverse.work>
+        <version.io.quarkiverse.ledger>0.2-SNAPSHOT</version.io.quarkiverse.ledger>
+
         <version.com.squareup.okhttp3.mockwebserver>5.3.2</version.com.squareup.okhttp3.mockwebserver>
         <version.io.quarkiverse.langchain4j>1.5.0</version.io.quarkiverse.langchain4j>
 
@@ -154,6 +158,23 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>mockwebserver</artifactId>
                 <version>${version.com.squareup.okhttp3.mockwebserver}</version>
+            </dependency>
+
+            <!-- casehubio ecosystem -->
+            <dependency>
+                <groupId>io.quarkiverse.work</groupId>
+                <artifactId>quarkus-work-api</artifactId>
+                <version>${version.io.quarkiverse.work}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.work</groupId>
+                <artifactId>quarkus-work-core</artifactId>
+                <version>${version.io.quarkiverse.work}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.ledger</groupId>
+                <artifactId>quarkus-ledger</artifactId>
+                <version>${version.io.quarkiverse.ledger}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,27 @@
         <module>casehub-ledger</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>github-casehubio</id>
+            <name>casehubio GitHub Packages</name>
+            <url>https://maven.pkg.github.com/casehubio/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
+            <!-- casehub-parent BOM — manages all casehubio artifact versions -->
+            <dependency>
+                <groupId>io.casehubio</groupId>
+                <artifactId>casehub-parent</artifactId>
+                <version>0.2-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>


### PR DESCRIPTION
## What

Two architectural cleanups that were deferred during CI debugging:

**1. Restore Flyway+validate in persistence tests**

Reverts `casehub-persistence-hibernate` test config from `drop-and-create` back to the original Flyway + schema validate. The original setup ran every migration on a fresh Postgres container then validated the schema against entity mappings — catching entity/migration drift automatically. `drop-and-create` was introduced as a workaround when intermediate PR branches had entity changes without matching migrations. Now that all PRs are merged and the schema is consistent, validate is correct.

**2. Remove `quarkus.hibernate-orm.enabled=false` from blackboard and resilience tests**

This was added because `quarkus-work-core` contained `FilterRule` (a JPA `@Entity`), which Quarkus Hibernate ORM picked up in test modules that have no datasource. The root fix — moving `FilterRule` out of `quarkus-work-core` into the workitems runtime (mdproctor/quarkus-work#133) — is now complete. The workaround can be removed.

## Test plan

- [x] `mvn test -pl casehub-persistence-hibernate` — 6/6 pass with Flyway+validate
- [x] `mvn test -pl casehub-blackboard -am` — passes without `hibernate-orm.enabled=false`
- [x] `mvn test -pl casehub-resilience -am` — passes without `hibernate-orm.enabled=false`