### PR TITLE
fix(ci): correct GitHub Packages deploy URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,12 +474,12 @@
         <repository>
             <id>github</id>
             <name>casehubio GitHub Packages</name>
-            <url>https://maven.pkg.github.com/casehubio/casehub-engine</url>
+            <url>https://maven.pkg.github.com/casehubio/engine</url>
         </repository>
         <snapshotRepository>
             <id>github</id>
             <name>casehubio GitHub Packages</name>
-            <url>https://maven.pkg.github.com/casehubio/casehub-engine</url>
+            <url>https://maven.pkg.github.com/casehubio/engine</url>
             <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
     </distributionManagement>


### PR DESCRIPTION
## Summary

- `distributionManagement` in root `pom.xml` pointed to `maven.pkg.github.com/casehubio/casehub-engine` but the GitHub repo is `casehubio/engine`
- GitHub Packages accepts uploads but cannot serve them back for verification because the repo reference is wrong — causing `Could not find artifact` on every deploy attempt
- Fix: change URL to `maven.pkg.github.com/casehubio/engine`

## Test plan

- [ ] PR CI passes (`mvn verify`)
- [ ] Merge to main: `mvn deploy` run succeeds end-to-end (no more `Could not find artifact` loop)
- [ ] `io.casehub:api` and related artifacts visible in casehubio GitHub Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)