### PR TITLE
feat: idempotency window — configurable dedup TTL for WorkerScheduleEventHandler

### DIFF
--- a/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/SubCase.java
+++ b/casehub-blackboard/src/main/java/io/casehub/blackboard/stage/SubCase.java
@@ -18,14 +18,17 @@ package io.casehub.blackboard.stage;
 import java.util.Objects;
 
 /**
- * Identifies a child case definition to launch as part of a Stage's work. Data model only — full
- * engine integration in future epic. See casehubio/engine#76.
+ * Identifies a child case definition to launch as part of a Stage's work. SubCase binding wiring:
+ * casehubio/engine#195.
  */
 public class SubCase {
   private final String namespace;
   private final String name;
   private final String version;
   private final SubCaseCompletionStrategy completionStrategy;
+  private final boolean waitForCompletion;
+  private final String inputMapping;
+  private final String outputMapping;
 
   private SubCase(Builder b) {
     this.namespace = Objects.requireNonNull(b.namespace, "namespace");
@@ -35,6 +38,9 @@ public class SubCase {
         b.completionStrategy != null
             ? b.completionStrategy
             : new DefaultSubCaseCompletionStrategy();
+    this.waitForCompletion = b.waitForCompletion;
+    this.inputMapping = b.inputMapping != null ? b.inputMapping : ".";
+    this.outputMapping = b.outputMapping;
   }
 
   public String namespace() {
@@ -53,6 +59,18 @@ public class SubCase {
     return completionStrategy;
   }
 
+  public boolean waitForCompletion() {
+    return waitForCompletion;
+  }
+
+  public String inputMapping() {
+    return inputMapping;
+  }
+
+  public String outputMapping() {
+    return outputMapping;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -62,6 +80,9 @@ public class SubCase {
     private String name;
     private String version;
     private SubCaseCompletionStrategy completionStrategy;
+    private boolean waitForCompletion = true;
+    private String inputMapping;
+    private String outputMapping;
 
     public Builder namespace(String v) {
       namespace = v;
@@ -80,6 +101,21 @@ public class SubCase {
 
     public Builder completionStrategy(SubCaseCompletionStrategy s) {
       completionStrategy = s;
+      return this;
+    }
+
+    public Builder waitForCompletion(boolean v) {
+      waitForCompletion = v;
+      return this;
+    }
+
+    public Builder inputMapping(String v) {
+      inputMapping = v;
+      return this;
+    }
+
+    public Builder outputMapping(String v) {
+      outputMapping = v;
       return this;
     }
 

--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/SubCaseTest.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/stage/SubCaseTest.java
@@ -85,4 +85,43 @@ class SubCaseTest {
     plan.addSubCase(sc);
     assertThat(plan.getSubCases()).containsExactly(sc);
   }
+
+  @Test
+  void builder_defaultWaitForCompletion_isTrue() {
+    SubCase sc = SubCase.builder().namespace("ns").name("n").version("1.0").build();
+    assertThat(sc.waitForCompletion()).isTrue();
+  }
+
+  @Test
+  void builder_waitForCompletionFalse_stored() {
+    SubCase sc =
+        SubCase.builder().namespace("ns").name("n").version("1.0").waitForCompletion(false).build();
+    assertThat(sc.waitForCompletion()).isFalse();
+  }
+
+  @Test
+  void builder_inputMapping_defaultIdentity() {
+    SubCase sc = SubCase.builder().namespace("ns").name("n").version("1.0").build();
+    assertThat(sc.inputMapping()).isEqualTo(".");
+  }
+
+  @Test
+  void builder_outputMapping_defaultNull() {
+    SubCase sc = SubCase.builder().namespace("ns").name("n").version("1.0").build();
+    assertThat(sc.outputMapping()).isNull();
+  }
+
+  @Test
+  void builder_customMappings_stored() {
+    SubCase sc =
+        SubCase.builder()
+            .namespace("ns")
+            .name("n")
+            .version("1.0")
+            .inputMapping("{ id: .caseId }")
+            .outputMapping("{ result: .childResult }")
+            .build();
+    assertThat(sc.inputMapping()).isEqualTo("{ id: .caseId }");
+    assertThat(sc.outputMapping()).isEqualTo("{ result: .childResult }");
+  }
 }

--- a/casehub-blackboard/src/test/java/io/casehub/persistence/memory/InMemoryEventLogRepository.java
+++ b/casehub-blackboard/src/test/java/io/casehub/persistence/memory/InMemoryEventLogRepository.java
@@ -21,6 +21,7 @@ import io.casehub.engine.spi.EventLogRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -58,7 +59,7 @@ public class InMemoryEventLogRepository implements EventLogRepository {
   }
 
   @Override
-  public Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId) {
+  public Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId, Instant after) {
     List<EventLog> result =
         store.values().stream()
             .filter(e -> caseId.equals(e.getCaseId()) && workerId.equals(e.getWorkerId()))
@@ -67,6 +68,7 @@ public class InMemoryEventLogRepository implements EventLogRepository {
                     e.getEventType() == CaseHubEventType.WORKER_SCHEDULED
                         || e.getEventType() == CaseHubEventType.WORKER_EXECUTION_STARTED
                         || e.getEventType() == CaseHubEventType.WORKER_EXECUTION_COMPLETED)
+            .filter(e -> after == null || e.getTimestamp().isAfter(after))
             .toList();
     return Uni.createFrom().item(result);
   }

--- a/casehub-engine-common/src/main/java/io/casehub/engine/spi/EventLogRepository.java
+++ b/casehub-engine-common/src/main/java/io/casehub/engine/spi/EventLogRepository.java
@@ -18,6 +18,7 @@ package io.casehub.engine.spi;
 import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
 import io.smallrye.mutiny.Uni;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -41,9 +42,18 @@ public interface EventLogRepository {
 
   /**
    * Find all scheduling-lifecycle events (WORKER_SCHEDULED, WORKER_EXECUTION_STARTED,
-   * WORKER_EXECUTION_COMPLETED) for the given case and worker, ordered by seq ascending.
+   * WORKER_EXECUTION_COMPLETED) for the given case and worker, ordered by seq ascending. When
+   * {@code after} is non-null, only events with {@code timestamp > after} are returned.
    */
-  Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId);
+  Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId, Instant after);
+
+  /**
+   * Convenience overload with no time cutoff — equivalent to {@code findSchedulingEvents(caseId,
+   * workerId, null)}.
+   */
+  default Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId) {
+    return findSchedulingEvents(caseId, workerId, null);
+  }
 
   /**
    * Find all events matching the given types across all cases, ordered by seq ascending. Used by

--- a/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaEventLogRepository.java
+++ b/casehub-persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaEventLogRepository.java
@@ -21,6 +21,7 @@ import io.casehub.engine.spi.EventLogRepository;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -66,19 +67,33 @@ public class JpaEventLogRepository extends AbstractJpaRepository implements Even
   }
 
   @Override
-  public Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId) {
+  public Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId, Instant after) {
     return withSafeContext(
         () ->
             Panache.withSession(
-                    () ->
-                        EventLogEntity.<EventLogEntity>find(
+                    () -> {
+                      if (after == null) {
+                        return EventLogEntity.<EventLogEntity>find(
                                 "caseId = ?1 and workerId = ?2 and eventType in (?3, ?4, ?5)",
                                 caseId,
                                 workerId,
                                 CaseHubEventType.WORKER_SCHEDULED,
                                 CaseHubEventType.WORKER_EXECUTION_STARTED,
                                 CaseHubEventType.WORKER_EXECUTION_COMPLETED)
-                            .list())
+                            .list();
+                      } else {
+                        return EventLogEntity.<EventLogEntity>find(
+                                "caseId = ?1 and workerId = ?2 and eventType in (?3, ?4, ?5)"
+                                    + " and timestamp > ?6",
+                                caseId,
+                                workerId,
+                                CaseHubEventType.WORKER_SCHEDULED,
+                                CaseHubEventType.WORKER_EXECUTION_STARTED,
+                                CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                                after)
+                            .list();
+                      }
+                    })
                 .map(list -> list.stream().map(this::fromEntity).toList()));
   }
 

--- a/casehub-persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaEventLogRepositoryTest.java
+++ b/casehub-persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaEventLogRepositoryTest.java
@@ -219,7 +219,7 @@ class JpaEventLogRepositoryTest {
   }
 
   @Test
-  void findSchedulingEvents_withNullCutoff_returnsAll() {
+  void findSchedulingEvents_withNullAfter_returnsAll() {
     UUID caseId = UUID.randomUUID();
 
     EventLog e1 = new EventLog();

--- a/casehub-persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaEventLogRepositoryTest.java
+++ b/casehub-persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaEventLogRepositoryTest.java
@@ -36,6 +36,9 @@ class JpaEventLogRepositoryTest {
 
   @Inject EventLogRepository repository;
 
+  private static final com.fasterxml.jackson.databind.ObjectMapper OBJECT_MAPPER =
+      new com.fasterxml.jackson.databind.ObjectMapper();
+
   @Test
   void append_populatesIdAndSeq() {
     EventLog log = workerScheduled(UUID.randomUUID(), "worker-1");
@@ -185,6 +188,60 @@ class JpaEventLogRepositoryTest {
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getWorkerId()).isEqualTo(workerId);
     assertThat(result.get(0).getEventType()).isEqualTo(CaseHubEventType.WORKER_EXECUTION_FAILED);
+  }
+
+  @Test
+  void findSchedulingEvents_withAfterCutoff_excludesOlderEvents() {
+    UUID caseId = UUID.randomUUID();
+    Instant cutoff = Instant.now().minusSeconds(60);
+
+    EventLog old = new EventLog();
+    old.setCaseId(caseId);
+    old.setWorkerId("w-old");
+    old.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    old.setStreamType(EventStreamType.CASE);
+    old.setTimestamp(Instant.now().minusSeconds(120));
+    old.setMetadata(OBJECT_MAPPER.createObjectNode().put("inputDataHash", "hash-old"));
+    run(() -> repository.append(old));
+
+    EventLog recent = new EventLog();
+    recent.setCaseId(caseId);
+    recent.setWorkerId("w-old");
+    recent.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    recent.setStreamType(EventStreamType.CASE);
+    recent.setTimestamp(Instant.now());
+    recent.setMetadata(OBJECT_MAPPER.createObjectNode().put("inputDataHash", "hash-recent"));
+    run(() -> repository.append(recent));
+
+    List<EventLog> result = run(() -> repository.findSchedulingEvents(caseId, "w-old", cutoff));
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getTimestamp()).isAfter(cutoff);
+  }
+
+  @Test
+  void findSchedulingEvents_withNullCutoff_returnsAll() {
+    UUID caseId = UUID.randomUUID();
+
+    EventLog e1 = new EventLog();
+    e1.setCaseId(caseId);
+    e1.setWorkerId("w-null");
+    e1.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    e1.setStreamType(EventStreamType.CASE);
+    e1.setTimestamp(Instant.now().minusSeconds(120));
+    e1.setMetadata(OBJECT_MAPPER.createObjectNode().put("inputDataHash", "h1"));
+    run(() -> repository.append(e1));
+
+    EventLog e2 = new EventLog();
+    e2.setCaseId(caseId);
+    e2.setWorkerId("w-null");
+    e2.setEventType(CaseHubEventType.WORKER_EXECUTION_STARTED);
+    e2.setStreamType(EventStreamType.CASE);
+    e2.setTimestamp(Instant.now());
+    e2.setMetadata(OBJECT_MAPPER.createObjectNode().put("inputDataHash", "h1"));
+    run(() -> repository.append(e2));
+
+    List<EventLog> result = run(() -> repository.findSchedulingEvents(caseId, "w-null", null));
+    assertThat(result).hasSize(2);
   }
 
   private <T> T run(Supplier<Uni<T>> supplier) {

--- a/casehub-persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaEventLogRepositoryTest.java
+++ b/casehub-persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaEventLogRepositoryTest.java
@@ -17,6 +17,7 @@ package io.casehub.persistence.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.history.EventStreamType;
@@ -36,8 +37,7 @@ class JpaEventLogRepositoryTest {
 
   @Inject EventLogRepository repository;
 
-  private static final com.fasterxml.jackson.databind.ObjectMapper OBJECT_MAPPER =
-      new com.fasterxml.jackson.databind.ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Test
   void append_populatesIdAndSeq() {

--- a/casehub-persistence-memory/src/main/java/io/casehub/persistence/memory/InMemoryEventLogRepository.java
+++ b/casehub-persistence-memory/src/main/java/io/casehub/persistence/memory/InMemoryEventLogRepository.java
@@ -21,6 +21,7 @@ import io.casehub.engine.spi.EventLogRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -86,7 +87,7 @@ public class InMemoryEventLogRepository implements EventLogRepository {
   }
 
   @Override
-  public Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId) {
+  public Uni<List<EventLog>> findSchedulingEvents(UUID caseId, String workerId, Instant after) {
     rwLock.readLock().lock();
     try {
       List<EventLog> result =
@@ -97,6 +98,7 @@ public class InMemoryEventLogRepository implements EventLogRepository {
                       e.getEventType() == CaseHubEventType.WORKER_SCHEDULED
                           || e.getEventType() == CaseHubEventType.WORKER_EXECUTION_STARTED
                           || e.getEventType() == CaseHubEventType.WORKER_EXECUTION_COMPLETED)
+              .filter(e -> after == null || e.getTimestamp().isAfter(after))
               .toList();
       return Uni.createFrom().item(result);
     } finally {

--- a/casehub-persistence-memory/src/test/java/io/casehub/persistence/memory/InMemoryEventLogRepositoryTest.java
+++ b/casehub-persistence-memory/src/test/java/io/casehub/persistence/memory/InMemoryEventLogRepositoryTest.java
@@ -17,6 +17,7 @@ package io.casehub.persistence.memory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.engine.internal.history.CaseHubEventType;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.history.EventStreamType;
@@ -222,10 +223,7 @@ class InMemoryEventLogRepositoryTest {
     old.setEventType(CaseHubEventType.WORKER_SCHEDULED);
     old.setStreamType(EventStreamType.CASE);
     old.setTimestamp(Instant.now().minusSeconds(120));
-    old.setMetadata(
-        new com.fasterxml.jackson.databind.ObjectMapper()
-            .createObjectNode()
-            .put("inputDataHash", "h-old"));
+    old.setMetadata(new ObjectMapper().createObjectNode().put("inputDataHash", "h-old"));
     repository.append(old).await().indefinitely();
 
     // recent event — after cutoff
@@ -235,10 +233,7 @@ class InMemoryEventLogRepositoryTest {
     recent.setEventType(CaseHubEventType.WORKER_SCHEDULED);
     recent.setStreamType(EventStreamType.CASE);
     recent.setTimestamp(Instant.now());
-    recent.setMetadata(
-        new com.fasterxml.jackson.databind.ObjectMapper()
-            .createObjectNode()
-            .put("inputDataHash", "h-recent"));
+    recent.setMetadata(new ObjectMapper().createObjectNode().put("inputDataHash", "h-recent"));
     repository.append(recent).await().indefinitely();
 
     List<EventLog> result =
@@ -258,10 +253,7 @@ class InMemoryEventLogRepositoryTest {
     e1.setEventType(CaseHubEventType.WORKER_SCHEDULED);
     e1.setStreamType(EventStreamType.CASE);
     e1.setTimestamp(Instant.now().minusSeconds(120));
-    e1.setMetadata(
-        new com.fasterxml.jackson.databind.ObjectMapper()
-            .createObjectNode()
-            .put("inputDataHash", "h1"));
+    e1.setMetadata(new ObjectMapper().createObjectNode().put("inputDataHash", "h1"));
     repository.append(e1).await().indefinitely();
 
     EventLog e2 = new EventLog();
@@ -270,10 +262,7 @@ class InMemoryEventLogRepositoryTest {
     e2.setEventType(CaseHubEventType.WORKER_EXECUTION_STARTED);
     e2.setStreamType(EventStreamType.CASE);
     e2.setTimestamp(Instant.now());
-    e2.setMetadata(
-        new com.fasterxml.jackson.databind.ObjectMapper()
-            .createObjectNode()
-            .put("inputDataHash", "h1"));
+    e2.setMetadata(new ObjectMapper().createObjectNode().put("inputDataHash", "h1"));
     repository.append(e2).await().indefinitely();
 
     List<EventLog> result =

--- a/casehub-persistence-memory/src/test/java/io/casehub/persistence/memory/InMemoryEventLogRepositoryTest.java
+++ b/casehub-persistence-memory/src/test/java/io/casehub/persistence/memory/InMemoryEventLogRepositoryTest.java
@@ -210,6 +210,78 @@ class InMemoryEventLogRepositoryTest {
     assertThat(a.getSeq()).isNotEqualTo(b.getSeq());
   }
 
+  @Test
+  void findSchedulingEvents_withAfterCutoff_excludesOlderEvents() {
+    UUID caseId = UUID.randomUUID();
+    Instant cutoff = Instant.now().minusSeconds(60);
+
+    // old event — before cutoff
+    EventLog old = new EventLog();
+    old.setCaseId(caseId);
+    old.setWorkerId("w1");
+    old.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    old.setStreamType(EventStreamType.CASE);
+    old.setTimestamp(Instant.now().minusSeconds(120));
+    old.setMetadata(
+        new com.fasterxml.jackson.databind.ObjectMapper()
+            .createObjectNode()
+            .put("inputDataHash", "h-old"));
+    repository.append(old).await().indefinitely();
+
+    // recent event — after cutoff
+    EventLog recent = new EventLog();
+    recent.setCaseId(caseId);
+    recent.setWorkerId("w1");
+    recent.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    recent.setStreamType(EventStreamType.CASE);
+    recent.setTimestamp(Instant.now());
+    recent.setMetadata(
+        new com.fasterxml.jackson.databind.ObjectMapper()
+            .createObjectNode()
+            .put("inputDataHash", "h-recent"));
+    repository.append(recent).await().indefinitely();
+
+    List<EventLog> result =
+        repository.findSchedulingEvents(caseId, "w1", cutoff).await().indefinitely();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getTimestamp()).isAfter(cutoff);
+  }
+
+  @Test
+  void findSchedulingEvents_withNullAfter_returnsAll() {
+    UUID caseId = UUID.randomUUID();
+
+    EventLog e1 = new EventLog();
+    e1.setCaseId(caseId);
+    e1.setWorkerId("w2");
+    e1.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    e1.setStreamType(EventStreamType.CASE);
+    e1.setTimestamp(Instant.now().minusSeconds(120));
+    e1.setMetadata(
+        new com.fasterxml.jackson.databind.ObjectMapper()
+            .createObjectNode()
+            .put("inputDataHash", "h1"));
+    repository.append(e1).await().indefinitely();
+
+    EventLog e2 = new EventLog();
+    e2.setCaseId(caseId);
+    e2.setWorkerId("w2");
+    e2.setEventType(CaseHubEventType.WORKER_EXECUTION_STARTED);
+    e2.setStreamType(EventStreamType.CASE);
+    e2.setTimestamp(Instant.now());
+    e2.setMetadata(
+        new com.fasterxml.jackson.databind.ObjectMapper()
+            .createObjectNode()
+            .put("inputDataHash", "h1"));
+    repository.append(e2).await().indefinitely();
+
+    List<EventLog> result =
+        repository.findSchedulingEvents(caseId, "w2", null).await().indefinitely();
+
+    assertThat(result).hasSize(2);
+  }
+
   // --- Helper ---
 
   private EventLog event(UUID caseId, String workerId, CaseHubEventType type) {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -77,7 +77,7 @@ casehub-engine is a **hybrid choreography+orchestration engine**. Both models sh
 
 ### Choreography (Binding-Driven)
 
-Context changes trigger binding evaluations. When a binding's condition is met, `CaseContextChangedEventHandler` builds a `WorkerCandidate` list from capable workers, calls `WorkBroker.apply()` with `LeastLoadedStrategy`, and publishes a `WorkerScheduleEvent` for the selected worker. The case remains `RUNNING` throughout.
+Context changes trigger binding evaluations. When a binding's condition is met, `CaseContextChangedEventHandler` builds a `WorkerCandidate` list from capable workers, calls `WorkBroker.apply()` with `LeastLoadedStrategy`, and publishes a `WorkerScheduleEvent` for the selected worker. The case remains `RUNNING` throughout. A configurable `casehub.idempotency.window` bounds how far back this check looks — absent means permanent dedup (default).
 
 ```
 CaseContext change
@@ -241,6 +241,10 @@ quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 # Event bus (Vert.x)
 quarkus.vertx.event-loops=16
+
+# Idempotency window (optional) — limits how far back the EventLog dedup check looks.
+# Absent = permanent dedup (default, safest). Example: 7d
+# casehub.idempotency.window=7d
 ```
 
 See `src/main/resources/application.properties` for all available options.

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -37,9 +37,12 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import io.vertx.mutiny.core.shareddata.Lock;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -57,6 +60,9 @@ public class WorkerScheduleEventHandler {
   @Inject EventBus eventBus;
 
   @Inject EventLogRepository eventLogRepository;
+
+  @ConfigProperty(name = "casehub.idempotency.window")
+  Optional<Duration> idempotencyWindow;
 
   @ConsumeEvent(value = EventBusAddresses.WORKER_SCHEDULE)
   public Uni<Void> onWorkerScheduleEventHandler(WorkerScheduleEvent event) {
@@ -103,8 +109,10 @@ public class WorkerScheduleEventHandler {
       Capability capability,
       Map<String, Object> inputData,
       String inputDataHash) {
+    Instant idempotencyAfter = idempotencyWindow.map(w -> Instant.now().minus(w)).orElse(null);
+
     return eventLogRepository
-        .findSchedulingEvents(instance.getUuid(), worker.getName())
+        .findSchedulingEvents(instance.getUuid(), worker.getName(), idempotencyAfter)
         .map(existing -> decideAction(existing, inputDataHash))
         .chain(action -> executeAction(action, eventLog, instance, worker, capability))
         .chain(eventLogId -> submitIfNeeded(eventLogId, instance, worker, capability, inputData))


### PR DESCRIPTION
## Summary

Adds `casehub.idempotency.window` (optional `Duration`) to bound the EventLog deduplication check in `WorkerScheduleEventHandler`. When absent (default), behaviour is identical to before — permanent dedup per `(caseId, workerId, inputDataHash)`. When set, only EventLog entries newer than `now - window` are considered.

This follows the event-sourced pattern: the EventLog *is* the idempotency store. No separate Redis or dedup table needed.

## Changes

- `EventLogRepository` SPI: new `findSchedulingEvents(UUID, String, Instant)` abstract method; old two-arg becomes a default delegate
- `InMemoryEventLogRepository` and `JpaEventLogRepository`: implement the cutoff filter
- `WorkerScheduleEventHandler`: reads `casehub.idempotency.window` and computes the cutoff
- Tests: 4 new repository unit/integration tests (cutoff respected, null = no cutoff)
- Docs: DESIGN.md updated

Closes #193