### PR TITLE
fix(core): post-rename Jandex and CDI discovery fixes

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -53,4 +53,21 @@
         </dependency>
     </dependencies>
 
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/casehub-blackboard/pom.xml
+++ b/casehub-blackboard/pom.xml
@@ -57,6 +57,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-engine-ledger</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/casehub-blackboard/pom.xml
+++ b/casehub-blackboard/pom.xml
@@ -104,6 +104,18 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/casehub-blackboard/src/test/resources/application.properties
+++ b/casehub-blackboard/src/test/resources/application.properties
@@ -1,5 +1,15 @@
 # casehub-blackboard integration tests — in-memory persistence, no Docker.
 
+# Quarkus index-dependency: CDI beans from library JARs need explicit indexing.
+# Required because scheduler-quartz and persistence-memory are library JARs without
+# Quarkus extension descriptors — Quarkus will not scan them without this config.
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+quarkus.index-dependency.persistence-memory.group-id=io.casehub
+quarkus.index-dependency.persistence-memory.artifact-id=casehub-engine-persistence-memory
+quarkus.index-dependency.engine.group-id=io.casehub
+quarkus.index-dependency.engine.artifact-id=casehub-engine
+
 # Quartz: use in-memory store
 quarkus.quartz.store-type=ram
 

--- a/casehub-blackboard/src/test/resources/application.properties
+++ b/casehub-blackboard/src/test/resources/application.properties
@@ -17,6 +17,12 @@ quarkus.quartz.store-type=ram
 # Random port to avoid conflicts with other running services
 quarkus.http.test-port=0
 
+# Index dependency classes for CDI discovery
+quarkus.index-dependency.casehub-engine.group-id=io.casehub
+quarkus.index-dependency.casehub-engine.artifact-id=casehub-engine
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+
 # Activate in-memory repository implementations
 quarkus.arc.selected-alternatives=\
   io.casehub.persistence.memory.InMemoryCaseMetaModelRepository,\

--- a/casehub-ledger/pom.xml
+++ b/casehub-ledger/pom.xml
@@ -66,4 +66,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/casehub-persistence-hibernate/pom.xml
+++ b/casehub-persistence-hibernate/pom.xml
@@ -79,6 +79,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <parameters>true</parameters>

--- a/casehub-persistence-hibernate/src/main/resources/META-INF/beans.xml
+++ b/casehub-persistence-hibernate/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="all">
+</beans>

--- a/casehub-persistence-hibernate/src/test/resources/application.properties
+++ b/casehub-persistence-hibernate/src/test/resources/application.properties
@@ -22,4 +22,4 @@
 # map to the same tables as our *Entity classes. Indexing both would cause Hibernate to
 # discover duplicate entity mappings and fail.
 quarkus.index-dependency.api.group-id=io.casehub
-quarkus.index-dependency.api.artifact-id=api
+quarkus.index-dependency.api.artifact-id=casehub-engine-api

--- a/casehub-persistence-memory/pom.xml
+++ b/casehub-persistence-memory/pom.xml
@@ -40,6 +40,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <parameters>true</parameters>

--- a/casehub-persistence-memory/src/main/resources/META-INF/beans.xml
+++ b/casehub-persistence-memory/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="all">
+</beans>

--- a/casehub-resilience/pom.xml
+++ b/casehub-resilience/pom.xml
@@ -115,6 +115,18 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/casehub-resilience/pom.xml
+++ b/casehub-resilience/pom.xml
@@ -68,6 +68,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-engine-ledger</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/casehub-resilience/src/main/resources/META-INF/beans.xml
+++ b/casehub-resilience/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/casehub-resilience/src/main/resources/application.properties
+++ b/casehub-resilience/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+quarkus.quartz.store-type=ram
+
+quarkus.index-dependency.casehub-engine.group-id=io.casehub
+quarkus.index-dependency.casehub-engine.artifact-id=casehub-engine
+quarkus.index-dependency.casehub-blackboard.group-id=io.casehub
+quarkus.index-dependency.casehub-blackboard.artifact-id=casehub-engine-blackboard
+quarkus.index-dependency.casehub-persistence-memory.group-id=io.casehub
+quarkus.index-dependency.casehub-persistence-memory.artifact-id=casehub-persistence-memory
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+
+quarkus.arc.selected-alternatives=\
+  io.casehub.persistence.memory.InMemoryCaseInstanceRepository,\
+  io.casehub.persistence.memory.InMemoryCaseMetaModelRepository,\
+  io.casehub.persistence.memory.InMemoryEventLogRepository

