### PR TITLE
fix(deploy): deploy root parent POM to GitHub Packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,10 @@
         <version.io.quarkiverse.work>0.2-SNAPSHOT</version.io.quarkiverse.work>
         <version.io.quarkiverse.ledger>0.2-SNAPSHOT</version.io.quarkiverse.ledger>
 
-        <!-- Skip deploying the root aggregator POM — it is not a consumable artifact.
-             Sub-modules override this to publish their own JARs. -->
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <!-- The root POM is the parent of all published modules and must be deployed
+             so downstream resolvers can read the effective POM of api, engine, etc.
+             Modules that should not be deployed override this with true. -->
+        <maven.deploy.skip>false</maven.deploy.skip>
 
         <version.com.squareup.okhttp3.mockwebserver>5.3.2</version.com.squareup.okhttp3.mockwebserver>
         <version.io.quarkiverse.langchain4j>1.5.0</version.io.quarkiverse.langchain4j>


### PR DESCRIPTION
## Summary

- Root `io.casehub:parent:pom:0.2-SNAPSHOT` was not being deployed because `maven.deploy.skip=true` was the default
- Downstream consumers (claudony, etc.) fail to resolve `io.casehub:api` because Maven cannot read its effective POM without the parent being present in the repository
- Fix: change the default to `false`; modules that should not be published can override to `true`

## Impact

- `io.casehub:parent:pom` now published alongside `api`, `engine`, `engine-model`, `casehub-ledger`
- Internal modules without an explicit override (codegen, schema, persistence, blackboard, resilience, scheduler) will also deploy — these are harmless SNAPSHOTs with no downstream dependents

## Test plan

- [ ] PR CI passes
- [ ] Merge: confirm `io.casehub:parent:pom:0.2-SNAPSHOT` appears in casehubio GitHub Packages
- [ ] Re-run claudony CI: dependency resolution succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)