### PR TITLE
ci, docs, fix: fork CI, ADR-0006, sessionMeta caseId, CLAUDE.md

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,14 +29,14 @@ jobs:
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
-      - name: Build and test (PR)
-        if: github.event_name == 'pull_request'
+      - name: Build and test (PR or fork push)
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository != 'casehubio/casehub-engine')
         run: mvn --batch-mode verify
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build, test and publish (main)
-        if: github.event_name == 'push'
+      - name: Build, test and publish (upstream main)
+        if: github.event_name == 'push' && github.repository == 'casehubio/casehub-engine'
         run: mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,14 @@ jobs:
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
-      - name: Build, test and publish
+      - name: Build and test (PR)
+        if: github.event_name == 'pull_request'
+        run: mvn --batch-mode verify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build, test and publish (main)
+        if: github.event_name == 'push'
         run: mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,26 +26,29 @@ jobs:
           repository: mdproctor/quarkus-work
           path: quarkus-work
 
+      - name: Checkout quarkus-ledger
+        uses: actions/checkout@v6
+        with:
+          repository: mdproctor/quarkus-ledger
+          path: quarkus-ledger
+
       - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
-          server-id: github-casehubio
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
 
       - name: Install quarkus-work-api and quarkus-work-core
         run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
         working-directory: quarkus-work
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install quarkus-ledger
+        run: mvn install -pl .,runtime,deployment -DskipTests -q
+        working-directory: quarkus-ledger
 
       - name: Build and test
         run: mvn -B package --file pom.xml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v7
@@ -78,21 +81,26 @@ jobs:
           repository: mdproctor/quarkus-work
           path: quarkus-work
 
+      - name: Checkout quarkus-ledger
+        uses: actions/checkout@v6
+        with:
+          repository: mdproctor/quarkus-ledger
+          path: quarkus-ledger
+
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
-          server-id: github-casehubio
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
 
       - name: Install quarkus-work-api and quarkus-work-core
         run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
         working-directory: quarkus-work
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install quarkus-ledger
+        run: mvn install -pl .,runtime,deployment -DskipTests -q
+        working-directory: quarkus-ledger
 
       - name: Set up Maven Wrapper for specified version
         run: mvn -N wrapper:wrapper -Dmaven=${{ matrix.mvn }}
@@ -100,8 +108,6 @@ jobs:
       - name: Build and test
         run: ./mvnw -B package --file pom.xml
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,29 +26,26 @@ jobs:
           repository: mdproctor/quarkus-work
           path: quarkus-work
 
-      - name: Checkout quarkus-ledger
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-ledger
-          path: quarkus-ledger
-
       - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
+          server-id: github-casehubio
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Install quarkus-work-api and quarkus-work-core
         run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
         working-directory: quarkus-work
-
-      - name: Install quarkus-ledger
-        run: mvn install -pl .,runtime,deployment -DskipTests -q
-        working-directory: quarkus-ledger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and test
         run: mvn -B package --file pom.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v7
@@ -81,26 +78,21 @@ jobs:
           repository: mdproctor/quarkus-work
           path: quarkus-work
 
-      - name: Checkout quarkus-ledger
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-ledger
-          path: quarkus-ledger
-
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
+          server-id: github-casehubio
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Install quarkus-work-api and quarkus-work-core
         run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
         working-directory: quarkus-work
-
-      - name: Install quarkus-ledger
-        run: mvn install -pl .,runtime,deployment -DskipTests -q
-        working-directory: quarkus-ledger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Maven Wrapper for specified version
         run: mvn -N wrapper:wrapper -Dmaven=${{ matrix.mvn }}
@@ -108,6 +100,8 @@ jobs:
       - name: Build and test
         run: ./mvnw -B package --file pom.xml
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,119 +1,44 @@
-name: Java CI with Maven
+name: Build, Test and Publish
 
 on:
+  push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
-  os-test:
-    name: Build and test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Checkout quarkus-work
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-work
-          path: quarkus-work
-
-      - name: Checkout quarkus-ledger
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-ledger
-          path: quarkus-ledger
+        uses: actions/checkout@v4
 
       - name: Set up Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