--- a/casehub-resilience/src/test/resources/application.properties
+++ b/casehub-resilience/src/test/resources/application.properties
@@ -1,8 +1,13 @@
-# Index engine and api modules so Quarkus discovers their CDI beans
+# Index library JARs so Quarkus discovers their CDI beans.
+# artifact-ids updated after casehub-engine-* rename (was engine/api before rename).
 quarkus.index-dependency.engine.group-id=io.casehub
-quarkus.index-dependency.engine.artifact-id=engine
+quarkus.index-dependency.engine.artifact-id=casehub-engine
 quarkus.index-dependency.api.group-id=io.casehub
-quarkus.index-dependency.api.artifact-id=api
+quarkus.index-dependency.api.artifact-id=casehub-engine-api
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+quarkus.index-dependency.persistence-memory.group-id=io.casehub
+quarkus.index-dependency.persistence-memory.artifact-id=casehub-engine-persistence-memory
 
 # Activate in-memory persistence plus the PoisonPill guard for integration tests.
 quarkus.arc.selected-alternatives=\

--- a/casehub-resilience/src/test/resources/application.properties
+++ b/casehub-resilience/src/test/resources/application.properties
@@ -1,5 +1,4 @@
 # Index library JARs so Quarkus discovers their CDI beans.
-# artifact-ids updated after casehub-engine-* rename (was engine/api before rename).
 quarkus.index-dependency.engine.group-id=io.casehub
 quarkus.index-dependency.engine.artifact-id=casehub-engine
 quarkus.index-dependency.api.group-id=io.casehub
@@ -8,6 +7,9 @@ quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
 quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
 quarkus.index-dependency.persistence-memory.group-id=io.casehub
 quarkus.index-dependency.persistence-memory.artifact-id=casehub-engine-persistence-memory
+
+# Quartz: use in-memory store
+quarkus.quartz.store-type=ram
 
 # Activate in-memory persistence plus the PoisonPill guard for integration tests.
 quarkus.arc.selected-alternatives=\

--- a/casehub-testing/pom.xml
+++ b/casehub-testing/pom.xml
@@ -44,6 +44,18 @@
                     <parameters>true</parameters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/casehub-work-adapter/pom.xml
+++ b/casehub-work-adapter/pom.xml
@@ -46,13 +46,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.casehub</groupId>
-            <artifactId>scheduler-quartz</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
+<dependency>
             <groupId>io.casehub</groupId>
             <artifactId>casehub-work-testing</artifactId>
             <version>${version.io.casehub}</version>

--- a/casehub-work-adapter/pom.xml
+++ b/casehub-work-adapter/pom.xml
@@ -102,6 +102,18 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/casehub-work-adapter/pom.xml
+++ b/casehub-work-adapter/pom.xml
@@ -69,6 +69,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-engine-ledger</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/casehub-work-adapter/src/test/resources/application.properties
+++ b/casehub-work-adapter/src/test/resources/application.properties
@@ -1,5 +1,13 @@
 quarkus.http.test-port=0
 quarkus.quartz.store-type=ram
+
+# Index library JARs for CDI bean discovery (artifact-ids post casehub-engine-* rename)
+quarkus.index-dependency.engine.group-id=io.casehub
+quarkus.index-dependency.engine.artifact-id=casehub-engine
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+quarkus.index-dependency.persistence-memory.group-id=io.casehub
+quarkus.index-dependency.persistence-memory.artifact-id=casehub-engine-persistence-memory
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:test;MODE=PostgreSQL
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -73,6 +73,12 @@
 
         <dependency>
             <groupId>io.casehub</groupId>
