### PR TITLE
feat: add casehub-testing module — in-memory CaseEngine for @QuarkusTest

### DIFF
--- a/casehub-testing/pom.xml
+++ b/casehub-testing/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.casehub</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>casehub-testing</artifactId>
+    <name>Case Hub :: Testing</name>
+    <description>In-memory CaseEngine setup for consumer @QuarkusTest classes — no PostgreSQL, no Docker required</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-persistence-memory</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/casehub-testing/src/main/java/io/casehub/testing/TestCaseInstanceRepository.java
+++ b/casehub-testing/src/main/java/io/casehub/testing/TestCaseInstanceRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.testing;
+
+import io.casehub.persistence.memory.InMemoryCaseInstanceRepository;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * Auto-selected in-memory {@link io.casehub.engine.spi.CaseInstanceRepository} for
+ * {@code @QuarkusTest}.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class TestCaseInstanceRepository extends InMemoryCaseInstanceRepository {}

--- a/casehub-testing/src/main/java/io/casehub/testing/TestCaseMetaModelRepository.java
+++ b/casehub-testing/src/main/java/io/casehub/testing/TestCaseMetaModelRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.testing;
+
+import io.casehub.persistence.memory.InMemoryCaseMetaModelRepository;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * Auto-selected in-memory {@link io.casehub.engine.spi.CaseMetaModelRepository} for
+ * {@code @QuarkusTest}.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class TestCaseMetaModelRepository extends InMemoryCaseMetaModelRepository {}

--- a/casehub-testing/src/main/java/io/casehub/testing/TestEventLogRepository.java
+++ b/casehub-testing/src/main/java/io/casehub/testing/TestEventLogRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.testing;
+
+import io.casehub.persistence.memory.InMemoryEventLogRepository;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * Auto-selected in-memory {@link io.casehub.engine.spi.EventLogRepository} for
+ * {@code @QuarkusTest}.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class TestEventLogRepository extends InMemoryEventLogRepository {}

--- a/casehub-testing/src/main/java/io/casehub/testing/WorkResultSubmitter.java
+++ b/casehub-testing/src/main/java/io/casehub/testing/WorkResultSubmitter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.testing;
+
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.engine.CaseDefinitionRegistry;
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Test helper that simulates a provisioned worker completing its work.
+ *
+ * <p>Use this when the case uses a {@link io.casehub.api.spi.WorkerProvisioner} that provisions
+ * external workers — inject this bean in your {@code @QuarkusTest} and call {@link #complete(UUID,
+ * String, Map)} to drive the engine forward without a real worker process.
+ *
+ * <pre>{@code
+ * workResultSubmitter.complete(caseId, "my-worker", Map.of("result", "done"))
+ *     .await().atMost(Duration.ofSeconds(5));
+ * }</pre>
+ */
+@ApplicationScoped
+public class WorkResultSubmitter {
+
+  @Inject CaseInstanceRepository caseInstanceRepository;
+
+  @Inject CaseDefinitionRegistry caseDefinitionRegistry;
+
+  @Inject EventBus eventBus;
+
+  public Uni<Void> complete(UUID caseId, String workerId, Map<String, Object> output) {
+    return caseInstanceRepository
+        .findByUuid(caseId)
+        .map(
+            instance -> {
+              var definition =
+                  caseDefinitionRegistry.getCaseDefinition(instance.getCaseMetaModel());
+              Worker worker =
+                  definition.getWorkers().stream()
+                      .filter(w -> w.getName().equals(workerId))
+                      .findFirst()
+                      .orElseThrow(
+                          () ->
+                              new IllegalArgumentException(
+                                  "Worker not found in case definition: " + workerId));
+              String idempotency = UUID.randomUUID().toString();
+              eventBus.publish(
+                  EventBusAddresses.WORKER_EXECUTION_FINISHED,
+                  new WorkflowExecutionCompleted(instance, worker, idempotency, output));
+              return (Void) null;
+            });
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <module>casehub-blackboard</module>
         <module>casehub-resilience</module>
         <module>casehub-ledger</module>
+        <module>casehub-testing</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
Closes #170

Adds `casehub-testing` artifact providing `@Alternative @Priority(1)` in-memory repository implementations (`TestCaseInstanceRepository`, `TestCaseMetaModelRepository`, `TestEventLogRepository`) and `WorkResultSubmitter`. Downstream modules can write `@QuarkusTest` against CaseEngine without Postgres or Docker.

## Test plan
- [ ] Module builds and installs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)