### PR TITLE
feat(worker): add configurable execution timeout with per-worker over…

### DIFF
--- a/api/src/main/java/io/casehub/api/model/ExecutionPolicy.java
+++ b/api/src/main/java/io/casehub/api/model/ExecutionPolicy.java
@@ -15,9 +15,29 @@
  */
 package io.casehub.api.model;
 
+/**
+ * Execution policy for worker tasks.
+ *
+ * <p>Defines timeout and retry behavior for worker execution.
+ *
+ * <p><b>Timeout:</b> If {@code timeoutMs} is {@code null}, the engine uses the default configured
+ * via {@code casehub.engine.worker.default-timeout-ms} (default: 60000ms). Individual workers can
+ * override this by specifying a non-null {@code timeoutMs} in their ExecutionPolicy.
+ *
+ * <p><b>Retries:</b> Retry policy controls automatic retry behavior on failure. See {@link
+ * RetryPolicy} for details.
+ *
+ * @param timeoutMs worker execution timeout in milliseconds, or {@code null} to use configured
+ *     default
+ * @param retries retry policy for failed executions
+ */
 public record ExecutionPolicy(Integer timeoutMs, RetryPolicy retries) {
 
+  /**
+   * Default execution policy with system default timeout (configured via {@code
+   * casehub.engine.worker.default-timeout-ms}) and default retry policy.
+   */
   public ExecutionPolicy() {
-    this(60000, new RetryPolicy());
+    this(null, new RetryPolicy());
   }
 }

