### PR TITLE
ci: verify-only on forks, deploy only on upstream main

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,14 +29,14 @@ jobs:
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
-      - name: Build and test (PR)
-        if: github.event_name == 'pull_request'
+      - name: Build and test (PR or fork push)
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository != 'casehubio/casehub-engine')
         run: mvn --batch-mode verify
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build, test and publish (main)
-        if: github.event_name == 'push'
+      - name: Build, test and publish (upstream main)
+        if: github.event_name == 'push' && github.repository == 'casehubio/casehub-engine'
         run: mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #168

Fork CI was failing because `GITHUB_TOKEN` on a fork cannot write to `casehubio/engine` packages. This caused all pushes to `mdproctor/engine` to fail at the deploy step even though tests passed.

**Change:** `maven.yml` now distinguishes upstream from forks via `github.repository`. Only `casehubio/engine` runs `deploy`; any other repo (fork) runs `verify` (build + test only).

## Test plan
- [ ] CI passes on fork push (verify-only, no deploy attempt)
- [ ] CI passes on upstream after merge (build + test + deploy)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)