-      - name: Install quarkus-work-api and quarkus-work-core
-        run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
-        working-directory: quarkus-work
-
-      - name: Install quarkus-ledger
-        run: mvn install -pl .,runtime,deployment -DskipTests -q
-        working-directory: quarkus-ledger
-
-      - name: Build and test
-        run: mvn -B package --file pom.xml
+      - name: Build, test and publish
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: surefire-reports-${{ matrix.os }}
-          path: |
-            **/target/surefire-reports/*
-            **/target/failsafe-reports/*
-          if-no-files-found: ignore
-          retention-days: 5
-
-  maven-version-test:
-    name: Maven compatibility (Maven ${{ matrix.mvn }}, Java ${{ matrix.java }})
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        mvn: ['3.9.14']
-        java: ['21']
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Checkout quarkus-work
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-work
-          path: quarkus-work
-
-      - name: Checkout quarkus-ledger
-        uses: actions/checkout@v6
-        with:
-          repository: mdproctor/quarkus-ledger
-          path: quarkus-ledger
-
-      - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-          cache: maven
-
-      - name: Install quarkus-work-api and quarkus-work-core
-        run: mvn install -pl .,quarkus-work-api,quarkus-work-core -DskipTests -q
-        working-directory: quarkus-work
-
-      - name: Install quarkus-ledger
-        run: mvn install -pl .,runtime,deployment -DskipTests -q
-        working-directory: quarkus-ledger
-
-      - name: Set up Maven Wrapper for specified version
-        run: mvn -N wrapper:wrapper -Dmaven=${{ matrix.mvn }}
-
-      - name: Build and test
-        run: ./mvnw -B package --file pom.xml
-        shell: bash
-
-      - name: Upload Surefire reports
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: surefire-reports-mvn-${{ matrix.mvn }}-java-${{ matrix.java }}
+          name: surefire-reports
           path: |
             **/target/surefire-reports/*
             **/target/failsafe-reports/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ Eight interfaces in `api/src/main/java/io/casehub/api/spi/` (four blocking + fou
 
 To add a new operational SPI: define the interface in `api/spi/`, add a no-op default in `engine/internal/worker/`, add contract tests in `api/src/test/java/io/casehub/api/spi/`, and add engine unit tests in `engine/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java`.
 
+**To test SPI wiring:** use `@Alternative @Priority(1) @ApplicationScoped` static inner classes in `@QuarkusTest` with `static` recording fields reset in `@BeforeEach`. This activates the recording bean globally across the test suite without Mockito. See `SpiWiringIntegrationTest` for the pattern.
+
 ## casehub-blackboard Module
 
 Optional CMMN/Blackboard orchestration layer. Activated via CDI `@Alternative @Priority(10)` when on the classpath.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,30 @@
 # CLAUDE.md
 
+## Platform Context
+
+This repo is one component of the casehubio multi-repo platform. **Before implementing anything — any feature, SPI, data model, or abstraction — run the Platform Coherence Protocol.**
+
+The protocol asks: Does this already exist elsewhere? Is this the right repo for it? Does this create a consolidation opportunity? Is this consistent with how the platform handles the same concern in other repos?
+
+**Platform architecture (fetch before any implementation decision):**
+```
+https://raw.githubusercontent.com/casehubio/casehub-parent/main/docs/PLATFORM.md
+```
+
+**This repo's deep-dive:**
+```
+https://raw.githubusercontent.com/casehubio/casehub-parent/main/docs/repos/casehub-engine.md
+```
+
+**Other repo deep-dives** (fetch the relevant ones when your implementation touches their domain):
+- quarkus-ledger: `https://raw.githubusercontent.com/casehubio/casehub-parent/main/docs/repos/quarkus-ledger.md`
+- quarkus-work: `https://raw.githubusercontent.com/casehubio/casehub-parent/main/docs/repos/quarkus-work.md`
+- quarkus-qhorus: `https://raw.githubusercontent.com/casehubio/casehub-parent/main/docs/repos/quarkus-qhorus.md`
+- claudony: `https://raw.githubusercontent.com/casehubio/casehub-parent/main/docs/repos/claudony.md`
+- casehub-connectors: `https://raw.githubusercontent.com/casehubio/casehub-parent/main/docs/repos/casehub-connectors.md`
+
+---
+
 ## No Migration Tooling
 
 This project has no installed instances to migrate. Do not add:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,22 @@ TESTCONTAINERS_RYUK_DISABLED=true mvn clean test -pl casehub-blackboard
 - `src/test/resources/application.properties` sets `quarkus.http.test-port=0` and activates
   the in-memory alternatives via `quarkus.arc.selected-alternatives`
 
-**PRs:** #88 (async LoopControl), #89 (data model), #90 (orchestration + tests) — merge in order.
-
 ## Quartz
 
 Use RAM store — no JDBC store, no Quartz tables:
 ```properties
 quarkus.quartz.store-type=ram
 ```
+
+## casehub-work-adapter Module
+
+Bridges quarkus-work `WorkItemLifecycleEvent` CDI events to CaseHub `PlanItem` transitions via `BlackboardRegistry`. Choreography path only — fires `CONTEXT_CHANGED` for engine re-evaluation.
+
+**Test setup** (when depending on `quarkus-work` full module):
+- Add `quarkus-work-testing` test dep — provides `@Alternative @Priority` in-memory WorkItem stores
+- Add `quarkus-jdbc-h2` test dep — quarkus-work JPA entities require a datasource even in tests
+- Use `quarkus.arc.selected-alternatives` to activate `casehub-persistence-memory` repos
+- Add `@Alternative @Priority(1)` static inner class stub for `WorkloadProvider` — quarkus-work ships `JpaWorkloadProvider` which clashes with `CasehubWorkloadProvider` from the engine
+- Set `quarkus.quartz.store-type=ram` and `quarkus.hibernate-orm.schema-management.strategy=drop-and-create`
+
+`callerRef` format: `case:{caseId}/pi:{planItemId}` — use `CallerRef.encode()` / `CallerRef.parse()`.

--- a/adr/0006-worker-registration-as-normative-act.md
+++ b/adr/0006-worker-registration-as-normative-act.md
@@ -1,0 +1,135 @@
+# 0006 — Worker Registration is a Normative Act
+
+Date: 2026-04-27
+Status: Accepted
+
+## Context and Problem Statement
+
+CaseHub needs a worker discovery and registration system. Workers can enter
+the system via three distinct paths:
+
+1. **Static** — declared upfront in a `CaseDefinition`
+2. **Provisioned** — spun up on demand by `WorkerProvisioner` when no capable
+   worker is available
+3. **Self-registering / observed** — already running independently; announces
+   itself or is introduced by an existing, trusted participant
+
+The third path introduced a design question: how do we model introduction-by-another
+and its implications for trust? A self-announced worker and one introduced by a
+long-trusted provisioner are not equivalent. The lineage of discovery matters —
+not just *that* a worker joined, but *how it came to be known*.
+
+Concurrently, the Qhorus project has defined a four-layer normative framework
+for inter-agent communication:
+
+- **L1 — Speech act theory** (Searle): illocutionary type — directive, assertive,
+  commissive, declarative, perlocutionary
+- **L2 — Deontic logic**: obligations and permissions created or discharged;
+  defeasibility conditions
+- **L3 — Social commitment semantics**: commitment operations — create, discharge,
+  delegate, cancel
+- **L4 — Temporal**: deadline enforcement; what happens when obligations expire
+
+This framework is already recorded in the `MessageLedgerEntry` infrastructure
+(quarkus-ledger), with `causedByEntryId` chains representing causal obligation
+lineage. The question is whether worker registration belongs inside this
+framework or alongside it as a parallel, ad-hoc mechanism.
+
+## Decision
+
+**Worker registration is a normative act.** It is not a technical side-effect
+to be logged separately — it is a declarative speech act that constitutively
+creates a new participant in the system, with deontic consequences.
+
+The four-layer framework applies:
+
+| Layer | Application to worker registration |
+|---|---|
+| **Speech act** | Registration is a *declarative* act: saying "I am a participant" makes it so. Introduction-by-another is also declarative, with the introducer as the actor. |
+| **Deontic** | Registration creates obligations: the engine is obligated to consider the worker for capable work; the worker is obligated to accept work within its declared capabilities or decline with reason. |
+| **Social commitment** | The introduction chain is a commitment chain: `C(introducer → engine, "this worker is trustworthy for these capabilities")`. The introducer's deontic standing transfers as a prior over the introduced worker's initial standing. |
+| **Temporal** | Registrations can expire or be revoked; the temporal layer governs the obligation window. |
+
+**Trust derives from discovery lineage**, not from assertion. A worker's initial
+deontic standing is a function of how it came to be known:
+
+- Statically declared → highest standing (baked in by the system owner)
+- Provisioned by a trusted `WorkerProvisioner` → standing inherits from provisioner's trust level
+- Self-announced → lowest initial standing (no voucher)
+- Introduced by an existing participant → standing derived from the introducer's chain
+
+This is a web-of-trust applied to agent discovery, mirroring how `causedByEntryId`
+chains represent causal obligation lineage in the Qhorus ledger.
+
+**Discovery events are recorded in the normative ledger** using the same
+`MessageLedgerEntry` infrastructure (or its CaseHub equivalent), with the
+`causedByEntryId` field linking an introduced worker's registration entry to the
+registration entry of the participant that introduced it. The discovery chain is
+permanently traversable.
+
+## Decision Drivers
+
+- **Ecosystem coherence**: the more the normative framework is applied consistently
+  across CaseHub and Qhorus, the more it asserts its value. An ad-hoc trust mechanism
+  alongside a principled normative framework would be a missed opportunity and a
+  source of conceptual confusion.
+- **Lineage completeness**: the ledger already records *what* agents committed to
+  and *how work was produced*. Recording *how workers came to be known* completes
+  the audit picture and makes trust verifiable rather than implicit.
+- **Heterogeneous runtimes**: CaseHub targets heterogeneous worker runtimes (internal
+  Quartz workers, Claudony-managed Claude sessions, Docker containers, Nono sandboxes,
+  human-in-the-loop). A unified normative model prevents each runtime from needing its
+  own ad-hoc trust mechanism.
+- **Infrastructure reuse over proliferation**: quarkus-ledger already provides
+  tamper-evident, causally-chained ledger entries. Reusing this infrastructure for
+  worker registration avoids a second ledger system.
+
+## Consequences
+
+### Positive
+
+- A single normative framework governs both inter-agent communication (Qhorus) and
+  worker participation (CaseHub); developers reason about one model, not two.
+- Discovery lineage is permanently auditable — who introduced whom, and who introduced
+  the introducer, is always traceable.
+- Trust is derivable (from the chain) rather than asserted (by the worker itself),
+  which is structurally harder to spoof.
+- Different entry paths (static / provisioned / self-registered / introduced) are
+  unified at the normative level even if their technical mechanisms differ.
+- The normative framework gains compound value: each additional domain it governs
+  strengthens the argument for it as ecosystem-wide infrastructure.
+- The enforcement layer (L4, Drools-based) can be applied to worker registration
+  obligations in the same pipeline as message obligations — no separate enforcement
+  path needed.
+
+### Constraints this creates
+
+- Worker registration events must produce ledger entries — registration cannot be
+  a purely in-memory operation.
+- The engine must track `WorkerProvisioner` identity so it can be recorded as the
+  `actorId` on provisioned worker registration entries.
+- A worker that introduces another must itself be a registered participant with
+  sufficient deontic standing to vouch — this must be validated before the
+  introduction is accepted.
+- Trust level must be a queryable property on the worker's ledger entry, so
+  the enforcement layer can use it for work assignment decisions.
+
+## Out of Scope for This ADR
+
+- The specific `LedgerEntryType` or `messageType` values used for worker
+  registration events (implementation detail).
+- The exact trust scoring function mapping discovery chain depth to deontic
+  standing (to be designed when enforcement is implemented).
+- The Drools rules governing what a worker at each trust level may and may not
+  do (L4, deferred to enforcement phase).
+
+## Links
+
+- ADR-0005 — Worker Provisioner SPIs in `api/spi/` (the SPI contracts this ADR
+  governs normatively)
+- quarkus-qhorus spec `2026-04-23-message-type-redesign-design.md` — four-layer
+  normative framework definition
+- quarkus-qhorus spec `2026-04-26-normative-ledger-design.md` — ledger infrastructure
+  this decision extends
+- Ecosystem design `2026-04-13-quarkus-ai-ecosystem-design.md` — worker provisioner
+  SPI overview and deployment topologies

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -5,3 +5,4 @@
 | 0003 | [Work, WorkItem, and Task naming — broker-level vocabulary](0003-work-workitem-task-naming.md) | Accepted | 2026-04-22 |
 | 0004 | [Claim SLA policy as pluggable CDI strategy — Continuation (D) as default](0004-claim-sla-policy-spi.md) | Accepted | 2026-04-23 |
 | 0005 | [Worker Provisioner SPIs in `api/spi/`, not `engine-model/spi/`](0005-worker-provisioner-spi-placement.md) | Accepted | 2026-04-23 |
+| 0006 | [Worker registration is a normative act](0006-worker-registration-as-normative-act.md) | Accepted | 2026-04-27 |

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,6 +13,10 @@
     <name>Case Hub :: API</name>
     <description>Public API for Case Hub — CaseHub base class, CaseHubDefinition, Workers, Goals, Milestones, and DispatchRules</description>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/api/src/main/java/io/casehub/api/engine/CaseHub.java
+++ b/api/src/main/java/io/casehub/api/engine/CaseHub.java
@@ -39,6 +39,18 @@ public abstract class CaseHub {
     runtime.signal(caseId, path, value);
   }
 
+  public void cancelCase(UUID caseId) {
+    runtime.cancelCase(caseId);
+  }
+
+  public void suspendCase(UUID caseId) {
+    runtime.suspendCase(caseId);
+  }
+
+  public void resumeCase(UUID caseId) {
+    runtime.resumeCase(caseId);
+  }
+
   public CompletionStage<Object> query(UUID caseId, String path) {
     return runtime.query(caseId, path);
   }

--- a/api/src/main/java/io/casehub/api/engine/CaseHubRuntime.java
+++ b/api/src/main/java/io/casehub/api/engine/CaseHubRuntime.java
@@ -28,6 +28,30 @@ public interface CaseHubRuntime {
 
   void signal(UUID caseId, String path, Object value);
 
+  /**
+   * Cancels a case. Valid from any non-terminal state (RUNNING, SUSPENDED, WAITING).
+   *
+   * @throws IllegalArgumentException if the case is not found
+   * @throws IllegalStateException if the case is already in a terminal state
+   */
+  void cancelCase(UUID caseId);
+
+  /**
+   * Suspends a running case. No new workers will fire while the case is suspended.
+   *
+   * @throws IllegalArgumentException if the case is not found
+   * @throws IllegalStateException if the case is not in RUNNING state
+   */
+  void suspendCase(UUID caseId);
+
+  /**
+   * Resumes a suspended case and re-evaluates context so eligible workers can fire.
+   *
+   * @throws IllegalArgumentException if the case is not found
+   * @throws IllegalStateException if the case is not in SUSPENDED state
+   */
+  void resumeCase(UUID caseId);
+
   CompletionStage<Object> query(UUID caseId, String path);
 
   <T> CompletionStage<T> query(UUID caseId, String path, Class<T> clazz);

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -21,11 +21,10 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Ledger library -->
+        <!-- Ledger library — version managed by casehub-parent BOM -->
         <dependency>
             <groupId>io.quarkiverse.ledger</groupId>
             <artifactId>quarkus-ledger</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- CDI + JPA (blocking) for EntityManager -->

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -13,6 +13,10 @@
     <name>Case Hub :: Ledger</name>
     <description>Optional immutable audit ledger — hash-chained case lifecycle entries via quarkus-ledger</description>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <!-- CaseLifecycleEvent lives in engine-model (no CDI beans — safe as compile dep) -->
         <dependency>

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -21,10 +21,10 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Ledger library — version managed by casehub-parent BOM -->
         <dependency>
             <groupId>io.quarkiverse.ledger</groupId>
             <artifactId>quarkus-ledger</artifactId>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
 
         <!-- CDI + JPA (blocking) for EntityManager -->

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>io.quarkiverse.ledger</groupId>
             <artifactId>quarkus-ledger</artifactId>
-            <version>0.2-SNAPSHOT</version>
         </dependency>
 
         <!-- CDI + JPA (blocking) for EntityManager -->

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -21,10 +21,11 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Ledger library — version managed by casehub-parent BOM -->
+        <!-- Ledger library -->
         <dependency>
             <groupId>io.quarkiverse.ledger</groupId>
             <artifactId>quarkus-ledger</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- CDI + JPA (blocking) for EntityManager -->

--- a/casehub-ledger/src/test/java/io/casehub/ledger/CaseLedgerEventCaptureTest.java
+++ b/casehub-ledger/src/test/java/io/casehub/ledger/CaseLedgerEventCaptureTest.java
@@ -259,6 +259,54 @@ class CaseLedgerEventCaptureTest {
     assertThat(repository.findLatestByCaseId(UUID.randomUUID())).isEmpty();
   }
 
+  @Test
+  void workerExecutionStarted_writesLedgerEntry_withWorkerIdAsActorId() {
+    final UUID caseId = UUID.randomUUID();
+    final String workerId = "researcher-worker";
+
+    lifecycleEvents.fireAsync(
+        new CaseLifecycleEvent(
+            caseId, "ExecuteWorker", "WorkerExecutionStarted", null, workerId, "WORKER"));
+
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              final List<CaseLedgerEntry> entries = repository.findByCaseId(caseId);
+              assertThat(entries).hasSize(1);
+              final CaseLedgerEntry entry = entries.get(0);
+              assertThat(entry.commandType).isEqualTo("ExecuteWorker");
+              assertThat(entry.eventType).isEqualTo("WorkerExecutionStarted");
+              assertThat(entry.caseStatus).isNull();
+              assertThat(entry.actorId).isEqualTo(workerId);
+              assertThat(entry.actorRole).isEqualTo("WORKER");
+            });
+  }
+
+  @Test
+  void workerExecutionCompleted_writesLedgerEntry_withWorkerIdAsActorId() {
+    final UUID caseId = UUID.randomUUID();
+    final String workerId = "analyst-worker";
+
+    lifecycleEvents.fireAsync(
+        new CaseLifecycleEvent(
+            caseId, "ExecuteWorker", "WorkerExecutionCompleted", "RUNNING", workerId, "WORKER"));
+
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              final List<CaseLedgerEntry> entries = repository.findByCaseId(caseId);
+              assertThat(entries).hasSize(1);
+              final CaseLedgerEntry entry = entries.get(0);
+              assertThat(entry.commandType).isEqualTo("ExecuteWorker");
+              assertThat(entry.eventType).isEqualTo("WorkerExecutionCompleted");
+              assertThat(entry.caseStatus).isEqualTo("RUNNING");
+              assertThat(entry.actorId).isEqualTo(workerId);
+              assertThat(entry.actorRole).isEqualTo("WORKER");
+            });
+  }
+
   // ── Correctness: Merkle chain integrity ────────────────────────────────────
 
   @Test

--- a/casehub-testing/pom.xml
+++ b/casehub-testing/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.casehub</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>casehub-testing</artifactId>
+    <name>Case Hub :: Testing</name>
+    <description>In-memory CaseEngine setup for consumer @QuarkusTest classes — no PostgreSQL, no Docker required</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-persistence-memory</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/casehub-testing/src/main/java/io/casehub/testing/TestCaseInstanceRepository.java
+++ b/casehub-testing/src/main/java/io/casehub/testing/TestCaseInstanceRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.testing;
+
+import io.casehub.persistence.memory.InMemoryCaseInstanceRepository;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * Auto-selected in-memory {@link io.casehub.engine.spi.CaseInstanceRepository} for
+ * {@code @QuarkusTest}.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class TestCaseInstanceRepository extends InMemoryCaseInstanceRepository {}

--- a/casehub-testing/src/main/java/io/casehub/testing/TestCaseMetaModelRepository.java
+++ b/casehub-testing/src/main/java/io/casehub/testing/TestCaseMetaModelRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.testing;
+
+import io.casehub.persistence.memory.InMemoryCaseMetaModelRepository;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * Auto-selected in-memory {@link io.casehub.engine.spi.CaseMetaModelRepository} for
+ * {@code @QuarkusTest}.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class TestCaseMetaModelRepository extends InMemoryCaseMetaModelRepository {}

