### PR TITLE
ci: enable deploy on main branch pushes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build, test and publish (main)
         if: github.event_name == 'push'
-        run: mvn --batch-mode verify
+        run: mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Change `mvn verify` → `mvn deploy` on push-to-main so artifacts are published to GitHub Packages
- Key modules already override `maven.deploy.skip` to `false` (`api`, `engine-model`, `engine`, `casehub-ledger`); root pom keeps `true` as default
- `maven-deploy-plugin` already has `retryFailedDeploymentCount=10` for GitHub Packages transience

## Test plan

- [ ] PR CI passes (`mvn verify` — unchanged for PRs)
- [ ] Merge to main and confirm deploy phase runs in CI without error
- [ ] Verify `io.casehub:api` and `io.casehub:engine` artifacts appear in casehubio GitHub Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)