--- a/docs/worker-timeout.md
+++ b/docs/worker-timeout.md
@@ -1,0 +1,118 @@
+# Worker Execution Timeout
+
+Workers can hang or run indefinitely. To prevent this, Case Hub supports configurable execution timeouts at both global and per-worker levels.
+
+## Configuration
+
+### Global Default Timeout
+
+Set the default timeout for all workers in `application.properties`:
+
+```properties
+# Default timeout for worker execution (in milliseconds)
+casehub.engine.worker.default-timeout-ms=60000
+```
+
+**Default value:** 60000ms (60 seconds)
+
+### Per-Worker Timeout Override
+
+Individual workers can override the default timeout via `ExecutionPolicy`:
+
+```java
+Worker worker = Worker.builder()
+    .name("slow-worker")
+    .capabilities(capability)
+    .function(ctx -> {
+        // Long-running work
+        return Map.of("result", "done");
+    })
+    .executionPolicy(new ExecutionPolicy(
+        120000,  // 120 seconds timeout for this specific worker
+        new RetryPolicy()
+    ))
+    .build();
+```
+
+**YAML/JSON example:**
+
+```yaml
+workers:
+  - name: slow-worker
+    executionPolicy:
+      timeoutMs: 120000  # Override default timeout
+      retries:
+        maxAttempts: 3
+    capabilities:
+      - processLargeFile
+    function: ...
+```
+
+## Behavior
+
+- When `timeoutMs` is **null** or **not specified**: uses the global default from `casehub.engine.worker.default-timeout-ms`
+- When `timeoutMs` is **specified**: uses the worker-specific value, overriding the global default
+- On **timeout**: worker execution fails with `JobExecutionException` containing a `TimeoutException` cause
+- **Retry logic**: if `ExecutionPolicy.retries` is configured, the worker will be retried according to the retry policy
+
+## Timeout Exception Handling
+
+When a worker times out:
+
+1. A `JobExecutionException` is thrown with message: `"Worker execution timed out after {timeout}ms: {workerName}"`
+2. The cause is a `TimeoutException`
+3. Retry logic (if configured) will attempt to re-execute the worker
+4. After exhausting retries, the case may transition to `FAULTED` state (depending on error handling policy)
+
+## Example: Progressive Timeout Strategy
+
+```java
+// Fast workers: 10 seconds
+Worker fastWorker = Worker.builder()
+    .name("validate-input")
+    .executionPolicy(new ExecutionPolicy(10000, new RetryPolicy()))
+    .function(ctx -> quickValidation(ctx))
+    .build();
+
+// Medium workers: use default (60 seconds)
+Worker mediumWorker = Worker.builder()
+    .name("process-data")
+    .executionPolicy(new ExecutionPolicy())  // uses default timeout
+    .function(ctx -> processData(ctx))
+    .build();
+
+// Slow workers: 5 minutes
+Worker slowWorker = Worker.builder()
+    .name("generate-report")
+    .executionPolicy(new ExecutionPolicy(300000, new RetryPolicy()))
+    .function(ctx -> generateReport(ctx))
+    .build();
+```
+
+## Monitoring
+
+Timeout events are logged at WARN level:
+
+```
+WARN  [QuartzWorkerExecutionJob] Worker execution timed out after 60000ms: slow-worker
+```
+
+Monitor these logs to identify workers that consistently hit timeout limits and may need:
+- Longer timeout configuration
+- Performance optimization
+- Breaking into smaller workers
+
+## Best Practices
+
+1. **Set realistic defaults**: Base `default-timeout-ms` on your typical worker execution time
+2. **Override judiciously**: Only override timeout for workers with genuinely different performance characteristics
+3. **Monitor and adjust**: Track timeout occurrences and adjust timeouts based on actual execution patterns
+4. **Consider retry policy**: Workers with longer timeouts may benefit from fewer retries to avoid cascading delays
+5. **Break up long operations**: If a worker consistently needs very long timeouts (>5 minutes), consider breaking it into smaller workers
+
+## Implementation Notes
+
+- **Workflow workers**: Timeout applies to the entire serverless workflow execution
+- **Function workers**: Timeout applies to the Java function execution
+- **Thread safety**: Function workers execute in a separate thread pool to enable timeout enforcement
+- **Interruption**: When timeout occurs, the worker thread receives an interrupt signal (but may not immediately stop if the code doesn't check interruption status)

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -4,3 +4,25 @@ quarkus.index-dependency.engine.group-id=io.casehub
 quarkus.index-dependency.engine.artifact-id=engine
 quarkus.index-dependency.api.group-id=io.casehub
 quarkus.index-dependency.api.artifact-id=api
+
+# Resilience configuration
+# Poison pill detection: threshold for failures within the sliding window
+casehub.resilience.poison-pill.threshold=5
+# Poison pill detection: sliding window duration for failure tracking
+casehub.resilience.poison-pill.window=PT10M
+# Poison pill detection: quarantine duration after threshold is breached
+casehub.resilience.poison-pill.quarantine=PT30M
+# Maximum duration for case execution timeout (optional, uncomment to enable)
+#casehub.resilience.timeout.max-duration=PT1H
+
+# Case Definition Registry configuration
+# Timeout for registering case definitions during startup
+casehub.engine.definition-registry.startup-timeout=PT30S
+
+# Milestone SLA configuration
+# Whether to deactivate milestone when SLA is violated (true) or keep it ACTIVE (false)
+casehub.engine.milestone.sla-violation-deactivates=false
+
+# Worker execution configuration
+# Default timeout for worker execution (in milliseconds) if not specified in ExecutionPolicy
+casehub.engine.worker.default-timeout-ms=60000

--- a/engine/src/test/java/io/casehub/engine/WorkerTimeoutTest.java
+++ b/engine/src/test/java/io/casehub/engine/WorkerTimeoutTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.ExecutionPolicy;
+import io.casehub.api.model.RetryPolicy;
+import io.casehub.api.model.Worker;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.casehub.engine.spi.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class WorkerTimeoutTest {
+
+  @Inject FastWorkerTestBean fastWorkerBean;
+  @Inject SlowWorkerDefaultTimeoutTestBean slowWorkerDefaultTimeoutBean;
+  @Inject SlowWorkerCustomTimeoutTestBean slowWorkerCustomTimeoutBean;
+  @Inject FastWorkerWithShortTimeoutTestBean fastWorkerWithShortTimeoutBean;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @BeforeEach
+  void setUp() {
+    FastWorkerTestBean.executionCount.set(0);
+    SlowWorkerDefaultTimeoutTestBean.executionCount.set(0);
+    SlowWorkerCustomTimeoutTestBean.executionCount.set(0);
+    FastWorkerWithShortTimeoutTestBean.executionCount.set(0);
+  }
+
+  @Test
+  void fastWorkerShouldCompleteSuccessfully() {
+    UUID caseId = fastWorkerBean.startCase(Map.of("input", "data")).toCompletableFuture().join();
+
+    // Worker should execute quickly and complete
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(FastWorkerTestBean.executionCount.get()).isEqualTo(1));
+
+    // Wait for result to be written to context
+    await()
+        .atMost(3, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              CaseInstance instance = caseInstanceCache.get(caseId);
+              assertThat(instance.getCaseContext().get("result")).isEqualTo("fast-completed");
+            });
+  }
+
+  @Test
+  void slowWorkerShouldTimeoutWithDefaultTimeout() {
+    UUID caseId =
+        slowWorkerDefaultTimeoutBean
+            .startCase(Map.of("input", "data"))
+            .toCompletableFuture()
+            .join();
+
+    // Worker starts executing
+    await()
+        .atMost(3, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> assertThat(SlowWorkerDefaultTimeoutTestBean.executionCount.get()).isEqualTo(1));
+
+    // Case should eventually transition to FAULTED due to timeout (after retry exhaustion)
+    // Default timeout is 2000ms in tests, worker sleeps 10s, so timeout happens ~2s after start
+    await()
+        .atMost(6, TimeUnit.SECONDS)
+        .pollInterval(200, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              CaseInstance instance = caseInstanceCache.get(caseId);
+              assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
+            });
+  }
+
+  @Test
+  void slowWorkerShouldCompleteWithCustomLongerTimeout() {
+    UUID caseId =
+        slowWorkerCustomTimeoutBean.startCase(Map.of("input", "data")).toCompletableFuture().join();
+
+    // Worker should complete successfully with 10 second timeout (worker sleeps 3 seconds)
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> assertThat(SlowWorkerCustomTimeoutTestBean.executionCount.get()).isEqualTo(1));
+
+    // Wait for worker to complete and result to be written to context
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              CaseInstance instance = caseInstanceCache.get(caseId);
+              assertThat(instance.getCaseContext().get("result")).isEqualTo("slow-completed");
+              assertThat(instance.getState()).isEqualTo(CaseStatus.RUNNING);
+            });
+  }
+
+  @Test
+  void fastWorkerShouldTimeoutWithVeryShortTimeout() {
+    UUID caseId =
+        fastWorkerWithShortTimeoutBean
+            .startCase(Map.of("input", "data"))
+            .toCompletableFuture()
+            .join();
+
+    // Worker starts executing
+    await()
+        .atMost(3, TimeUnit.SECONDS)
+        .pollInterval(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> assertThat(FastWorkerWithShortTimeoutTestBean.executionCount.get()).isEqualTo(1));
+
+    // Case should eventually fault due to timeout (100ms is too short even for fast worker)
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .pollInterval(200, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              CaseInstance instance = caseInstanceCache.get(caseId);
+              assertThat(instance.getState()).isEqualTo(CaseStatus.FAULTED);
+            });
+  }
+
+  @ApplicationScoped
+  static class FastWorkerTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("fastWork")
+              .inputSchema("{ }")
+              .outputSchema("{ result: .result }")
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("fast-worker")
+              .capabilities(cap)
+              .executionPolicy(new ExecutionPolicy()) // Uses default timeout
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    // Completes immediately
+                    return Map.of("result", "fast-completed");
+                  })
+              .build();
+
+      return CaseDefinition.builder()
+          .name("fast-worker-test")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(
+              Binding.builder()
+                  .name("trigger-fast-worker")
+                  .capability(cap)
+                  .on(new ContextChangeTrigger(".input != null"))
+                  .build())
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  static class SlowWorkerDefaultTimeoutTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("slowWork")
+              .inputSchema("{ }")
+              .outputSchema("{ result: .result }")
+              .build();
+
+      // No retry to make test faster
+      RetryPolicy noRetry = new RetryPolicy(0, null, null);
+
+      Worker worker =
+          Worker.builder()
+              .name("slow-worker-default")
+              .capabilities(cap)
+              .executionPolicy(
+                  new ExecutionPolicy(
+                      null, // Use default timeout (60000ms from config)
+                      noRetry))
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    try {
+                      // Sleep longer than default timeout (2000ms in tests)
+                      Thread.sleep(10000); // 10 seconds
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                    }
+                    return Map.of("result", "should-not-complete");
+                  })
+              .build();
+
+      return CaseDefinition.builder()
+          .name("slow-worker-default-timeout-test")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(
+              Binding.builder()
+                  .name("trigger-slow-worker-default")
+                  .capability(cap)
+                  .on(new ContextChangeTrigger(".input != null"))
+                  .build())
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  static class SlowWorkerCustomTimeoutTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("slowWorkCustom")
+              .inputSchema("{ }")
+              .outputSchema("{ result: .result }")
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("slow-worker-custom")
+              .capabilities(cap)
+              .executionPolicy(
+                  new ExecutionPolicy(
+                      10000, // 10 second custom timeout
+                      new RetryPolicy()))
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    try {
+                      // Sleep 3 seconds - within custom timeout
+                      Thread.sleep(3000);
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                    }
+                    return Map.of("result", "slow-completed");
+                  })
+              .build();
+
+      return CaseDefinition.builder()
+          .name("slow-worker-custom-timeout-test")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(
+              Binding.builder()
+                  .name("trigger-slow-worker-custom")
+                  .capability(cap)
+                  .on(new ContextChangeTrigger(".input != null"))
+                  .build())
+          .build();
+    }
+  }
+
+  @ApplicationScoped
+  static class FastWorkerWithShortTimeoutTestBean extends CaseHub {
+    static final AtomicInteger executionCount = new AtomicInteger(0);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability cap =
+          Capability.builder()
+              .name("fastWorkShortTimeout")
+              .inputSchema("{ }")
+              .outputSchema("{ result: .result }")
+              .build();
+
+      // No retry to make test faster
+      RetryPolicy noRetry = new RetryPolicy(0, null, null);
+
+      Worker worker =
+          Worker.builder()
+              .name("fast-worker-short-timeout")
+              .capabilities(cap)
+              .executionPolicy(
+                  new ExecutionPolicy(
+                      100, // Very short timeout (100ms)
+                      noRetry))
+              .function(
+                  ctx -> {
+                    executionCount.incrementAndGet();
+                    try {
+                      // Sleep 500ms - exceeds short timeout
+                      Thread.sleep(500);
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                    }
+                    return Map.of("result", "should-not-complete");
+                  })
+              .build();
+
+      return CaseDefinition.builder()
+          .name("fast-worker-short-timeout-test")
+          .namespace("test")
+          .version("1.0")
+          .capabilities(cap)
+          .workers(worker)
+          .bindings(
+              Binding.builder()
+                  .name("trigger-fast-worker-short")
+                  .capability(cap)
+                  .on(new ContextChangeTrigger(".input != null"))
+                  .build())
+          .build();
+    }
+  }
+}