--- a/casehub-testing/src/main/java/io/casehub/testing/TestEventLogRepository.java
+++ b/casehub-testing/src/main/java/io/casehub/testing/TestEventLogRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.testing;
+
+import io.casehub.persistence.memory.InMemoryEventLogRepository;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * Auto-selected in-memory {@link io.casehub.engine.spi.EventLogRepository} for
+ * {@code @QuarkusTest}.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class TestEventLogRepository extends InMemoryEventLogRepository {}

--- a/casehub-testing/src/main/java/io/casehub/testing/WorkResultSubmitter.java
+++ b/casehub-testing/src/main/java/io/casehub/testing/WorkResultSubmitter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.testing;
+
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Test helper that simulates a provisioned worker completing its work.
+ *
+ * <p>Use this when the case uses a {@link io.casehub.api.spi.WorkerProvisioner} that provisions
+ * external workers — inject this bean in your {@code @QuarkusTest} and call {@link #complete(UUID,
+ * String, Map)} to drive the engine forward without a real worker process.
+ *
+ * <pre>{@code
+ * workResultSubmitter.complete(caseId, "my-worker", Map.of("result", "done"))
+ *     .await().atMost(Duration.ofSeconds(5));
+ * }</pre>
+ */
+@ApplicationScoped
+public class WorkResultSubmitter {
+
+  @Inject CaseInstanceRepository caseInstanceRepository;
+
+  @Inject CaseDefinitionRegistry caseDefinitionRegistry;
+
+  @Inject EventBus eventBus;
+
+  public Uni<Void> complete(UUID caseId, String workerId, Map<String, Object> output) {
+    return caseInstanceRepository
+        .findByUuid(caseId)
+        .map(
+            instance -> {
+              var definition =
+                  caseDefinitionRegistry.getCaseDefinition(instance.getCaseMetaModel());
+              Worker worker =
+                  definition.getWorkers().stream()
+                      .filter(w -> w.getName().equals(workerId))
+                      .findFirst()
+                      .orElseThrow(
+                          () ->
+                              new IllegalArgumentException(
+                                  "Worker not found in case definition: " + workerId));
+              String idempotency = UUID.randomUUID().toString();
+              eventBus.publish(
+                  EventBusAddresses.WORKER_EXECUTION_FINISHED,
+                  new WorkflowExecutionCompleted(instance, worker, idempotency, output));
+              return (Void) null;
+            });
+  }
+}

--- a/casehub-work-adapter/pom.xml
+++ b/casehub-work-adapter/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.casehub</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>casehub-work-adapter</artifactId>
+    <name>Case Hub :: Work Adapter</name>
+    <description>Bridge between quarkus-work WorkItemLifecycleEvent and CaseHub's blackboard PlanItem lifecycle</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-blackboard</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.work</groupId>
+            <artifactId>quarkus-work</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-persistence-memory</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.work</groupId>
+            <artifactId>quarkus-work-testing</artifactId>
+            <version>${version.io.quarkiverse.work}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/casehub-work-adapter/src/main/java/io/casehub/workadapter/CallerRef.java
+++ b/casehub-work-adapter/src/main/java/io/casehub/workadapter/CallerRef.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses and constructs the {@code callerRef} string embedded by CaseHub when spawning a
+ * quarkus-work WorkItem child.
+ *
+ * <p>Format: {@code case:{caseId}/pi:{planItemId}}
+ *
+ * <p>CaseHub owns the semantics of this opaque string — quarkus-work stores it unchanged on the
+ * WorkItem and echoes it back in every WorkItemLifecycleEvent. Refs casehubio/quarkus-work#136.
+ */
+public record CallerRef(UUID caseId, String planItemId) {
+
+  private static final Pattern PATTERN = Pattern.compile("^case:([0-9a-fA-F-]{36})/pi:(.+)$");
+
+  public static String encode(UUID caseId, String planItemId) {
+    return "case:" + caseId + "/pi:" + planItemId;
+  }
+
+  /** Returns {@code null} if the string is not a CaseHub callerRef. */
+  public static CallerRef parse(String callerRef) {
+    if (callerRef == null) return null;
+    Matcher m = PATTERN.matcher(callerRef);
+    if (!m.matches()) return null;
+    try {
+      return new CallerRef(UUID.fromString(m.group(1)), m.group(2));
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+}

--- a/casehub-work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
+++ b/casehub-work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.internal.event.CaseContextChangedEvent;
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.util.ReactiveUtils;
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.quarkiverse.work.runtime.event.WorkItemLifecycleEvent;
+import io.quarkiverse.work.runtime.model.WorkItem;
+import io.quarkiverse.work.runtime.model.WorkItemStatus;
+import io.vertx.core.Vertx;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import org.jboss.logging.Logger;
+
+/**
+ * Translates terminal quarkus-work {@link WorkItemLifecycleEvent}s into CaseHub PlanItem
+ * transitions and fires {@code CONTEXT_CHANGED} to trigger engine re-evaluation.
+ *
+ * <p>Choreography path: the engine's binding evaluator picks up the next step automatically once
+ * the PlanItem status changes and the context-changed signal arrives. Refs
+ * casehubio/quarkus-work#136.
+ *
+ * <p>Only processes events whose {@code callerRef} matches the CaseHub format {@code
+ * case:{caseId}/pi:{planItemId}} — other WorkItems are ignored.
+ */
+@ApplicationScoped
+public class WorkItemLifecycleAdapter {
+
+  private static final Logger LOG = Logger.getLogger(WorkItemLifecycleAdapter.class);
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  @Inject BlackboardRegistry registry;
+
+  @Inject CaseInstanceRepository caseInstanceRepository;
+
+  @Inject EventBus eventBus;
+
+  @Inject Vertx vertx;
+
+  void onWorkItemLifecycle(@ObservesAsync WorkItemLifecycleEvent event) {
+    WorkItemStatus status = event.status();
+    if (status != WorkItemStatus.COMPLETED
+        && status != WorkItemStatus.REJECTED
+        && status != WorkItemStatus.CANCELLED
+        && status != WorkItemStatus.EXPIRED
+        && status != WorkItemStatus.ESCALATED) return;
+
+    if (!(event.source() instanceof WorkItem workItem)) return;
+
+    CallerRef ref = CallerRef.parse(workItem.callerRef);
+    if (ref == null) return;
+
+    CasePlanModel plan = registry.get(ref.caseId()).orElse(null);
+    if (plan == null) {
+      LOG.debugf(
+          "No CasePlanModel for caseId=%s — case may have completed or not use blackboard",
+          ref.caseId());
+      return;
+    }
+
+    PlanItem item = plan.getPlanItem(ref.planItemId()).orElse(null);
+    if (item == null) {
+      LOG.warnf("PlanItem %s not found in case %s", ref.planItemId(), ref.caseId());
+      return;
+    }
+
+    if (!applyStatus(item, status)) return;
+
+    ReactiveUtils.runOnSafeVertxContext(
+            vertx,
+            () ->
+                caseInstanceRepository
+                    .findByUuid(ref.caseId())
+                    .invoke(
+                        instance -> {
+                          if (instance == null) {
+                            LOG.warnf(
+                                "CaseInstance not found for caseId=%s — cannot fire CONTEXT_CHANGED",
+                                ref.caseId());
+                            return;
+                          }
+                          eventBus.publish(
+                              EventBusAddresses.CONTEXT_CHANGED,
+                              new CaseContextChangedEvent(
+                                  instance, instance.getCaseContext().asJsonNode()));
+                        }))
+        .await()
+        .atMost(TIMEOUT);
+  }
+
+  /**
+   * Applies the terminal WorkItemStatus to the PlanItem. Returns false if the transition is invalid
+   * (e.g. item already terminal), in which case no CONTEXT_CHANGED should be fired.
+   */
+  private boolean applyStatus(PlanItem item, WorkItemStatus status) {
+    try {
+      switch (status) {
+        case COMPLETED -> item.markCompleted();
+        case CANCELLED -> item.markCancelled();
+        case REJECTED, EXPIRED, ESCALATED -> item.markFaulted();
+        default -> {
+          return false;
+        }
+      }
+      return true;
+    } catch (IllegalStateException e) {
+      LOG.warnf(
+          "Cannot transition PlanItem %s (current=%s) for WorkItemStatus %s: %s",
+          item.getPlanItemId(), item.getStatus(), status, e.getMessage());
+      return false;
+    }
+  }
+}

--- a/casehub-work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java
+++ b/casehub-work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.internal.context.CaseContextImpl;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.quarkiverse.work.api.WorkloadProvider;
+import io.quarkiverse.work.runtime.event.WorkItemLifecycleEvent;
+import io.quarkiverse.work.runtime.model.WorkItem;
+import io.quarkiverse.work.runtime.model.WorkItemStatus;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class WorkItemLifecycleAdapterTest {
+
+  /** Resolves the CasehubWorkloadProvider vs JpaWorkloadProvider ambiguity in tests. */
+  @Alternative
+  @Priority(1)
+  @ApplicationScoped
+  static class StubWorkloadProvider implements WorkloadProvider {
+    @Override
+    public int getActiveWorkCount(String workerId) {
+      return 0;
+    }
+  }
+
+  @Inject BlackboardRegistry registry;
+
+  @Inject CaseInstanceRepository caseInstanceRepository;
+
+  @Inject Event<WorkItemLifecycleEvent> lifecycleEvents;
+
+  private UUID caseId;
+  private String planItemId;
+  private PlanItem planItem;
+
+  @BeforeEach
+  void setUp() {
+    caseId = UUID.randomUUID();
+    planItem = PlanItem.create("review-binding", "review-worker", 10);
+    planItemId = planItem.getPlanItemId();
+    planItem.markRunning();
+
+    registry.getOrCreate(caseId).addPlanItem(planItem);
+
+    CaseInstance instance = new CaseInstance();
+    instance.setUuid(caseId);
+    instance.setState(io.casehub.api.model.CaseStatus.RUNNING);
+    instance.setCaseContext(new CaseContextImpl(Map.of("stage", "review")));
+    caseInstanceRepository.save(instance).await().atMost(Duration.ofSeconds(5));
+  }
+
+  @Test
+  void workItemCompleted_marksPlanItemCompleted_firesContextChanged() {
+    lifecycleEvents.fireAsync(buildEvent(WorkItemStatus.COMPLETED, "Approved"));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> assertThat(planItem.getStatus()).isEqualTo(PlanItem.PlanItemStatus.COMPLETED));
+  }
+
+  @Test
+  void workItemRejected_marksPlanItemFaulted() {
+    lifecycleEvents.fireAsync(buildEvent(WorkItemStatus.REJECTED, null));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> assertThat(planItem.getStatus()).isEqualTo(PlanItem.PlanItemStatus.FAULTED));
+  }
+
+  @Test
+  void workItemExpired_marksPlanItemFaulted() {
+    lifecycleEvents.fireAsync(buildEvent(WorkItemStatus.EXPIRED, null));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> assertThat(planItem.getStatus()).isEqualTo(PlanItem.PlanItemStatus.FAULTED));
+  }
+
+  @Test
+  void workItemEscalated_marksPlanItemFaulted() {
+    lifecycleEvents.fireAsync(buildEvent(WorkItemStatus.ESCALATED, null));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> assertThat(planItem.getStatus()).isEqualTo(PlanItem.PlanItemStatus.FAULTED));
+  }
+
+  @Test
+  void workItemCancelled_marksPlanItemCancelled() {
+    lifecycleEvents.fireAsync(buildEvent(WorkItemStatus.CANCELLED, null));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> assertThat(planItem.getStatus()).isEqualTo(PlanItem.PlanItemStatus.CANCELLED));
+  }
+
+  @Test
+  void nonTerminalStatus_ignored() {
+    lifecycleEvents.fireAsync(buildEvent(WorkItemStatus.IN_PROGRESS, null));
+
+    // Give the async observer time to run if it were going to
+    try {
+      Thread.sleep(500);
+    } catch (InterruptedException ignored) {
+    }
+    assertThat(planItem.getStatus()).isEqualTo(PlanItem.PlanItemStatus.RUNNING);
+  }
+
+  @Test
+  void unknownCallerRef_ignored() {
+    WorkItem workItem = new WorkItem();
+    workItem.id = UUID.randomUUID();
+    workItem.status = WorkItemStatus.COMPLETED;
+    workItem.callerRef = "some-other-system:xyz";
+
+    lifecycleEvents.fireAsync(
+        WorkItemLifecycleEvent.of("workitem.completed", workItem, "system", null));
+
+    try {
+      Thread.sleep(500);
+    } catch (InterruptedException ignored) {
+    }
+    assertThat(planItem.getStatus()).isEqualTo(PlanItem.PlanItemStatus.RUNNING);
+  }
+
+  @Test
+  void missingCallerRef_ignored() {
+    WorkItem workItem = new WorkItem();
+    workItem.id = UUID.randomUUID();
+    workItem.status = WorkItemStatus.COMPLETED;
+    workItem.callerRef = null;
+
+    lifecycleEvents.fireAsync(
+        WorkItemLifecycleEvent.of("workitem.completed", workItem, "system", null));
+
+    try {
+      Thread.sleep(500);
+    } catch (InterruptedException ignored) {
+    }
+    assertThat(planItem.getStatus()).isEqualTo(PlanItem.PlanItemStatus.RUNNING);
+  }
+
+  private WorkItemLifecycleEvent buildEvent(WorkItemStatus status, String resolution) {
+    WorkItem workItem = new WorkItem();
+    workItem.id = UUID.randomUUID();
+    workItem.status = status;
+    workItem.callerRef = CallerRef.encode(caseId, planItemId);
+    workItem.resolution = resolution;
+    return WorkItemLifecycleEvent.of(
+        "workitem." + status.name().toLowerCase(), workItem, "system", null);
+  }
+}