+            <artifactId>casehub-engine-ledger</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
             <artifactId>casehub-engine-scheduler-quartz</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -196,7 +196,7 @@
         <profile>
             <id>persistence-memory</id>
             <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
+                <maven.deploy.skip>false</maven.deploy.skip>
                 <engine.test.extra.jvm.args>-Dquarkus.test.profile=memory</engine.test.extra.jvm.args>
             </properties>
             <dependencies>
@@ -204,6 +204,11 @@
                     <groupId>io.casehub</groupId>
                     <artifactId>casehub-engine-persistence-memory</artifactId>
                     <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jdbc-h2</artifactId>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.index-dependency.engine.group-id=io.casehub
-quarkus.index-dependency.engine.artifact-id=engine
+quarkus.index-dependency.engine.artifact-id=casehub-engine
 quarkus.index-dependency.api.group-id=io.casehub
-quarkus.index-dependency.api.artifact-id=api
+quarkus.index-dependency.api.artifact-id=casehub-engine-api
 
 # Resilience configuration
 # Poison pill detection: threshold for failures within the sliding window

--- a/engine/src/test/resources/application-memory.properties
+++ b/engine/src/test/resources/application-memory.properties
@@ -1,5 +1,7 @@
-# Quarkus index-dependency: scheduler-quartz CDI beans need explicit indexing
-# (same as application.properties, repeated here so memory profile works standalone)
+# Quartz: use in-memory store
+quarkus.quartz.store-type=ram
+
+# Quarkus index-dependency: scheduler-quartz and persistence-memory CDI beans
 quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
 quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
 quarkus.index-dependency.persistence-memory.group-id=io.casehub
@@ -10,3 +12,16 @@ quarkus.arc.selected-alternatives=\
   io.casehub.persistence.memory.InMemoryCaseMetaModelRepository,\
   io.casehub.persistence.memory.InMemoryCaseInstanceRepository,\
   io.casehub.persistence.memory.InMemoryEventLogRepository
+
+# Index dependency classes for CDI discovery
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+
+# casehub-ledger JPA entities land on the classpath via engine -> casehub-ledger.
+# Provide an H2 datasource so Hibernate can start; memory profile tests use in-memory repos.
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:enginememorytest;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+quarkus.datasource.username=sa
+quarkus.datasource.password=
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+quarkus.flyway.migrate-at-start=false

--- a/engine/src/test/resources/application-memory.properties
+++ b/engine/src/test/resources/application-memory.properties
@@ -1,3 +1,10 @@
+# Quarkus index-dependency: scheduler-quartz CDI beans need explicit indexing
+# (same as application.properties, repeated here so memory profile works standalone)
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+quarkus.index-dependency.persistence-memory.group-id=io.casehub
+quarkus.index-dependency.persistence-memory.artifact-id=casehub-engine-persistence-memory
+
 # Activate in-memory repository implementations for all three SPIs
 quarkus.arc.selected-alternatives=\
   io.casehub.persistence.memory.InMemoryCaseMetaModelRepository,\

--- a/engine/src/test/resources/application.properties
+++ b/engine/src/test/resources/application.properties
@@ -2,14 +2,8 @@
 # need explicit indexing so their CDI beans are discovered.
 quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
 quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
-quarkus.index-dependency.persistence-memory.group-id=io.casehub
-quarkus.index-dependency.persistence-memory.artifact-id=casehub-engine-persistence-memory
-
-# Activate in-memory repository implementations — no Docker required for engine tests.
-quarkus.arc.selected-alternatives=\
-  io.casehub.persistence.memory.InMemoryCaseMetaModelRepository,\
-  io.casehub.persistence.memory.InMemoryCaseInstanceRepository,\
-  io.casehub.persistence.memory.InMemoryEventLogRepository
+quarkus.index-dependency.persistence-hibernate.group-id=io.casehub
+quarkus.index-dependency.persistence-hibernate.artifact-id=casehub-engine-persistence-hibernate
 
 # Disable Ollama Dev Services — model preloading is not needed for tests
 quarkus.langchain4j.ollama.devservices.enabled=false