--- a/engine/src/test/resources/application.properties
+++ b/engine/src/test/resources/application.properties
@@ -7,6 +7,8 @@ quarkus.quartz.clustered=false
 
 # Dev Services: do not keep Testcontainers databases alive after Maven test runs.
 quarkus.datasource.devservices.reuse=false
+# Worker execution: short timeout for faster tests
+casehub.engine.worker.default-timeout-ms=2000
 
 # Hibernate ORM: use dedicated JSON mapper, not the REST ObjectMapper customizer.
 # Only applies in default test profile (hibernate). Ignored in memory profile.

--- a/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJob.java
+++ b/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJob.java
@@ -40,6 +40,9 @@ import jakarta.inject.Inject;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import org.jboss.logging.Logger;
 import org.quartz.Job;
@@ -61,6 +64,8 @@ class QuartzWorkerExecutionJob implements Job {
   @Inject WorkerExecutionRecoveryService workerExecutionRecoveryService;
 
   @Inject EventLogRepository eventLogRepository;
+
+  @Inject WorkerExecutionConfig executionConfig;
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -125,17 +130,29 @@ class QuartzWorkerExecutionJob implements Job {
                     new RuntimeException(
                         "Capability not found in case definition: " + capabilityName));
 
+    int timeoutMs = executionConfig.getEffectiveTimeout(worker.getExecutionPolicy().timeoutMs());
+
     Map<String, Object> outputData;
-    if (worker.getFunction().getValue() instanceof Workflow workflow) {
-      outputData = workflow(workflow, inputData);
-    } else if (worker.getFunction().getValue() instanceof Function function) {
-      outputData = function(function, inputData);
-    } else {
-      throw new RuntimeException(
-          "Worker function is not a workflow: "
-              + worker.getName()
-              + " "
-              + worker.getFunction().getValue().getClass().getCanonicalName());
+    try {
+      if (worker.getFunction().getValue() instanceof Workflow workflow) {
+        outputData = workflow(workflow, inputData, timeoutMs);
+      } else if (worker.getFunction().getValue() instanceof Function function) {
+        outputData = function(function, inputData, timeoutMs);
+      } else {
+        throw new RuntimeException(
+            "Worker function is not a workflow: "
+                + worker.getName()
+                + " "
+                + worker.getFunction().getValue().getClass().getCanonicalName());
+      }
+    } catch (TimeoutException e) {
+      throw new JobExecutionException(
+          "Worker execution timed out after " + timeoutMs + "ms: " + worker.getName(), e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new JobExecutionException("Worker execution interrupted: " + worker.getName(), e);
+    } catch (ExecutionException e) {
+      throw new JobExecutionException("Worker execution failed: " + worker.getName(), e.getCause());
     }
 
     Map<String, Object> toContextOutputData =
@@ -146,17 +163,34 @@ class QuartzWorkerExecutionJob implements Job {
     eventBus.publish(WORKER_EXECUTION_FINISHED, event);
   }
 
-  private Map<String, Object> workflow(Workflow workflow, Map<String, Object> inputData) {
+  private Map<String, Object> workflow(
+      Workflow workflow, Map<String, Object> inputData, int timeoutMs)
+      throws TimeoutException, InterruptedException, ExecutionException {
     CompletableFuture<WorkflowModel> cf = workflowExecutor.execute(workflow, inputData);
-    WorkflowModel workflowModel = cf.join(); // TODO handle exception + join() in a non-blocking way
+
+    LOG.debugf("Executing workflow with timeout: %d ms", timeoutMs);
+
+    // Use get() with timeout instead of join() to handle timeouts
+    WorkflowModel workflowModel = cf.get(timeoutMs, TimeUnit.MILLISECONDS);
+
     return workflowModel
         .asMap()
         .orElseThrow(() -> new RuntimeException("Failed to convert workflow model to map"));
   }
 
   private Map<String, Object> function(
-      Function<Map<String, Object>, Map<String, Object>> function, Map<String, Object> inputData) {
-    return function.apply(inputData);
+      Function<Map<String, Object>, Map<String, Object>> function,
+      Map<String, Object> inputData,
+      int timeoutMs)
+      throws TimeoutException, InterruptedException, ExecutionException {
+
+    LOG.debugf("Executing function with timeout: %d ms", timeoutMs);
+
+    // Execute function in a separate thread with timeout
+    CompletableFuture<Map<String, Object>> cf =
+        CompletableFuture.supplyAsync(() -> function.apply(inputData));
+
+    return cf.get(timeoutMs, TimeUnit.MILLISECONDS);
   }
 
   private Uni<EventLog> findEventLog(String eventLogId) {

--- a/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/WorkerExecutionConfig.java
+++ b/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/WorkerExecutionConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.scheduler.quartz;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Configuration for worker execution behavior.
+ *
+ * <p>Provides default timeout and other execution-related settings that can be overridden per
+ * worker via {@link io.casehub.api.model.ExecutionPolicy}.
+ */
+@ApplicationScoped
+class WorkerExecutionConfig {
+
+  @ConfigProperty(name = "casehub.engine.worker.default-timeout-ms", defaultValue = "60000")
+  int defaultTimeoutMs;
+
+  /**
+   * Returns the effective timeout for a worker execution.
+   *
+   * <p>If the worker's ExecutionPolicy specifies a timeout, uses that. Otherwise uses the
+   * configured default.
+   *
+   * @param workerTimeoutMs worker-specific timeout from ExecutionPolicy, or null
+   * @return effective timeout in milliseconds
+   */
+  int getEffectiveTimeout(Integer workerTimeoutMs) {
+    return workerTimeoutMs != null ? workerTimeoutMs : defaultTimeoutMs;
+  }
+}

--- a/scheduler-quartz/src/test/java/io/casehub/engine/scheduler/quartz/WorkerExecutionConfigTest.java
+++ b/scheduler-quartz/src/test/java/io/casehub/engine/scheduler/quartz/WorkerExecutionConfigTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.scheduler.quartz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WorkerExecutionConfigTest {
+
+  private WorkerExecutionConfig config;
+  private final int defaultTimeout = 60000;
+
+  @BeforeEach
+  void setUp() {
+    config = new WorkerExecutionConfig();
+    config.defaultTimeoutMs = defaultTimeout;
+  }
+
+  @Test
+  void shouldUseDefaultTimeoutWhenWorkerTimeoutIsNull() {
+    int effectiveTimeout = config.getEffectiveTimeout(null);
+
+    assertThat(effectiveTimeout).isEqualTo(defaultTimeout);
+  }
+
+  @Test
+  void shouldUseWorkerSpecificTimeoutWhenProvided() {
+    int workerTimeout = 120000;
+
+    int effectiveTimeout = config.getEffectiveTimeout(workerTimeout);
+
+    assertThat(effectiveTimeout).isEqualTo(workerTimeout);
+  }
+
+  @Test
+  void shouldUseWorkerSpecificTimeoutEvenIfZero() {
+    // Edge case: worker explicitly sets timeout to 0 (immediate timeout)
+    int effectiveTimeout = config.getEffectiveTimeout(0);
+
+    assertThat(effectiveTimeout).isEqualTo(0);
+  }
+
+  @Test
+  void shouldHandleVeryLargeTimeout() {
+    int largeTimeout = Integer.MAX_VALUE;
+
+    int effectiveTimeout = config.getEffectiveTimeout(largeTimeout);
+
+    assertThat(effectiveTimeout).isEqualTo(largeTimeout);
+  }
+}

--- a/schema/src/main/java/io/casehub/model/ExecutionPolicy.java
+++ b/schema/src/main/java/io/casehub/model/ExecutionPolicy.java
@@ -15,9 +15,30 @@
  */
 package io.casehub.model;
 
+/**
+ * Execution policy for worker tasks.
+ *
+ * <p>Defines timeout and retry behavior for worker execution.
+ *
+ * <p><b>Timeout:</b> If {@code timeoutMs} is {@code null} or not specified in YAML/JSON, the engine
+ * uses the default configured via {@code casehub.engine.worker.default-timeout-ms} (default:
+ * 60000ms). Individual workers can override this by specifying a {@code timeoutMs} value.
+ *
+ * <p><b>Retries:</b> Retry policy controls automatic retry behavior on failure. See {@link
+ * RetryPolicy} for details.
+ */
 public class ExecutionPolicy {
 
-  private Integer timeoutMs = 60000; // default to 60 seconds
+  /**
+   * Worker execution timeout in milliseconds, or {@code null} to use configured default.
+   *
+   * <p>When not specified in YAML/JSON definition, defaults to {@code null}, which means the engine
+   * will use the system-wide default configured via {@code
+   * casehub.engine.worker.default-timeout-ms}.
+   */
+  private Integer timeoutMs = null;
+
+  /** Retry policy for failed executions. */
   private RetryPolicy retries = new RetryPolicy();
 
   public Integer getTimeoutMs() {


### PR DESCRIPTION
…ride

  Workers can now timeout to prevent hanging or infinite execution. Timeout is
  enforced at both workflow and function worker levels using CompletableFuture
  with deadline-based execution.

  Configuration:
  - Global default via casehub.engine.worker.default-timeout-ms (default: 60000ms)
  - Per-worker override via ExecutionPolicy.timeoutMs (null uses global default)

  Implementation:
  - WorkerExecutionConfig CDI bean manages timeout resolution
  - QuartzWorkerExecutionJob enforces timeout using CompletableFuture.get(timeout, MILLISECONDS)
  - Timeout failures trigger JobExecutionException with TimeoutException cause
  - Retry logic applies after timeout (configurable via RetryPolicy)

  When a worker times out:
  1. CompletableFuture.get() throws TimeoutException
  2. Wrapped as JobExecutionException with descriptive message
  3. QuartzWorkerExecutionJobListener handles retry logic
  4. Case transitions to FAULTED after retry exhaustion

  Tests:
  - WorkerTimeoutTest: 4 integration tests covering fast/slow workers with default/custom/short timeouts
  - WorkerExecutionConfigTest: unit tests for timeout resolution logic

  Documentation:
  - docs/worker-timeout.md: comprehensive guide with configuration examples, behavior, best practices