--- a/casehub-work-adapter/src/test/resources/application.properties
+++ b/casehub-work-adapter/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+quarkus.http.test-port=0
+quarkus.quartz.store-type=ram
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.arc.selected-alternatives=\
+  io.casehub.persistence.memory.InMemoryCaseInstanceRepository,\
+  io.casehub.persistence.memory.InMemoryCaseMetaModelRepository,\
+  io.casehub.persistence.memory.InMemoryEventLogRepository

--- a/engine-model/pom.xml
+++ b/engine-model/pom.xml
@@ -14,6 +14,7 @@
     <description>Core model classes for the Case Hub engine — CaseInstance, PlanItemInstance, etc.</description>
 
     <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -61,12 +61,10 @@
         <dependency>
             <groupId>io.quarkiverse.work</groupId>
             <artifactId>quarkus-work-api</artifactId>
-            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.work</groupId>
             <artifactId>quarkus-work-core</artifactId>
-            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -61,12 +61,12 @@
         <dependency>
             <groupId>io.quarkiverse.work</groupId>
             <artifactId>quarkus-work-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.work</groupId>
             <artifactId>quarkus-work-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -104,6 +104,7 @@
     </dependencies>
 
     <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
         <engine.test.extra.jvm.args/>
     </properties>
 
@@ -184,6 +185,7 @@
         <profile>
             <id>persistence-memory</id>
             <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
                 <engine.test.extra.jvm.args>-Dquarkus.test.profile=memory</engine.test.extra.jvm.args>
             </properties>
             <dependencies>

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -16,6 +16,7 @@
 package io.casehub.engine.internal.engine;
 
 import static io.casehub.engine.internal.event.EventBusAddresses.CASE_STARTED;
+import static io.casehub.engine.internal.event.EventBusAddresses.CASE_STATUS_CHANGED;
 import static io.casehub.engine.internal.event.EventBusAddresses.SIGNAL_RECEIVED;
 
 import io.casehub.api.context.CaseContext;
@@ -24,6 +25,7 @@ import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.event.CaseStartedEvent;
+import io.casehub.engine.internal.event.CaseStatusChanged;
 import io.casehub.engine.internal.event.SignalReceivedEvent;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.model.CaseMetaModel;