--- a/engine/src/test/resources/application.properties
+++ b/engine/src/test/resources/application.properties
@@ -1,3 +1,8 @@
+# Quarkus index-dependency: scheduler-quartz CDI beans need explicit indexing
+# since it is a library JAR without a Quarkus extension descriptor.
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+
 # Disable Ollama Dev Services — model preloading is not needed for tests
 quarkus.langchain4j.ollama.devservices.enabled=false
 

--- a/engine/src/test/resources/application.properties
+++ b/engine/src/test/resources/application.properties
@@ -1,7 +1,15 @@
-# Quarkus index-dependency: scheduler-quartz CDI beans need explicit indexing
-# since it is a library JAR without a Quarkus extension descriptor.
+# Quarkus index-dependency: library JARs without Quarkus extension descriptors
+# need explicit indexing so their CDI beans are discovered.
 quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
 quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+quarkus.index-dependency.persistence-memory.group-id=io.casehub
+quarkus.index-dependency.persistence-memory.artifact-id=casehub-engine-persistence-memory
+
+# Activate in-memory repository implementations — no Docker required for engine tests.
+quarkus.arc.selected-alternatives=\
+  io.casehub.persistence.memory.InMemoryCaseMetaModelRepository,\
+  io.casehub.persistence.memory.InMemoryCaseInstanceRepository,\
+  io.casehub.persistence.memory.InMemoryEventLogRepository
 
 # Disable Ollama Dev Services — model preloading is not needed for tests
 quarkus.langchain4j.ollama.devservices.enabled=false

--- a/engine/src/test/resources/application.properties
+++ b/engine/src/test/resources/application.properties
@@ -28,6 +28,12 @@ quarkus.flyway.out-of-order=true
 quarkus.flyway.migrate-at-start=false
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
+# Index dependency classes for CDI discovery
+quarkus.index-dependency.casehub-persistence-hibernate.group-id=io.casehub
+quarkus.index-dependency.casehub-persistence-hibernate.artifact-id=casehub-engine-persistence-hibernate
+quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz
+
 # casehub-ledger is on the engine classpath (via LedgerTraceIdProvider) but its JPA-backed
 # beans require a LedgerEntryRepository. NoOpLedgerEntryRepository (@Alternative @Priority(1))
 # satisfies that dependency so the in-memory test profile starts cleanly.

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,11 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${version.build-helper-maven-plugin}</version>
                 </plugin>
+                <plugin>
+                    <groupId>io.smallrye</groupId>
+                    <artifactId>jandex-maven-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/scheduler-quartz/pom.xml
+++ b/scheduler-quartz/pom.xml
@@ -40,4 +40,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/scheduler-quartz/src/main/resources/META-INF/beans.xml
+++ b/scheduler-quartz/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="all">
+</beans>

--- a/scheduler-quartz/src/main/resources/application.properties
+++ b/scheduler-quartz/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 quarkus.scheduler.start-mode=forced
 
 quarkus.index-dependency.scheduler-quartz.group-id=io.casehub
-quarkus.index-dependency.scheduler-quartz.artifact-id=scheduler-quartz
+quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-quartz


### PR DESCRIPTION
Rebased and conflict-resolved version of #222 (Dmitrii Tikhomirov's fix).

## What

Properly fixes CDI bean discovery across all modules after the casehub-engine-* rename, using Jandex instead of workarounds:

- Add `jandex-maven-plugin` to `casehub-persistence-hibernate` and `casehub-persistence-memory` — generates `META-INF/jandex.idx` so Quarkus discovers CDI beans automatically
- Fix stale artifact IDs in `application.properties` files across all modules (`engine` → `casehub-engine`, `api` → `casehub-engine-api`, `scheduler-quartz` → `casehub-engine-scheduler-quartz`)
- Add missing `quarkus.index-dependency` entries where Jandex is not yet configured
- Add H2 datasource config to memory test profiles (casehub-ledger JPA entities on classpath require it)
- Add `quarkus.quartz.store-type=ram` to test configs that were missing it
- Fix `engine/pom.xml` indentation in persistence-memory profile, add `quarkus-jdbc-h2` test dep

Closes #222
Refs #219

Co-Authored-By: Dmitrii Tikhomirov <chani.liet@gmail.com>