### PR TITLE
fix(test): implement new LedgerEntryRepository attestation methods in NoOpLedgerEntryRepository

### DIFF
--- a/casehub-blackboard/src/test/java/io/casehub/blackboard/NoOpLedgerEntryRepository.java
+++ b/casehub-blackboard/src/test/java/io/casehub/blackboard/NoOpLedgerEntryRepository.java
@@ -102,4 +102,21 @@ class NoOpLedgerEntryRepository implements LedgerEntryRepository {
   public List<LedgerEntry> findCausedBy(UUID entryId) {
     return List.of();
   }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByEntryIdAndCapabilityTag(
+      UUID entryId, String capabilityTag) {
+    return List.of();
+  }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByEntryIdGlobal(UUID entryId) {
+    return List.of();
+  }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByAttestorIdAndCapabilityTag(
+      String attestorId, String capabilityTag) {
+    return List.of();
+  }
 }

--- a/casehub-resilience/src/test/java/io/casehub/resilience/NoOpLedgerEntryRepository.java
+++ b/casehub-resilience/src/test/java/io/casehub/resilience/NoOpLedgerEntryRepository.java
@@ -102,4 +102,21 @@ class NoOpLedgerEntryRepository implements LedgerEntryRepository {
   public List<LedgerEntry> findCausedBy(UUID entryId) {
     return List.of();
   }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByEntryIdAndCapabilityTag(
+      UUID entryId, String capabilityTag) {
+    return List.of();
+  }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByEntryIdGlobal(UUID entryId) {
+    return List.of();
+  }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByAttestorIdAndCapabilityTag(
+      String attestorId, String capabilityTag) {
+    return List.of();
+  }
 }

--- a/casehub-work-adapter/src/test/java/io/casehub/workadapter/NoOpLedgerEntryRepository.java
+++ b/casehub-work-adapter/src/test/java/io/casehub/workadapter/NoOpLedgerEntryRepository.java
@@ -102,4 +102,21 @@ class NoOpLedgerEntryRepository implements LedgerEntryRepository {
   public List<LedgerEntry> findCausedBy(UUID entryId) {
     return List.of();
   }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByEntryIdAndCapabilityTag(
+      UUID entryId, String capabilityTag) {
+    return List.of();
+  }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByEntryIdGlobal(UUID entryId) {
+    return List.of();
+  }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByAttestorIdAndCapabilityTag(
+      String attestorId, String capabilityTag) {
+    return List.of();
+  }
 }

--- a/engine/src/test/java/io/casehub/engine/NoOpLedgerEntryRepository.java
+++ b/engine/src/test/java/io/casehub/engine/NoOpLedgerEntryRepository.java
@@ -102,4 +102,21 @@ class NoOpLedgerEntryRepository implements LedgerEntryRepository {
   public List<LedgerEntry> findCausedBy(UUID entryId) {
     return List.of();
   }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByEntryIdAndCapabilityTag(
+      UUID entryId, String capabilityTag) {
+    return List.of();
+  }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByEntryIdGlobal(UUID entryId) {
+    return List.of();
+  }
+
+  @Override
+  public List<LedgerAttestation> findAttestationsByAttestorIdAndCapabilityTag(
+      String attestorId, String capabilityTag) {
+    return List.of();
+  }
 }


### PR DESCRIPTION
## Problem

`casehub-ledger` added three attestation query methods to `LedgerEntryRepository`:
- `findAttestationsByEntryIdAndCapabilityTag(UUID, String)`
- `findAttestationsByEntryIdGlobal(UUID)`
- `findAttestationsByAttestorIdAndCapabilityTag(String, String)`

The test stub `NoOpLedgerEntryRepository` in the engine test suite was not updated, causing upstream-published CI builds to fail with a compilation error.

## Fix

Add all three methods returning `List.of()` in the no-op stub — same pattern as all existing stub methods.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)