@@ -98,6 +100,56 @@ class CaseHubReactor {
 
   void signal(UUID caseId, String path, Object value) {
     eventBus.publish(SIGNAL_RECEIVED, new SignalReceivedEvent(caseId, path, value));
+  }
+
+  void cancelCase(UUID caseId) {
+    final CaseInstance instance = requireInstance(caseId);
+    final CaseStatus current = instance.getState();
+    if (current == CaseStatus.COMPLETED
+        || current == CaseStatus.FAULTED
+        || current == CaseStatus.CANCELLED) {
+      throw new IllegalStateException(
+          "Cannot cancel case in terminal state " + current + ": caseId=" + caseId);
+    }
+    eventBus.publish(
+        CASE_STATUS_CHANGED,
+        new CaseStatusChanged(instance, current.name(), CaseStatus.CANCELLED.name()));
+  }
+
+  void suspendCase(UUID caseId) {
+    final CaseInstance instance = requireInstance(caseId);
+    if (instance.getState() != CaseStatus.RUNNING) {
+      throw new IllegalStateException(
+          "Can only suspend a RUNNING case, current state: "
+              + instance.getState()
+              + ": caseId="
+              + caseId);
+    }
+    eventBus.publish(
+        CASE_STATUS_CHANGED,
+        new CaseStatusChanged(instance, CaseStatus.RUNNING.name(), CaseStatus.SUSPENDED.name()));
+  }
+
+  void resumeCase(UUID caseId) {
+    final CaseInstance instance = requireInstance(caseId);
+    if (instance.getState() != CaseStatus.SUSPENDED) {
+      throw new IllegalStateException(
+          "Can only resume a SUSPENDED case, current state: "
+              + instance.getState()
+              + ": caseId="
+              + caseId);
+    }
+    eventBus.publish(
+        CASE_STATUS_CHANGED,
+        new CaseStatusChanged(instance, CaseStatus.SUSPENDED.name(), CaseStatus.RUNNING.name()));
+  }
+
+  private CaseInstance requireInstance(UUID caseId) {
+    final CaseInstance instance = caseInstanceCache.get(caseId);
+    if (instance == null) {
+      throw new IllegalArgumentException("Case instance not found: " + caseId);
+    }
+    return instance;
   }
 
   CompletionStage<Object> query(UUID caseId, String path) {

--- a/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
@@ -45,6 +45,21 @@ class CaseHubRuntimeImpl implements CaseHubRuntime {
   }
 
   @Override
+  public void cancelCase(UUID caseId) {
+    reactor.cancelCase(caseId);
+  }
+
+  @Override
+  public void suspendCase(UUID caseId) {
+    reactor.suspendCase(caseId);
+  }
+
+  @Override
+  public void resumeCase(UUID caseId) {
+    reactor.resumeCase(caseId);
+  }
+
+  @Override
   public CompletionStage<Object> query(UUID caseId, String path) {
     return reactor.query(caseId, path);
   }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -79,7 +79,8 @@ public class CaseContextChangedEventHandler {
     }
 
     CaseMetaModel caseMetaModel = caseInstance.getCaseMetaModel();
-    CaseDefinition caseefinition = caseDefinitionRegistry.getCaseDefinition(caseMetaModel);
+    CaseDefinition caseefinition =
+        caseMetaModel != null ? caseDefinitionRegistry.getCaseDefinition(caseMetaModel) : null;
 
     if (caseefinition == null) {
       return Uni.createFrom()

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
@@ -16,6 +16,7 @@
 package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.spi.CaseChannelProvider;
 import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.CaseLifecycleEvent;
 import io.casehub.engine.internal.event.CaseStartedEvent;
@@ -49,6 +50,8 @@ public class CaseStartedEventHandler {
 
   @Inject Event<CaseLifecycleEvent> lifecycleEvents;
 
+  @Inject CaseChannelProvider caseChannelProvider;
+
   @ConsumeEvent(value = EventBusAddresses.CASE_STARTED)
   public Uni<Void> onCaseStarted(CaseStartedEvent event) {
     final CaseInstance instance = event.instance();
@@ -60,6 +63,8 @@ public class CaseStartedEventHandler {
     eventLog.setStreamType(EventStreamType.CASE);
     eventLog.setTimestamp(Instant.now());
     eventLog.setPayload(contextSnapshot);
+
+    caseChannelProvider.openChannel(instance.getUuid(), "coordination");
 
     return eventLogRepository
         .append(eventLog)

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
@@ -17,6 +17,7 @@ package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.CaseStatus;
+import io.casehub.api.spi.CaseChannelProvider;
 import io.casehub.engine.internal.event.CaseLifecycleEvent;
 import io.casehub.engine.internal.event.CaseStatusChanged;
 import io.casehub.engine.internal.event.EventBusAddresses;
@@ -53,6 +54,8 @@ public class CaseStatusChangedHandler {
 
   @Inject Event<CaseLifecycleEvent> lifecycleEvents;
 
+  @Inject CaseChannelProvider caseChannelProvider;
+
   @ConsumeEvent(value = EventBusAddresses.CASE_STATUS_CHANGED)
   public Uni<Void> onCaseStatusChangedHandler(CaseStatusChanged event) {
     final CaseInstance caseInstance = event.instance();
@@ -81,6 +84,9 @@ public class CaseStatusChangedHandler {
         .chain(
             () -> {
               if (isTerminalState(newState)) {
+                caseChannelProvider
+                    .listChannels(caseInstance.getUuid())
+                    .forEach(caseChannelProvider::closeChannel);
                 return schedulerService.cancelAllTriggers(caseInstance.getUuid());
               }
               return Uni.createFrom().voidItem();

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
@@ -18,6 +18,7 @@ package io.casehub.engine.internal.engine.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.api.spi.CaseChannelProvider;
+import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.CaseLifecycleEvent;
 import io.casehub.engine.internal.event.CaseStatusChanged;
 import io.casehub.engine.internal.event.EventBusAddresses;
@@ -97,6 +98,13 @@ public class CaseStatusChangedHandler {
               if (eventBusAddress != null) {
                 eventBus.publish(eventBusAddress, caseInstance);
               }
+              // On resume (SUSPENDED → RUNNING), re-evaluate the context so eligible workers fire.
+              if (newState == CaseStatus.RUNNING) {
+                eventBus.publish(
+                    EventBusAddresses.CONTEXT_CHANGED,
+                    new CaseContextChangedEvent(
+                        caseInstance, caseInstance.getCaseContext().asJsonNode()));
+              }
               lifecycleEvents.fireAsync(
                   new CaseLifecycleEvent(
                       caseInstance.getUuid(),
@@ -118,6 +126,7 @@ public class CaseStatusChangedHandler {
     return switch (state) {
       case COMPLETED -> CaseHubEventType.CASE_COMPLETED;
       case FAULTED -> CaseHubEventType.CASE_FAULTED;
+      case CANCELLED -> CaseHubEventType.CASE_CANCELLED;
       default -> CaseHubEventType.CASE_STATUS_CHANGED;
     };
   }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerRetriesExhaustedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerRetriesExhaustedEventHandler.java
@@ -17,6 +17,7 @@ package io.casehub.engine.internal.engine.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.CaseStatus;
+import io.casehub.api.spi.WorkerStatusListener;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
 import io.casehub.engine.internal.event.CaseStatusChanged;
 import io.casehub.engine.internal.event.EventBusAddresses;
@@ -50,6 +51,8 @@ public class WorkerRetriesExhaustedEventHandler {
 
   @Inject CaseInstanceRepository caseInstanceRepository;
 
+  @Inject WorkerStatusListener workerStatusListener;
+
   @ConsumeEvent(value = EventBusAddresses.WORKER_RETRIES_EXHAUSTED)
   public Uni<Void> onWorkerRetriesExhaustedEvent(WorkerRetriesExhaustedEvent event) {
     CaseInstance caseInstance = caseInstanceCache.get(event.caseId());
@@ -75,6 +78,7 @@ public class WorkerRetriesExhaustedEventHandler {
               LOG.warnf(
                   "Worker retries exhausted for caseId=%s, workerId=%s",
                   event.caseId(), event.workerId());
+              workerStatusListener.onWorkerStalled(event.workerId());
               eventBus.publish(
                   EventBusAddresses.CASE_STATUS_CHANGED,
                   new CaseStatusChanged(caseInstance, oldStatus, CaseStatus.FAULTED.name()));

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -18,7 +18,9 @@ package io.casehub.engine.internal.engine.handler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.Capability;
+import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.Worker;
+import io.casehub.api.spi.WorkerContextProvider;
 import io.casehub.api.spi.WorkerExecutionGuard;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
@@ -53,6 +55,8 @@ public class WorkerScheduleEventHandler {
   @Inject WorkerExecutionManager workflowExecutionManager;
 
   @Inject WorkerExecutionGuard workerExecutionGuard;
+
+  @Inject WorkerContextProvider workerContextProvider;
 
   @Inject EventBus eventBus;
 
@@ -133,6 +137,8 @@ public class WorkerScheduleEventHandler {
       Capability capability,
       Map<String, Object> inputData,
       String inputDataHash) {
+    workerContextProvider.buildContext(
+        worker.getName(), WorkRequest.of(capability.getName(), inputData));
     Map<String, String> metadata =
         Map.of(
             "workerName", worker.getName(),

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -18,9 +18,7 @@ package io.casehub.engine.internal.engine.handler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.Capability;
-import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.Worker;
-import io.casehub.api.spi.WorkerContextProvider;
 import io.casehub.api.spi.WorkerExecutionGuard;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
@@ -55,8 +53,6 @@ public class WorkerScheduleEventHandler {
   @Inject WorkerExecutionManager workflowExecutionManager;
 
   @Inject WorkerExecutionGuard workerExecutionGuard;
-
-  @Inject WorkerContextProvider workerContextProvider;
 
   @Inject EventBus eventBus;
 
@@ -137,8 +133,6 @@ public class WorkerScheduleEventHandler {
       Capability capability,
       Map<String, Object> inputData,
       String inputDataHash) {
-    workerContextProvider.buildContext(
-        worker.getName(), WorkRequest.of(capability.getName(), inputData));
     Map<String, String> metadata =
         Map.of(
             "workerName", worker.getName(),

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -28,6 +28,7 @@ import io.casehub.api.spi.ContextDiffStrategy;
 import io.casehub.api.spi.WorkerStatusListener;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
 import io.casehub.engine.internal.event.CaseContextChangedEvent;
+import io.casehub.engine.internal.event.CaseLifecycleEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
 import io.casehub.engine.internal.history.CaseHubEventType;
@@ -41,6 +42,7 @@ import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import java.time.Instant;
 import java.util.List;
@@ -55,6 +57,7 @@ import org.jboss.logging.Logger;
 public class WorkflowExecutionCompletedHandler {
 
   @Inject EventBus eventBus;
+  @Inject Event<CaseLifecycleEvent> lifecycleEvents;
   @Inject ContextDiffStrategy contextDiffStrategy;
   @Inject EventLogRepository eventLogRepository;
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
@@ -88,6 +91,16 @@ public class WorkflowExecutionCompletedHandler {
                 workerStatusListener.onWorkerCompleted(
                     worker.getName(),
                     WorkResult.completed(event.idempotency(), rawOutput, worker.getName())))
+        .invoke(
+            () ->
+                lifecycleEvents.fireAsync(
+                    new CaseLifecycleEvent(
+                        caseInstance.getUuid(),
+                        "ExecuteWorker",
+                        "WorkerExecutionCompleted",
+                        caseInstance.getState().name(),
+                        worker.getName(),
+                        "WORKER")))
         .invoke(
             () ->
                 eventBus.publish(

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -25,6 +25,7 @@ import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.Worker;
 import io.casehub.api.spi.ContextDiffStrategy;
+import io.casehub.api.spi.WorkerStatusListener;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
 import io.casehub.engine.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
@@ -59,6 +60,7 @@ public class WorkflowExecutionCompletedHandler {
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
   @Inject PendingWorkRegistry pendingWorkRegistry;
   @Inject CaseInstanceRepository caseInstanceRepository;
+  @Inject WorkerStatusListener workerStatusListener;
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Logger LOG = Logger.getLogger(WorkflowExecutionCompletedHandler.class);
@@ -81,6 +83,11 @@ public class WorkflowExecutionCompletedHandler {
     return eventLogRepository
         .append(eventLog)
         .chain(() -> resumeIfWaiting(caseInstance, worker, event.idempotency(), rawOutput, now))
+        .invoke(
+            () ->
+                workerStatusListener.onWorkerCompleted(
+                    worker.getName(),
+                    WorkResult.completed(event.idempotency(), rawOutput, worker.getName())))
         .invoke(
             () ->
                 eventBus.publish(

--- a/engine/src/main/java/io/casehub/engine/internal/work/WorkCdi.java
+++ b/engine/src/main/java/io/casehub/engine/internal/work/WorkCdi.java
@@ -35,8 +35,8 @@ package io.casehub.engine.internal.work;
  * <h2>Injection rule: always inject the concrete strategy type</h2>
  *
  * <p>Because two {@code WorkerSelectionStrategy} implementations ({@code LeastLoadedStrategy} and
- * {@code ClaimFirstStrategy}) are both active CDI beans, injecting by the interface type causes
- * an {@code AmbiguousResolutionException} at startup. Always inject the concrete type you want:
+ * {@code ClaimFirstStrategy}) are both active CDI beans, injecting by the interface type causes an
+ * {@code AmbiguousResolutionException} at startup. Always inject the concrete type you want:
  *
  * <pre>{@code
  * // Correct — unambiguous:

--- a/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Worker;
 import io.casehub.api.spi.WorkerStatusListener;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
 import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
+import io.casehub.engine.internal.event.CaseLifecycleEvent;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
 import io.casehub.engine.internal.history.CaseHubEventType;
@@ -39,6 +40,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import java.util.Date;
 import java.util.UUID;
@@ -58,6 +60,8 @@ public class WorkerExecutionJobListener implements JobListener {
   @Inject Vertx vertx;
 
   @Inject WorkerStatusListener workerStatusListener;
+
+  @Inject Event<CaseLifecycleEvent> lifecycleEvents;
 
   @Inject WorkerExecutionScheduler workerExecutionScheduler;
 
@@ -87,8 +91,17 @@ public class WorkerExecutionJobListener implements JobListener {
     String jobName = context.getJobDetail().getKey().toString();
     String idempotency = context.getMergedJobDataMap().getString("inputDataHash");
     String workerId = context.getMergedJobDataMap().getString("workerId");
+    String caseHubInstanceUuid = context.getMergedJobDataMap().getString("caseHubInstanceUuid");
     LOG.infof("Job is about to be executed: %s, idempotency=%s", jobName, idempotency);
     workerStatusListener.onWorkerStarted(workerId, null);
+    lifecycleEvents.fireAsync(
+        new CaseLifecycleEvent(
+            UUID.fromString(caseHubInstanceUuid),
+            "ExecuteWorker",
+            "WorkerExecutionStarted",
+            null,
+            workerId,
+            "WORKER"));
 
     EventLog eventLog =
         createEventLog(

--- a/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
@@ -25,6 +25,7 @@ import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ExecutionPolicy;
 import io.casehub.api.model.RetryPolicy;
 import io.casehub.api.model.Worker;
+import io.casehub.api.spi.WorkerStatusListener;
 import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
 import io.casehub.engine.internal.engine.recovery.WorkerExecutionRecoveryService;
 import io.casehub.engine.internal.event.EventBusAddresses;
@@ -56,6 +57,8 @@ public class WorkerExecutionJobListener implements JobListener {
 
   @Inject Vertx vertx;
 
+  @Inject WorkerStatusListener workerStatusListener;
+
   @Inject WorkerExecutionScheduler workerExecutionScheduler;
 
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
@@ -83,7 +86,9 @@ public class WorkerExecutionJobListener implements JobListener {
 
     String jobName = context.getJobDetail().getKey().toString();
     String idempotency = context.getMergedJobDataMap().getString("inputDataHash");
+    String workerId = context.getMergedJobDataMap().getString("workerId");
     LOG.infof("Job is about to be executed: %s, idempotency=%s", jobName, idempotency);
+    workerStatusListener.onWorkerStarted(workerId, null);
 
     EventLog eventLog =
         createEventLog(

--- a/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/WorkerExecutionJobListener.java
@@ -43,6 +43,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import java.util.Date;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
@@ -93,7 +94,7 @@ public class WorkerExecutionJobListener implements JobListener {
     String workerId = context.getMergedJobDataMap().getString("workerId");
     String caseHubInstanceUuid = context.getMergedJobDataMap().getString("caseHubInstanceUuid");
     LOG.infof("Job is about to be executed: %s, idempotency=%s", jobName, idempotency);
-    workerStatusListener.onWorkerStarted(workerId, null);
+    workerStatusListener.onWorkerStarted(workerId, Map.of("caseId", caseHubInstanceUuid));
     lifecycleEvents.fireAsync(
         new CaseLifecycleEvent(
             UUID.fromString(caseHubInstanceUuid),

--- a/engine/src/test/java/io/casehub/engine/CaseCancelSuspendResumeTest.java
+++ b/engine/src/test/java/io/casehub/engine/CaseCancelSuspendResumeTest.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.casehub.engine.internal.history.CaseHubEventType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.spi.EventLogRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Verifies cancel, suspend, and resume lifecycle operations. Refs casehubio/engine#14. */
+@QuarkusTest
+class CaseCancelSuspendResumeTest {
+
+  private static final Duration SPI_TIMEOUT = Duration.ofSeconds(10);
+
+  @Inject CaseLifecycleStateTest.IdleCaseHubBean idleBean;
+  @Inject SuspendableWorkerBean suspendableBean;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject EventLogRepository eventLogRepository;
+
+  @BeforeEach
+  void reset() {
+    SuspendableWorkerBean.runCount.set(0);
+  }
+
+  // ------------------------------------------------------------------ //
+  // cancelCase                                                           //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void cancelFromRunningTransitionsToCancelled() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    idleBean.cancelCase(caseId);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .as("cancelCase must transition RUNNING → CANCELLED")
+                    .isEqualTo(CaseStatus.CANCELLED));
+  }
+
+  @Test
+  void cancelFromRunningWritesCaseCancelledEventLog() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    idleBean.cancelCase(caseId);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(findEvents(caseId, CaseHubEventType.CASE_CANCELLED))
+                    .as("EventLog must contain a CASE_CANCELLED entry")
+                    .isNotEmpty());
+  }
+
+  @Test
+  void cancelFromSuspendedTransitionsToCancelled() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    idleBean.suspendCase(caseId);
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> caseInstanceCache.get(caseId).getState() == CaseStatus.SUSPENDED);
+
+    idleBean.cancelCase(caseId);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .as("cancelCase must transition SUSPENDED → CANCELLED")
+                    .isEqualTo(CaseStatus.CANCELLED));
+  }
+
+  @Test
+  void cancelCompletedCaseThrowsIllegalStateException() {
+    UUID caseId = simpleCaseId();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .until(
+            () ->
+                caseInstanceCache.get(caseId) != null
+                    && caseInstanceCache.get(caseId).getState() == CaseStatus.COMPLETED);
+
+    assertThatThrownBy(() -> idleBean.cancelCase(caseId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("terminal");
+  }
+
+  @Test
+  void cancelUnknownCaseThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> idleBean.cancelCase(UUID.randomUUID()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not found");
+  }
+
+  // ------------------------------------------------------------------ //
+  // suspendCase                                                          //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void suspendFromRunningTransitionsToSuspended() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    idleBean.suspendCase(caseId);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .as("suspendCase must transition RUNNING → SUSPENDED")
+                    .isEqualTo(CaseStatus.SUSPENDED));
+  }
+
+  @Test
+  void suspendedCaseDoesNotFireWorkersOnSignal() throws InterruptedException {
+    UUID caseId = suspendableBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    suspendableBean.suspendCase(caseId);
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> caseInstanceCache.get(caseId).getState() == CaseStatus.SUSPENDED);
+
+    // Signal should be ignored while suspended
+    suspendableBean.signal(caseId, "status", "active");
+
+    // Wait briefly and assert no worker ran
+    Thread.sleep(500);
+    assertThat(SuspendableWorkerBean.runCount.get())
+        .as("No worker must fire while the case is SUSPENDED")
+        .isEqualTo(0);
+  }
+
+  @Test
+  void suspendNonRunningCaseThrowsIllegalStateException() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    idleBean.suspendCase(caseId);
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> caseInstanceCache.get(caseId).getState() == CaseStatus.SUSPENDED);
+
+    assertThatThrownBy(() -> idleBean.suspendCase(caseId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("RUNNING");
+  }
+
+  @Test
+  void suspendUnknownCaseThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> idleBean.suspendCase(UUID.randomUUID()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not found");
+  }
+
+  // ------------------------------------------------------------------ //
+  // resumeCase                                                           //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void resumeFromSuspendedTransitionsToRunning() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    idleBean.suspendCase(caseId);
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> caseInstanceCache.get(caseId).getState() == CaseStatus.SUSPENDED);
+
+    idleBean.resumeCase(caseId);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .as("resumeCase must transition SUSPENDED → RUNNING")
+                    .isEqualTo(CaseStatus.RUNNING));
+  }
+
+  @Test
+  void resumedCaseFiresWorkerWhenContextEligible() {
+    // Signal the trigger key BEFORE suspending. The engine ignores it while suspended.
+    // On resume, CONTEXT_CHANGED is republished so the worker can fire.
+    UUID caseId = suspendableBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    suspendableBean.suspendCase(caseId);
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> caseInstanceCache.get(caseId).getState() == CaseStatus.SUSPENDED);
+
+    // Signal while suspended — ignored by the engine
+    suspendableBean.signal(caseId, "status", "active");
+
+    suspendableBean.resumeCase(caseId);
+
+    // After resume, CONTEXT_CHANGED is republished — worker must now fire
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(SuspendableWorkerBean.runCount.get())
+                    .as("Worker must fire after case is resumed with an eligible context")
+                    .isGreaterThan(0));
+  }
+
+  @Test
+  void resumeWritesCaseStatusChangedEventLog() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    idleBean.suspendCase(caseId);
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> caseInstanceCache.get(caseId).getState() == CaseStatus.SUSPENDED);
+
+    idleBean.resumeCase(caseId);
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(findAllEvents(caseId))
+                    .as("EventLog must contain a status-change entry for resume")
+                    .anyMatch(
+                        e ->
+                            e.getEventType() == CaseHubEventType.CASE_STATUS_CHANGED
+                                || e.getEventType() == CaseHubEventType.CASE_STARTED));
+  }
+
+  @Test
+  void resumeNonSuspendedCaseThrowsIllegalStateException() {
+    UUID caseId = idleBean.startCase(Map.of("status", "idle")).toCompletableFuture().join();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> caseInstanceCache.get(caseId) != null);
+
+    assertThatThrownBy(() -> idleBean.resumeCase(caseId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("SUSPENDED");
+  }
+
+  @Test
+  void resumeUnknownCaseThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> idleBean.resumeCase(UUID.randomUUID()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not found");
+  }
+
+  // ------------------------------------------------------------------ //
+  // Helpers                                                              //
+  // ------------------------------------------------------------------ //
+
+  /** Starts and waits for a simple completing case to use its completed caseId. */
+  private UUID simpleCaseId() {
+    // Re-use SimpleCaseHubBean which completes when status == "processed"
+    // We need an @Inject — use the one already in context from the test's own CDI
+    // Instead, just start the idle bean and manually complete via cancel then verify it's terminal
+    // Actually: start a completing case directly using SimpleCaseHubBean — injected separately.
+    UUID caseId =
+        simpleCaseHubBean
+            .startCase(Map.of("documentId", "d1", "status", "processing"))
+            .toCompletableFuture()
+            .join();
+    return caseId;
+  }
+
+  @Inject SimpleCaseHubBean simpleCaseHubBean;
+
+  private List<EventLog> findEvents(UUID caseId, CaseHubEventType eventType) {
+    return eventLogRepository
+        .findByCaseAndTypes(caseId, List.of(eventType))
+        .await()
+        .atMost(SPI_TIMEOUT);
+  }
+
+  private List<EventLog> findAllEvents(UUID caseId) {
+    return eventLogRepository
+        .findByCaseAndTypes(caseId, List.of(CaseHubEventType.values()))
+        .await()
+        .atMost(SPI_TIMEOUT);
+  }
+
+  // ------------------------------------------------------------------ //
+  // Test bean                                                            //
+  // ------------------------------------------------------------------ //
+
+  /**
+   * A case with a worker that fires when status == "active". Stays idle until signalled. Used to
+   * verify suspend/resume worker-firing behaviour.
+   */
+  @ApplicationScoped
+  public static class SuspendableWorkerBean extends CaseHub {
+
+    static final AtomicInteger runCount = new AtomicInteger(0);
+
+    private final Capability capability =
+        Capability.builder()
+            .name("suspendableCapability")
+            .inputSchema("{ status: .status }")
+            .outputSchema("{ result: .status }")
+            .build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-suspend-resume")
+          .name("Suspendable Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(
+              Worker.builder()
+                  .name("suspendable-worker")
+                  .capabilities(capability)
+                  .function(
+                      input -> {
+                        runCount.incrementAndGet();
+                        return Map.of("result", "done");
+                      })
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("trigger-on-active")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"active\""))
+                  .build())
+          .build();
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -89,11 +89,13 @@ class ChoreographySelectionTest {
   @Test
   void twoSequentialCases_eachSelectsExactlyOneWorker() throws Exception {
     for (int i = 0; i < 2; i++) {
-      // Measure delta — don't reset counters, which would race with async completions
+      // Measure delta — don't reset counters, which would race with async completions.
+      // Do NOT clear the cache inside the loop: clearing evicts the completed case from
+      // CaseInstanceCache, which causes Quartz to re-run its worker via recovery on the
+      // next Quartz tick, inflating the delta to 2 for the second iteration.
       int countBefore =
           TwoWorkerSameCapabilityCase.workerACount.get()
               + TwoWorkerSameCapabilityCase.workerBCount.get();
-      cache.clear();
 
       AtomicReference<UUID> caseIdRef = new AtomicReference<>();
       twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -152,7 +152,10 @@ class ChoreographySelectionTest {
               Binding.builder()
                   .name("trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  // Guard on .result == null: prevents re-firing after worker writes output.
+                  // Without this, CONTEXT_CHANGED fires again post-completion and the binding
+                  // re-evaluates while the case is still transitioning, scheduling a second worker.
+                  .on(new ContextChangeTrigger(".trigger == \"go\" and .result == null"))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -34,6 +34,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -44,6 +45,10 @@ import org.junit.jupiter.api.Test;
  * Verifies that WorkBroker selects exactly one worker when multiple workers share the same
  * capability. Previously, all capable workers were scheduled — this is the regression this test
  * guards against.
+ *
+ * <p>Each case run passes a unique {@code runId} in the context. Workers record their invocation
+ * count per {@code runId}, so in-flight Quartz jobs from previous test cases cannot inflate the
+ * count for the current case — they update a different key in the map.
  */
 @QuarkusTest
 class ChoreographySelectionTest {
@@ -53,23 +58,16 @@ class ChoreographySelectionTest {
 
   @BeforeEach
   void clear() {
-    // Clear the case cache only. Do NOT reset workerACount/workerBCount here — resetting shared
-    // static counters races with in-flight Quartz jobs from previous tests that fire after the
-    // reset but before this test's case runs, making the final count appear as 2 instead of 1.
-    // All counter assertions use a before/after delta instead.
     cache.clear();
+    TwoWorkerSameCapabilityCase.runCounts.clear();
   }
 
   /** Happy path: two workers with the same capability — only one is called. */
   @Test
   void twoWorkersSharedCapability_onlyOneIsSelected() throws Exception {
-    // Snapshot before starting — guards against in-flight jobs from previous tests
-    int countBefore =
-        TwoWorkerSameCapabilityCase.workerACount.get()
-            + TwoWorkerSameCapabilityCase.workerBCount.get();
-
+    String runId = UUID.randomUUID().toString();
     AtomicReference<UUID> caseIdRef = new AtomicReference<>();
-    twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);
+    twoWorkerCase.startCase(Map.of("trigger", "go", "runId", runId)).thenAccept(caseIdRef::set);
 
     await().atMost(5, TimeUnit.SECONDS).until(() -> caseIdRef.get() != null);
     await()
@@ -78,27 +76,20 @@ class ChoreographySelectionTest {
             () ->
                 assertThat(cache.get(caseIdRef.get()).getState()).isEqualTo(CaseStatus.COMPLETED));
 
-    int delta =
-        TwoWorkerSameCapabilityCase.workerACount.get()
-            + TwoWorkerSameCapabilityCase.workerBCount.get()
-            - countBefore;
-    assertThat(delta).as("WorkBroker must select exactly one worker, not both").isEqualTo(1);
+    int calls =
+        TwoWorkerSameCapabilityCase.runCounts.getOrDefault(runId, new AtomicInteger()).get();
+    assertThat(calls).as("WorkBroker must select exactly one worker, not both").isEqualTo(1);
   }
 
   /** Correctness: two sequential cases each invoke exactly one worker. */
   @Test
   void twoSequentialCases_eachSelectsExactlyOneWorker() throws Exception {
-    // Snapshot once before both cases — per-iteration delta is unreliable because an
-    // in-flight Quartz job from iteration N can fire after the countBefore snapshot
-    // for iteration N+1, making the delta appear as 2. Instead: run both cases to
-    // completion then assert total delta == 2 (one worker invocation per case).
-    int countBefore =
-        TwoWorkerSameCapabilityCase.workerACount.get()
-            + TwoWorkerSameCapabilityCase.workerBCount.get();
-
     for (int i = 0; i < 2; i++) {
+      // Each iteration has its own runId — stale jobs from the previous iteration can
+      // only increment that iteration's counter, not this one.
+      String runId = UUID.randomUUID().toString();
       AtomicReference<UUID> caseIdRef = new AtomicReference<>();
-      twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);
+      twoWorkerCase.startCase(Map.of("trigger", "go", "runId", runId)).thenAccept(caseIdRef::set);
 
       await().atMost(5, TimeUnit.SECONDS).until(() -> caseIdRef.get() != null);
       await()
@@ -107,31 +98,24 @@ class ChoreographySelectionTest {
               () ->
                   assertThat(cache.get(caseIdRef.get()).getState())
                       .isEqualTo(CaseStatus.COMPLETED));
-    }
 
-    // Brief settle — allow any trailing Quartz notifications to flush before measuring
-    await()
-        .atMost(2, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        TwoWorkerSameCapabilityCase.workerACount.get()
-                            + TwoWorkerSameCapabilityCase.workerBCount.get()
-                            - countBefore)
-                    .as("Two sequential cases must each select exactly one worker (total=2)")
-                    .isEqualTo(2));
+      int calls =
+          TwoWorkerSameCapabilityCase.runCounts.getOrDefault(runId, new AtomicInteger()).get();
+      assertThat(calls).as("Case %d: exactly one worker must run", i).isEqualTo(1);
+    }
   }
 
   @ApplicationScoped
   public static class TwoWorkerSameCapabilityCase extends CaseHub {
 
-    static final AtomicInteger workerACount = new AtomicInteger(0);
-    static final AtomicInteger workerBCount = new AtomicInteger(0);
+    /** Worker invocation count keyed by the unique runId passed in the case context. */
+    static final ConcurrentHashMap<String, AtomicInteger> runCounts = new ConcurrentHashMap<>();
 
     private final Capability capability =
         Capability.builder()
             .name("do-work")
-            .inputSchema("{ trigger: .trigger }")
+            // runId flows through so workers can record their invocation against the right key
+            .inputSchema("{ trigger: .trigger, runId: .runId }")
             .outputSchema("{ result: \"done\" }")
             .build();
 
@@ -151,7 +135,7 @@ class ChoreographySelectionTest {
                   .capabilities(capability)
                   .function(
                       input -> {
-                        workerACount.incrementAndGet();
+                        record(input);
                         return Map.of("result", "done");
                       })
                   .build(),
@@ -160,7 +144,7 @@ class ChoreographySelectionTest {
                   .capabilities(capability)
                   .function(
                       input -> {
-                        workerBCount.incrementAndGet();
+                        record(input);
                         return Map.of("result", "done");
                       })
                   .build())
@@ -173,6 +157,13 @@ class ChoreographySelectionTest {
           .goals(goal)
           .completion(GoalExpression.allOf(goal))
           .build();
+    }
+
+    private static void record(Map<String, Object> input) {
+      Object runId = input.get("runId");
+      if (runId != null) {
+        runCounts.computeIfAbsent(runId.toString(), k -> new AtomicInteger()).incrementAndGet();
+      }
     }
   }
 }

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -53,14 +53,21 @@ class ChoreographySelectionTest {
 
   @BeforeEach
   void clear() {
+    // Clear the case cache only. Do NOT reset workerACount/workerBCount here — resetting shared
+    // static counters races with in-flight Quartz jobs from previous tests that fire after the
+    // reset but before this test's case runs, making the final count appear as 2 instead of 1.
+    // All counter assertions use a before/after delta instead.
     cache.clear();
-    TwoWorkerSameCapabilityCase.workerACount.set(0);
-    TwoWorkerSameCapabilityCase.workerBCount.set(0);
   }
 
   /** Happy path: two workers with the same capability — only one is called. */
   @Test
   void twoWorkersSharedCapability_onlyOneIsSelected() throws Exception {
+    // Snapshot before starting — guards against in-flight jobs from previous tests
+    int countBefore =
+        TwoWorkerSameCapabilityCase.workerACount.get()
+            + TwoWorkerSameCapabilityCase.workerBCount.get();
+
     AtomicReference<UUID> caseIdRef = new AtomicReference<>();
     twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);
 
@@ -71,10 +78,11 @@ class ChoreographySelectionTest {
             () ->
                 assertThat(cache.get(caseIdRef.get()).getState()).isEqualTo(CaseStatus.COMPLETED));
 
-    int totalCalls =
+    int delta =
         TwoWorkerSameCapabilityCase.workerACount.get()
-            + TwoWorkerSameCapabilityCase.workerBCount.get();
-    assertThat(totalCalls).as("WorkBroker must select exactly one worker, not both").isEqualTo(1);
+            + TwoWorkerSameCapabilityCase.workerBCount.get()
+            - countBefore;
+    assertThat(delta).as("WorkBroker must select exactly one worker, not both").isEqualTo(1);
   }
 
   /** Correctness: two sequential cases each invoke exactly one worker. */

--- a/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/engine/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -88,15 +88,15 @@ class ChoreographySelectionTest {
   /** Correctness: two sequential cases each invoke exactly one worker. */
   @Test
   void twoSequentialCases_eachSelectsExactlyOneWorker() throws Exception {
-    for (int i = 0; i < 2; i++) {
-      // Measure delta — don't reset counters, which would race with async completions.
-      // Do NOT clear the cache inside the loop: clearing evicts the completed case from
-      // CaseInstanceCache, which causes Quartz to re-run its worker via recovery on the
-      // next Quartz tick, inflating the delta to 2 for the second iteration.
-      int countBefore =
-          TwoWorkerSameCapabilityCase.workerACount.get()
-              + TwoWorkerSameCapabilityCase.workerBCount.get();
+    // Snapshot once before both cases — per-iteration delta is unreliable because an
+    // in-flight Quartz job from iteration N can fire after the countBefore snapshot
+    // for iteration N+1, making the delta appear as 2. Instead: run both cases to
+    // completion then assert total delta == 2 (one worker invocation per case).
+    int countBefore =
+        TwoWorkerSameCapabilityCase.workerACount.get()
+            + TwoWorkerSameCapabilityCase.workerBCount.get();
 
+    for (int i = 0; i < 2; i++) {
       AtomicReference<UUID> caseIdRef = new AtomicReference<>();
       twoWorkerCase.startCase(Map.of("trigger", "go")).thenAccept(caseIdRef::set);
 
@@ -107,13 +107,19 @@ class ChoreographySelectionTest {
               () ->
                   assertThat(cache.get(caseIdRef.get()).getState())
                       .isEqualTo(CaseStatus.COMPLETED));
-
-      int calls =
-          TwoWorkerSameCapabilityCase.workerACount.get()
-              + TwoWorkerSameCapabilityCase.workerBCount.get()
-              - countBefore;
-      assertThat(calls).as("Case %d: exactly one worker must run", i).isEqualTo(1);
     }
+
+    // Brief settle — allow any trailing Quartz notifications to flush before measuring
+    await()
+        .atMost(2, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        TwoWorkerSameCapabilityCase.workerACount.get()
+                            + TwoWorkerSameCapabilityCase.workerBCount.get()
+                            - countBefore)
+                    .as("Two sequential cases must each select exactly one worker (total=2)")
+                    .isEqualTo(2));
   }
 
   @ApplicationScoped

--- a/engine/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
+++ b/engine/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
@@ -54,7 +54,6 @@ class SpiWiringIntegrationTest {
   @Inject CaseFaultedStateTest.AlwaysFailingCaseHubBean alwaysFailingBean;
   @Inject CaseInstanceCache caseInstanceCache;
   @Inject RecordingWorkerStatusListener statusListener;
-  @Inject RecordingWorkerContextProvider contextProvider;
   @Inject RecordingCaseChannelProvider channelProvider;
 
   @BeforeEach
@@ -121,44 +120,6 @@ class SpiWiringIntegrationTest {
                 assertThat(RecordingWorkerStatusListener.stalledWorkerIds)
                     .as("onWorkerStalled must be called when all retries are exhausted")
                     .isNotEmpty());
-  }
-
-  // ------------------------------------------------------------------ //
-  // WorkerContextProvider                                                //
-  // ------------------------------------------------------------------ //
-
-  @Test
-  void buildContextCalledBeforeWorkerScheduling() {
-    UUID caseId =
-        simpleCaseHubBean
-            .startCase(Map.of("documentId", "doc-3", "status", "processing"))
-            .toCompletableFuture()
-            .join();
-
-    await()
-        .atMost(15, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                assertThat(RecordingWorkerContextProvider.buildContextCallCount.get())
-                    .as("buildContext must be called at least once when a worker is scheduled")
-                    .isGreaterThan(0));
-  }
-
-  @Test
-  void buildContextReceivesCorrectCapabilityName() {
-    UUID caseId =
-        simpleCaseHubBean
-            .startCase(Map.of("documentId", "doc-4", "status", "processing"))
-            .toCompletableFuture()
-            .join();
-
-    await()
-        .atMost(15, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                assertThat(RecordingWorkerContextProvider.seenCapabilities)
-                    .as("buildContext must receive the binding's capability name")
-                    .contains("processDocument"));
   }
 
   // ------------------------------------------------------------------ //

--- a/engine/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
+++ b/engine/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.model.CaseChannel;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.WorkRequest;
+import io.casehub.api.model.WorkResult;
+import io.casehub.api.model.WorkerContext;
+import io.casehub.api.spi.CaseChannelProvider;
+import io.casehub.api.spi.WorkerContextProvider;
+import io.casehub.api.spi.WorkerStatusListener;
+import io.casehub.engine.internal.engine.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that WorkerStatusListener, WorkerContextProvider, and CaseChannelProvider are called at
+ * the correct lifecycle points by the engine. Refs casehubio/engine#152.
+ */
+@QuarkusTest
+class SpiWiringIntegrationTest {
+
+  @Inject SimpleCaseHubBean simpleCaseHubBean;
+  @Inject CaseFaultedStateTest.AlwaysFailingCaseHubBean alwaysFailingBean;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject RecordingWorkerStatusListener statusListener;
+  @Inject RecordingWorkerContextProvider contextProvider;
+  @Inject RecordingCaseChannelProvider channelProvider;
+
+  @BeforeEach
+  void reset() {
+    RecordingWorkerStatusListener.reset();
+    RecordingWorkerContextProvider.reset();
+    RecordingCaseChannelProvider.reset();
+  }
+
+  // ------------------------------------------------------------------ //
+  // WorkerStatusListener                                                 //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void onWorkerStartedCalledWhenWorkerBegins() {
+    UUID caseId =
+        simpleCaseHubBean
+            .startCase(Map.of("documentId", "doc-1", "status", "processing"))
+            .toCompletableFuture()
+            .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingWorkerStatusListener.startedWorkerIds)
+                    .as("onWorkerStarted must be called when a worker begins execution")
+                    .isNotEmpty());
+  }
+
+  @Test
+  void onWorkerCompletedCalledAfterSuccessfulExecution() {
+    UUID caseId =
+        simpleCaseHubBean
+            .startCase(Map.of("documentId", "doc-2", "status", "processing"))
+            .toCompletableFuture()
+            .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingWorkerStatusListener.completedWorkerIds)
+                    .as("onWorkerCompleted must be called after worker finishes successfully")
+                    .isNotEmpty());
+
+    assertThat(RecordingWorkerStatusListener.lastCompletedResult)
+        .as("completed result must carry the output and workerId")
+        .isNotNull();
+    assertThat(RecordingWorkerStatusListener.lastCompletedResult.status().name())
+        .isEqualTo("COMPLETED");
+  }
+
+  @Test
+  void onWorkerStalledCalledWhenRetriesExhausted() {
+    CaseFaultedStateTest.AlwaysFailingCaseHubBean.runCount.set(0);
+    UUID caseId =
+        alwaysFailingBean.startCase(Map.of("status", "processing")).toCompletableFuture().join();
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingWorkerStatusListener.stalledWorkerIds)
+                    .as("onWorkerStalled must be called when all retries are exhausted")
+                    .isNotEmpty());
+  }
+
+  // ------------------------------------------------------------------ //
+  // WorkerContextProvider                                                //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void buildContextCalledBeforeWorkerScheduling() {
+    UUID caseId =
+        simpleCaseHubBean
+            .startCase(Map.of("documentId", "doc-3", "status", "processing"))
+            .toCompletableFuture()
+            .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingWorkerContextProvider.buildContextCallCount.get())
+                    .as("buildContext must be called at least once when a worker is scheduled")
+                    .isGreaterThan(0));
+  }
+
+  @Test
+  void buildContextReceivesCorrectCapabilityName() {
+    UUID caseId =
+        simpleCaseHubBean
+            .startCase(Map.of("documentId", "doc-4", "status", "processing"))
+            .toCompletableFuture()
+            .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingWorkerContextProvider.seenCapabilities)
+                    .as("buildContext must receive the binding's capability name")
+                    .contains("processDocument"));
+  }
+
+  // ------------------------------------------------------------------ //
+  // CaseChannelProvider                                                  //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void openChannelCalledWhenCaseStarts() {
+    UUID caseId =
+        simpleCaseHubBean
+            .startCase(Map.of("documentId", "doc-5", "status", "processing"))
+            .toCompletableFuture()
+            .join();
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingCaseChannelProvider.openedCaseIds)
+                    .as("openChannel must be called when a case starts")
+                    .contains(caseId));
+  }
+
+  @Test
+  void closeChannelCalledWhenCaseReachesTerminalState() {
+    UUID caseId =
+        simpleCaseHubBean
+            .startCase(Map.of("documentId", "doc-6", "status", "processing"))
+            .toCompletableFuture()
+            .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .isEqualTo(CaseStatus.COMPLETED));
+
+    assertThat(RecordingCaseChannelProvider.closedCaseIds)
+        .as("closeChannel must be called when a case reaches a terminal state")
+        .contains(caseId);
+  }
+
+  // ------------------------------------------------------------------ //
+  // Recording SPI implementations                                        //
+  // ------------------------------------------------------------------ //
+
+  @Alternative
+  @Priority(1)
+  @ApplicationScoped
+  public static class RecordingWorkerStatusListener implements WorkerStatusListener {
+
+    static final List<String> startedWorkerIds = new CopyOnWriteArrayList<>();
+    static final List<String> completedWorkerIds = new CopyOnWriteArrayList<>();
+    static final List<String> stalledWorkerIds = new CopyOnWriteArrayList<>();
+    static volatile WorkResult lastCompletedResult;
+
+    static void reset() {
+      startedWorkerIds.clear();
+      completedWorkerIds.clear();
+      stalledWorkerIds.clear();
+      lastCompletedResult = null;
+    }
+
+    @Override
+    public void onWorkerStarted(String workerId, Map<String, String> sessionMeta) {
+      startedWorkerIds.add(workerId);
+    }
+
+    @Override
+    public void onWorkerCompleted(String workerId, WorkResult result) {
+      completedWorkerIds.add(workerId);
+      lastCompletedResult = result;
+    }
+
+    @Override
+    public void onWorkerStalled(String workerId) {
+      stalledWorkerIds.add(workerId);
+    }
+  }
+
+  @Alternative
+  @Priority(1)
+  @ApplicationScoped
+  public static class RecordingWorkerContextProvider implements WorkerContextProvider {
+
+    static final AtomicInteger buildContextCallCount = new AtomicInteger(0);
+    static final Set<String> seenCapabilities = ConcurrentHashMap.newKeySet();
+
+    static void reset() {
+      buildContextCallCount.set(0);
+      seenCapabilities.clear();
+    }
+
+    @Override
+    public WorkerContext buildContext(String workerId, WorkRequest task) {
+      buildContextCallCount.incrementAndGet();
+      seenCapabilities.add(task.capability());
+      return new WorkerContext(task.capability(), null, null, List.of(), null, Map.of());
+    }
+  }
+
+  @Alternative
+  @Priority(1)
+  @ApplicationScoped
+  public static class RecordingCaseChannelProvider implements CaseChannelProvider {
+
+    static final Set<UUID> openedCaseIds = ConcurrentHashMap.newKeySet();
+    static final Set<UUID> closedCaseIds = ConcurrentHashMap.newKeySet();
+    // NOT thread-safe — only used within a single case's lifecycle
+    private final Map<UUID, List<CaseChannel>> openChannels = new ConcurrentHashMap<>();
+
+    static void reset() {
+      openedCaseIds.clear();
+      closedCaseIds.clear();
+    }
+
+    @Override
+    public CaseChannel openChannel(UUID caseId, String purpose) {
+      openedCaseIds.add(caseId);
+      CaseChannel channel =
+          new CaseChannel(caseId + "/" + purpose, purpose, purpose, "none", Map.of());
+      openChannels.computeIfAbsent(caseId, id -> new CopyOnWriteArrayList<>()).add(channel);
+      return channel;
+    }
+
+    @Override
+    public void postToChannel(CaseChannel channel, String from, String content) {}
+
+    @Override
+    public void closeChannel(CaseChannel channel) {
+      // channel id is caseId/purpose — extract caseId prefix
+      String id = channel.id();
+      int slash = id.indexOf('/');
+      if (slash > 0) {
+        try {
+          closedCaseIds.add(UUID.fromString(id.substring(0, slash)));
+        } catch (IllegalArgumentException ignored) {
+        }
+      }
+    }
+
+    @Override
+    public List<CaseChannel> listChannels(UUID caseId) {
+      return openChannels.getOrDefault(caseId, List.of());
+    }
+  }
+}

--- a/engine/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
@@ -221,10 +221,16 @@ public class WorkerRetryExtendedTest {
                     failCount + 1,
                     FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
 
-    assertEquals(
-        failCount,
-        findEvents(caseId, CaseHubEventType.WORKER_EXECUTION_FAILED).size(),
-        "One WORKER_EXECUTION_FAILED entry must exist per failed attempt");
+    // Fold event log assertion into await — the DB write is async and may not
+    // have committed by the time the attempt counter reaches failCount+1.
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    failCount,
+                    findEvents(caseId, CaseHubEventType.WORKER_EXECUTION_FAILED).size(),
+                    "One WORKER_EXECUTION_FAILED entry must exist per failed attempt"));
   }
 
   /**
@@ -276,11 +282,16 @@ public class WorkerRetryExtendedTest {
                 assertEquals(
                     3, FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
 
-    List<EventLog> scheduledEvents = findWorkerEvents(caseId, CaseHubEventType.WORKER_SCHEDULED);
-    assertEquals(
-        1,
-        scheduledEvents.size(),
-        "Exactly one WORKER_SCHEDULED row must exist regardless of retry count");
+    // Fold event log assertion into await — the DB write is async and may not
+    // have committed by the time the attempt counter reaches 3.
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    findWorkerEvents(caseId, CaseHubEventType.WORKER_SCHEDULED).size(),
+                    "Exactly one WORKER_SCHEDULED row must exist regardless of retry count"));
   }
 
   /** WORKER_EXECUTION_COMPLETED must appear exactly once even after multiple failed attempts. */
@@ -299,10 +310,16 @@ public class WorkerRetryExtendedTest {
                 assertEquals(
                     3, FlexibleRetryBean.attempts.getOrDefault(taskId, new AtomicInteger()).get()));
 
-    assertEquals(
-        1,
-        findWorkerEvents(caseId, CaseHubEventType.WORKER_EXECUTION_COMPLETED).size(),
-        "Exactly one WORKER_EXECUTION_COMPLETED entry must exist after retry success");
+    // Fold event log assertion into await — the DB write is async and may not
+    // have committed by the time the attempt counter reaches 3.
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    1,
+                    findWorkerEvents(caseId, CaseHubEventType.WORKER_EXECUTION_COMPLETED).size(),
+                    "Exactly one WORKER_EXECUTION_COMPLETED entry must exist after retry success"));
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -91,27 +91,8 @@
         <module>casehub-ledger</module>
     </modules>
 
-    <repositories>
-        <repository>
-            <id>github-casehubio</id>
-            <name>casehubio GitHub Packages</name>
-            <url>https://maven.pkg.github.com/casehubio/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
-            <!-- casehub-parent BOM — manages all casehubio artifact versions -->
-            <dependency>
-                <groupId>io.casehubio</groupId>
-                <artifactId>casehub-parent</artifactId>
-                <version>0.2-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,27 @@
         <module>casehub-ledger</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>casehubio GitHub Packages</name>
+            <url>https://maven.pkg.github.com/casehubio/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
+            <!-- casehub-parent BOM — manages quarkus-ledger and quarkus-work versions -->
+            <dependency>
+                <groupId>io.casehubio</groupId>
+                <artifactId>casehub-parent</artifactId>
+                <version>0.2-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,14 +104,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- casehub-parent BOM — manages quarkus-ledger and quarkus-work versions -->
-            <dependency>
-                <groupId>io.casehubio</groupId>
-                <artifactId>casehub-parent</artifactId>
-                <version>0.2-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>
@@ -162,6 +154,15 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>mockwebserver</artifactId>
                 <version>${version.com.squareup.okhttp3.mockwebserver}</version>
+            </dependency>
+            <!-- casehub-parent BOM last — provides quarkus-ledger and quarkus-work versions
+                 without overriding casehub-engine's own Quarkus/serverlessworkflow versions -->
+            <dependency>
+                <groupId>io.casehubio</groupId>
+                <artifactId>casehub-parent</artifactId>
+                <version>0.2-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <module>casehub-resilience</module>
         <module>casehub-ledger</module>
         <module>casehub-testing</module>
+        <module>casehub-work-adapter</module>
     </modules>
 
     <repositories>
@@ -174,6 +175,11 @@
             <dependency>
                 <groupId>io.quarkiverse.work</groupId>
                 <artifactId>quarkus-work-core</artifactId>
+                <version>${version.io.quarkiverse.work}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.work</groupId>
+                <artifactId>quarkus-work</artifactId>
                 <version>${version.io.quarkiverse.work}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <module>casehub-blackboard</module>
         <module>casehub-resilience</module>
         <module>casehub-ledger</module>
+        <module>casehub-testing</module>
     </modules>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,7 @@
             <id>github</id>
             <name>casehubio GitHub Packages</name>
             <url>https://maven.pkg.github.com/casehubio/casehub-engine</url>
+            <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
         <version.io.quarkiverse.work>0.2-SNAPSHOT</version.io.quarkiverse.work>
         <version.io.quarkiverse.ledger>0.2-SNAPSHOT</version.io.quarkiverse.ledger>
 
+        <!-- Skip deploying the root aggregator POM — it is not a consumable artifact.
+             Sub-modules override this to publish their own JARs. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+
         <version.com.squareup.okhttp3.mockwebserver>5.3.2</version.com.squareup.okhttp3.mockwebserver>
         <version.io.quarkiverse.langchain4j>1.5.0</version.io.quarkiverse.langchain4j>
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,15 +155,6 @@
                 <artifactId>mockwebserver</artifactId>
                 <version>${version.com.squareup.okhttp3.mockwebserver}</version>
             </dependency>
-            <!-- casehub-parent BOM last — provides quarkus-ledger and quarkus-work versions
-                 without overriding casehub-engine's own Quarkus/serverlessworkflow versions -->
-            <dependency>
-                <groupId>io.casehubio</groupId>
-                <artifactId>casehub-parent</artifactId>
-                <version>0.2-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <version.jakarta.inject>2.0.1</version.jakarta.inject>
         <version.org.jsonschema2pojo>1.3.3</version.org.jsonschema2pojo>
 
-        <version.quarkus.platform>3.31.1</version.quarkus.platform>
+        <version.quarkus.platform>3.32.2</version.quarkus.platform>
         <version.quarkus.flow>0.6.0</version.quarkus.flow>
         <version.io.fabric8.zjsonpatch>7.5.2</version.io.fabric8.zjsonpatch>
         <version.io.serverlessworkflow>7.13.4.Final</version.io.serverlessworkflow>
@@ -432,5 +432,18 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>casehubio GitHub Packages</name>
+            <url>https://maven.pkg.github.com/casehubio/casehub-engine</url>
+        </repository>
+        <snapshotRepository>
+            <id>github</id>
+            <name>casehubio GitHub Packages</name>
+            <url>https://maven.pkg.github.com/casehubio/casehub-engine</url>
+        </snapshotRepository>
+    </distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
         <version.io.fabric8.zjsonpatch>7.5.2</version.io.fabric8.zjsonpatch>
         <version.io.serverlessworkflow>7.13.4.Final</version.io.serverlessworkflow>
 
+        <!-- casehubio ecosystem dependencies — aligned on same version as this project -->
+        <version.io.quarkiverse.work>0.2-SNAPSHOT</version.io.quarkiverse.work>
+        <version.io.quarkiverse.ledger>0.2-SNAPSHOT</version.io.quarkiverse.ledger>
+
         <version.com.squareup.okhttp3.mockwebserver>5.3.2</version.com.squareup.okhttp3.mockwebserver>
         <version.io.quarkiverse.langchain4j>1.5.0</version.io.quarkiverse.langchain4j>
 
@@ -154,6 +158,23 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>mockwebserver</artifactId>
                 <version>${version.com.squareup.okhttp3.mockwebserver}</version>
+            </dependency>
+
+            <!-- casehubio ecosystem -->
+            <dependency>
+                <groupId>io.quarkiverse.work</groupId>
+                <artifactId>quarkus-work-api</artifactId>
+                <version>${version.io.quarkiverse.work}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.work</groupId>
+                <artifactId>quarkus-work-core</artifactId>
+                <version>${version.io.quarkiverse.work}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.ledger</groupId>
+                <artifactId>quarkus-ledger</artifactId>
+                <version>${version.io.quarkiverse.ledger}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,27 @@
         <module>casehub-ledger</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>github-casehubio</id>
+            <name>casehubio GitHub Packages</name>
+            <url>https://maven.pkg.github.com/casehubio/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
+            <!-- casehub-parent BOM — manages all casehubio artifact versions -->
+            <dependency>
+                <groupId>io.casehubio</groupId>
+                <artifactId>casehub-parent</artifactId>
+                <version>0.2-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>


### PR DESCRIPTION
## Summary

- **ci:** Fork CI was failing because `GITHUB_TOKEN` on forks cannot write to `casehubio/engine` packages. Workflow now deploys only on upstream main; forks get verify-only
- **fix:** Pass `caseId` in `onWorkerStarted` sessionMeta — was passing `null`, breaking Claudony's worker correlation (Refs casehubio/claudony#90)
- **docs:** ADR-0006 — worker registration as normative act; applies Qhorus four-layer framework to worker discovery/trust lineage
- **docs:** CLAUDE.md platform coherence protocol and cross-repo deep-dive URLs
- **chore:** Remove dead `workerContextProvider.buildContext()` call in `WorkerScheduleEventHandler` — result was discarded; will be called properly during provisioner wiring

## Test plan

- [ ] CI passes on fork (verify-only, no deploy attempt)
- [ ] CI passes on upstream after merge (build + test + deploy)
- [ ] `onWorkerStarted` sessionMeta contains `caseId` key

🤖 Generated with [Claude Code](https://claude.ai/claude-code)