### PR TITLE
fix(deploy): disable timestamped SNAPSHOT versions for GitHub Packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,7 @@
             <id>github</id>
             <name>casehubio GitHub Packages</name>
             <url>https://maven.pkg.github.com/casehubio/casehub-engine</url>
+            <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
GitHub Packages has trouble resolving existing timestamped SNAPSHOTs during the first deploy attempt, causing `mvn deploy` on the main branch to fail with:

```
Failed to deploy artifacts: Could not find artifact io.casehub:parent:pom:0.2-20260424.173226-1
```

Setting `<uniqueVersion>false</uniqueVersion>` deploys as `0.2-SNAPSHOT` instead of a timestamped variant, which resolves the issue.