### PR TITLE
fix: null guard CaseContextChangedEventHandler when CaseMetaModel is null

### DIFF
--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -79,7 +79,8 @@ public class CaseContextChangedEventHandler {
     }
 
     CaseMetaModel caseMetaModel = caseInstance.getCaseMetaModel();
-    CaseDefinition caseefinition = caseDefinitionRegistry.getCaseDefinition(caseMetaModel);
+    CaseDefinition caseefinition =
+        caseMetaModel != null ? caseDefinitionRegistry.getCaseDefinition(caseMetaModel) : null;
 
     if (caseefinition == null) {
       return Uni.createFrom()


### PR DESCRIPTION
Closes #172
Refs casehubio/claudony#82

`getCaseMetaModel()` can return null before the model is initialised. The handler called `ConcurrentHashMap.get()` on null, throwing NPE. Added null guard.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)