### PR TITLE
feat: WorkerExecutionContext thread-local + WorkerContext.channels() wiring (engine#220)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,14 @@ Submodule poms reference `${version.io.casehub.work}` etc. — no hardcoded vers
 
 **Publishing:** `maven.deploy.skip=false` is the default in root `pom.xml` properties — the root parent POM (`io.casehub:parent`) IS published to GitHub Packages. Downstream consumers need it to resolve the effective POM of child artifacts (`api`, `engine`, etc.). Modules that should not be published override with `<maven.deploy.skip>true</maven.deploy.skip>` in their own `<properties>`.
 
+## IntelliJ MCP Tools
+
+Two IntelliJ MCP servers are available (`mcp__intellij__*` and `mcp__intellij-index__*`).
+Before using Bash tools, check whether the operation can be performed via IntelliJ — it is
+often more correct, faster, and less error-prone (symbol lookup, rename refactoring, diagnostics,
+file search). Verify both are responsive at session start; stop and report to the user if either
+is unavailable.
+
 ## casehub-work-adapter Module
 
 Bridges casehub-work `WorkItemLifecycleEvent` CDI events to CaseHub `PlanItem` transitions via `BlackboardRegistry`. Choreography path only — fires `CONTEXT_CHANGED` for engine re-evaluation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,13 @@ To add a new operational SPI: define the interface in `api/spi/`, add a no-op de
 | `WorkerStatusListener.onWorkerStalled` | `WorkerRetriesExhaustedEventHandler` | All retries exhausted |
 | `CaseChannelProvider.openChannel` | `CaseStartedEventHandler` | Case starts |
 | `CaseChannelProvider.closeChannel` | `CaseStatusChangedHandler` | Case reaches terminal state |
-| `WorkerContextProvider.buildContext` | `WorkerScheduleEventHandler` | Before Quartz job is submitted |
+| `WorkerContextProvider.buildContext` | `WorkerScheduleEventHandler` | Before Quartz job is submitted (timing contract) |
+| `WorkerContextProvider.buildContext` + `WorkerExecutionContext.set` | `QuartzWorkerExecutionJob` | Immediately before worker function — sets thread-local with channels |
 | `WorkerProvisioner.provision` | `CaseContextChangedEventHandler.tryProvision` | No pre-defined workers match capability |
 
 `WorkerProvisioner.provision()` is called only when `workerProvisioner.getCapabilities()` contains the required capability. `ProvisioningException` is caught and logged; the binding stays eligible for the next context-change tick. The no-op default returns empty capabilities, so it is never called unless a real provisioner is wired in.
+
+`WorkerExecutionContext.current()` returns the active `WorkerContext` (including `channels`) inside a worker's function body. Cleared in a `finally` block after the function returns.
 
 **To test SPI wiring:** use `@Alternative @Priority(1) @ApplicationScoped` static inner classes in `@QuarkusTest` with `static` recording fields reset in `@BeforeEach`. This activates the recording bean globally across the test suite without Mockito. See `SpiWiringIntegrationTest` for the pattern. To test provisioner wiring, define a `CaseHub` subclass with a capability binding and no workers — the engine will fall through to `tryProvision()`.
 

--- a/api/src/main/java/io/casehub/api/model/WorkerExecutionContext.java
+++ b/api/src/main/java/io/casehub/api/model/WorkerExecutionContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+/**
+ * Thread-local holder for the {@link WorkerContext} active during worker function execution.
+ *
+ * <p>Set by the engine immediately before invoking the worker function; cleared in a {@code
+ * finally} block after execution completes or fails. Workers running in the same thread as their
+ * invocation can call {@link #current()} to access their case's channels and other startup context.
+ *
+ * <p>Not safe to use across async boundaries (e.g. CompletableFuture continuations on other
+ * threads). For reactive workers, the engine's reactive execution path propagates context
+ * separately.
+ */
+public final class WorkerExecutionContext {
+
+  private static final ThreadLocal<WorkerContext> HOLDER = new ThreadLocal<>();
+
+  private WorkerExecutionContext() {}
+
+  /** Returns the {@link WorkerContext} for the currently executing worker, or {@code null}. */
+  public static WorkerContext current() {
+    return HOLDER.get();
+  }
+
+  /** Called by the engine before invoking a worker function. */
+  public static void set(WorkerContext context) {
+    HOLDER.set(context);
+  }
+
+  /** Called by the engine after the worker function returns (success or failure). */
+  public static void clear() {
+    HOLDER.remove();
+  }
+}

--- a/api/src/main/java/io/casehub/api/spi/ReactiveWorkerContextProvider.java
+++ b/api/src/main/java/io/casehub/api/spi/ReactiveWorkerContextProvider.java
@@ -18,12 +18,13 @@ package io.casehub.api.spi;
 import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkerContext;
 import io.smallrye.mutiny.Uni;
+import java.util.UUID;
 
 /**
  * Reactive mirror of {@link WorkerContextProvider} — returns {@link Uni}.
  *
- * <p>Builds startup context for a new worker without blocking the caller. The empty default returns
- * a minimal context with the task capability as the description and an empty prior-workers list.
+ * <p>Builds startup context for a new worker without blocking the caller. Implementations populate
+ * {@link WorkerContext#channels()} via {@code ReactiveCaseChannelProvider.listChannels(caseId)}.
  */
 public interface ReactiveWorkerContextProvider {
 
@@ -31,8 +32,11 @@ public interface ReactiveWorkerContextProvider {
    * Build context for a worker about to start work on a task.
    *
    * @param workerId the ID of the worker being started
+   * @param caseId the ID of the case the worker is executing for; may be {@code null} for
+   *     provisioning-only flows where no live case exists yet
    * @param task the work request describing what the worker should do
-   * @return a {@code Uni} emitting startup context including task description, channel, and lineage
+   * @return a {@code Uni} emitting startup context including task description, open channels, and
+   *     lineage
    */
-  Uni<WorkerContext> buildContext(String workerId, WorkRequest task);
+  Uni<WorkerContext> buildContext(String workerId, UUID caseId, WorkRequest task);
 }

--- a/api/src/main/java/io/casehub/api/spi/WorkerContextProvider.java
+++ b/api/src/main/java/io/casehub/api/spi/WorkerContextProvider.java
@@ -17,6 +17,7 @@ package io.casehub.api.spi;
 
 import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkerContext;
+import java.util.UUID;
 
 /**
  * Builds startup context for a new worker.
@@ -25,6 +26,10 @@ import io.casehub.api.model.WorkerContext;
  * history, constructing {@link io.casehub.api.model.WorkerSummary} entries with {@code
  * ledgerEntryId} populated so new workers can set {@code causedByEntryId} on their own ledger
  * entries.
+ *
+ * <p>Implementations also populate {@link WorkerContext#channels()} by calling {@code
+ * CaseChannelProvider.listChannels(caseId)}, giving workers access to the channels open for their
+ * case during execution via {@link io.casehub.api.model.WorkerExecutionContext#current()}.
  */
 public interface WorkerContextProvider {
 
@@ -32,8 +37,10 @@ public interface WorkerContextProvider {
    * Build context for a worker about to start work on a task.
    *
    * @param workerId the ID of the worker being started
+   * @param caseId the ID of the case the worker is executing for; may be {@code null} for
+   *     provisioning-only flows where no live case exists yet
    * @param task the work request describing what the worker should do
-   * @return startup context including task description, channel, and lineage
+   * @return startup context including task description, open channels, and lineage
    */
-  WorkerContext buildContext(String workerId, WorkRequest task);
+  WorkerContext buildContext(String workerId, UUID caseId, WorkRequest task);
 }

--- a/api/src/test/java/io/casehub/api/model/WorkerExecutionContextTest.java
+++ b/api/src/test/java/io/casehub/api/model/WorkerExecutionContextTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.context.PropagationContext;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WorkerExecutionContextTest {
+
+  @AfterEach
+  void cleanup() {
+    WorkerExecutionContext.clear();
+  }
+
+  @Test
+  void current_returnsNullWhenNothingSet() {
+    assertThat(WorkerExecutionContext.current()).isNull();
+  }
+
+  @Test
+  void current_returnsContextAfterSet() {
+    WorkerContext ctx = minimalContext(UUID.randomUUID());
+    WorkerExecutionContext.set(ctx);
+    assertThat(WorkerExecutionContext.current()).isSameAs(ctx);
+  }
+
+  @Test
+  void clear_removesContext() {
+    WorkerExecutionContext.set(minimalContext(UUID.randomUUID()));
+    WorkerExecutionContext.clear();
+    assertThat(WorkerExecutionContext.current()).isNull();
+  }
+
+  @Test
+  void context_isThreadLocal_otherThreadSeesNull() throws InterruptedException {
+    WorkerExecutionContext.set(minimalContext(UUID.randomUUID()));
+
+    AtomicReference<WorkerContext> seenInOtherThread = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+
+    Thread other =
+        new Thread(
+            () -> {
+              seenInOtherThread.set(WorkerExecutionContext.current());
+              latch.countDown();
+            });
+    other.start();
+    latch.await();
+
+    assertThat(seenInOtherThread.get())
+        .as("other thread must not see the context set on this thread")
+        .isNull();
+  }
+
+  @Test
+  void set_replacesExistingContext() {
+    WorkerContext first = minimalContext(UUID.randomUUID());
+    WorkerContext second = minimalContext(UUID.randomUUID());
+    WorkerExecutionContext.set(first);
+    WorkerExecutionContext.set(second);
+    assertThat(WorkerExecutionContext.current()).isSameAs(second);
+  }
+
+  @Test
+  void current_exposesChannelsFromContext() {
+    UUID caseId = UUID.randomUUID();
+    CaseChannel channel =
+        new CaseChannel(caseId + "/coord", "coord", "coordination", "none", Map.of());
+    WorkerContext ctx =
+        new WorkerContext(
+            "desc", caseId, List.of(channel), List.of(), PropagationContext.createRoot(), Map.of());
+    WorkerExecutionContext.set(ctx);
+
+    assertThat(WorkerExecutionContext.current().channels()).containsExactly(channel);
+  }
+
+  private WorkerContext minimalContext(UUID caseId) {
+    return new WorkerContext(
+        "task", caseId, null, List.of(), PropagationContext.createRoot(), Map.of());
+  }
+}

--- a/api/src/test/java/io/casehub/api/spi/ReactiveWorkerContextProviderContractTest.java
+++ b/api/src/test/java/io/casehub/api/spi/ReactiveWorkerContextProviderContractTest.java
@@ -24,6 +24,7 @@ import io.casehub.api.model.WorkerContext;
 import io.smallrye.mutiny.Uni;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class ReactiveWorkerContextProviderContractTest {
@@ -32,7 +33,8 @@ class ReactiveWorkerContextProviderContractTest {
   void noOp_buildContext_returnsNonNullContext() {
     ReactiveWorkerContextProvider provider = new EmptyStub();
     WorkRequest task = WorkRequest.of("researcher", Map.of());
-    WorkerContext ctx = provider.buildContext("worker-1", task).await().indefinitely();
+    WorkerContext ctx =
+        provider.buildContext("worker-1", UUID.randomUUID(), task).await().indefinitely();
     assertThat(ctx).isNotNull();
     assertThat(ctx.priorWorkers()).isEmpty();
     assertThat(ctx.taskDescription()).isEqualTo("researcher");
@@ -42,7 +44,7 @@ class ReactiveWorkerContextProviderContractTest {
   void interface_hasBuildContextMethod() throws Exception {
     assertThat(
             ReactiveWorkerContextProvider.class.getMethod(
-                "buildContext", String.class, WorkRequest.class))
+                "buildContext", String.class, UUID.class, WorkRequest.class))
         .isNotNull();
   }
 
@@ -50,8 +52,23 @@ class ReactiveWorkerContextProviderContractTest {
   void emptyStub_propagationContext_isNotNull() {
     ReactiveWorkerContextProvider provider = new EmptyStub();
     WorkerContext ctx =
-        provider.buildContext("worker-1", WorkRequest.of("task", Map.of())).await().indefinitely();
+        provider
+            .buildContext("worker-1", UUID.randomUUID(), WorkRequest.of("task", Map.of()))
+            .await()
+            .indefinitely();
     assertThat(ctx.propagationContext()).isNotNull();
+  }
+
+  @Test
+  void caseId_isReflectedInContext() {
+    ReactiveWorkerContextProvider provider = new EmptyStub();
+    UUID caseId = UUID.randomUUID();
+    WorkerContext ctx =
+        provider
+            .buildContext("worker-1", caseId, WorkRequest.of("task", Map.of()))
+            .await()
+            .indefinitely();
+    assertThat(ctx.caseId()).isEqualTo(caseId);
   }
 
   @Test
@@ -60,18 +77,21 @@ class ReactiveWorkerContextProviderContractTest {
     assertThatNoException()
         .isThrownBy(
             () ->
-                provider.buildContext("", WorkRequest.of("task", Map.of())).await().indefinitely());
+                provider
+                    .buildContext("", UUID.randomUUID(), WorkRequest.of("task", Map.of()))
+                    .await()
+                    .indefinitely());
   }
 
   static class EmptyStub implements ReactiveWorkerContextProvider {
 
     @Override
-    public Uni<WorkerContext> buildContext(String workerId, WorkRequest task) {
+    public Uni<WorkerContext> buildContext(String workerId, UUID caseId, WorkRequest task) {
       return Uni.createFrom()
           .item(
               new WorkerContext(
                   task.capability(),
-                  null,
+                  caseId,
                   null,
                   List.of(),
                   PropagationContext.createRoot(),

--- a/api/src/test/java/io/casehub/api/spi/WorkerContextProviderContractTest.java
+++ b/api/src/test/java/io/casehub/api/spi/WorkerContextProviderContractTest.java
@@ -23,6 +23,7 @@ import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkerContext;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class WorkerContextProviderContractTest {
@@ -30,7 +31,8 @@ class WorkerContextProviderContractTest {
   @Test
   void interface_hasBuildContextMethod() throws Exception {
     assertThat(
-            WorkerContextProvider.class.getMethod("buildContext", String.class, WorkRequest.class))
+            WorkerContextProvider.class.getMethod(
+                "buildContext", String.class, UUID.class, WorkRequest.class))
         .isNotNull();
   }
 
@@ -38,7 +40,7 @@ class WorkerContextProviderContractTest {
   void happyPath_returnsNonNullContext() {
     WorkerContextProvider provider = new EmptyStub();
     WorkRequest task = WorkRequest.of("code-reviewer", Map.of("branch", "main"));
-    WorkerContext ctx = provider.buildContext("worker-1", task);
+    WorkerContext ctx = provider.buildContext("worker-1", UUID.randomUUID(), task);
     assertThat(ctx).isNotNull();
   }
 
@@ -46,7 +48,7 @@ class WorkerContextProviderContractTest {
   void emptyStub_priorWorkers_isEmptyNotNull() {
     WorkerContextProvider provider = new EmptyStub();
     WorkRequest task = WorkRequest.of("researcher", Map.of());
-    WorkerContext ctx = provider.buildContext("worker-1", task);
+    WorkerContext ctx = provider.buildContext("worker-1", UUID.randomUUID(), task);
     assertThat(ctx.priorWorkers()).isNotNull().isEmpty();
   }
 
@@ -54,7 +56,7 @@ class WorkerContextProviderContractTest {
   void emptyStub_taskDescription_matchesCapability() {
     WorkerContextProvider provider = new EmptyStub();
     WorkRequest task = WorkRequest.of("security-auditor", Map.of());
-    WorkerContext ctx = provider.buildContext("worker-1", task);
+    WorkerContext ctx = provider.buildContext("worker-1", UUID.randomUUID(), task);
     assertThat(ctx.taskDescription()).isEqualTo("security-auditor");
   }
 
@@ -62,22 +64,38 @@ class WorkerContextProviderContractTest {
   void emptyStub_propagationContext_isNotNull() {
     WorkerContextProvider provider = new EmptyStub();
     WorkRequest task = WorkRequest.of("task", Map.of());
-    WorkerContext ctx = provider.buildContext("worker-1", task);
+    WorkerContext ctx = provider.buildContext("worker-1", UUID.randomUUID(), task);
     assertThat(ctx.propagationContext()).isNotNull();
+  }
+
+  @Test
+  void caseId_isReflectedInContext() {
+    WorkerContextProvider provider = new EmptyStub();
+    UUID caseId = UUID.randomUUID();
+    WorkRequest task = WorkRequest.of("task", Map.of());
+    WorkerContext ctx = provider.buildContext("worker-1", caseId, task);
+    assertThat(ctx.caseId()).isEqualTo(caseId);
+  }
+
+  @Test
+  void nullCaseId_isHandled() {
+    WorkerContextProvider provider = new EmptyStub();
+    WorkRequest task = WorkRequest.of("task", Map.of());
+    assertThatNoException().isThrownBy(() -> provider.buildContext("worker-1", null, task));
   }
 
   @Test
   void robustness_emptyWorkerId_isHandled() {
     WorkerContextProvider provider = new EmptyStub();
     WorkRequest task = WorkRequest.of("task", Map.of());
-    assertThatNoException().isThrownBy(() -> provider.buildContext("", task));
+    assertThatNoException().isThrownBy(() -> provider.buildContext("", UUID.randomUUID(), task));
   }
 
   static class EmptyStub implements WorkerContextProvider {
     @Override
-    public WorkerContext buildContext(String workerId, WorkRequest task) {
+    public WorkerContext buildContext(String workerId, UUID caseId, WorkRequest task) {
       return new WorkerContext(
-          task.capability(), null, null, List.of(), PropagationContext.createRoot(), Map.of());
+          task.capability(), caseId, null, List.of(), PropagationContext.createRoot(), Map.of());
     }
   }
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -27,7 +27,7 @@ Manages storage and retrieval of domain objects. Uses JPA/Panache for production
 Orchestrates case execution via:
 
 - **`CaseContextChangedEventHandler`** — watches for context changes, evaluates bindings, triggers choreography
-- **`WorkerScheduleEventHandler`** — calls `WorkerContextProvider.buildContext()` then schedules work in Quartz
+- **`WorkerScheduleEventHandler`** — calls `WorkerContextProvider.buildContext()` (timing contract), schedules work in Quartz via `QuartzWorkerExecutionJob` which re-calls `buildContext` and sets `WorkerExecutionContext` for the worker function
 - **`WorkflowExecutionCompletedHandler`** — processes work completion, resumes WAITING cases
 - **`EventLog`** — persistent audit trail of all decisions and state changes
 
@@ -316,7 +316,8 @@ Four dual-stack SPI interfaces (blocking + reactive) enable external systems to 
 **Model types** in `api/model/`:
 - `CaseChannel` — backend-agnostic channel reference with extensible `properties` map
 - `WorkerSummary` — prior worker's execution summary, includes `ledgerEntryId` (UUID of the `WORKER_EXECUTION_COMPLETED` ledger entry)
-- `WorkerContext` — startup context for a newly provisioned worker, includes `channels` (all open channels for the case), `priorWorkers` list, and causal chain metadata. Real `WorkerContextProvider` implementations populate `channels` via `CaseChannelProvider.listChannels(caseId)` so workers can call `postToChannel` during execution.
+- `WorkerContext` — startup context handed to a worker at execution time; includes `channels` (all open channels for the case, from `CaseChannelProvider.listChannels(caseId)`), `priorWorkers` list, `caseId`, and causal chain metadata
+- `WorkerExecutionContext` — thread-local holder set by `QuartzWorkerExecutionJob` immediately before calling the worker function; cleared in a `finally` block after execution. Workers call `WorkerExecutionContext.current()` to access their `WorkerContext` (including channels) at runtime
 - `ProvisionContext` — input to `WorkerProvisioner.provision()`, contains the work request and case metadata
 
 **Channel layering:** casehub-engine does not own the Channel concept — that belongs to Qhorus. `CaseChannelProvider` is a thin bridge associating channels with case lifecycle: open on case start, close on terminal state, post for worker messages. Backend variety (Qhorus, Slack, WhatsApp, DB) is entirely a Qhorus concern — zero engine changes when a new backend is added. See casehubio/qhorus#131 for the generalised Channel design and casehubio/engine#220 for the SPI contract.
@@ -324,16 +325,18 @@ Four dual-stack SPI interfaces (blocking + reactive) enable external systems to 
 ```
 Backend (Qhorus / Slack / WhatsApp / DB)
     ↓
-CaseChannelProvider SPI   ← engine's only concern
+CaseChannelProvider SPI        ← engine's only concern
     ↓
-WorkerContext.channels()  ← workers post to the case's channels
+WorkerContext.channels()       ← channels available to the worker
+    ↓
+WorkerExecutionContext.current() ← accessed by the worker function at runtime
 ```
 
 **Default implementations** in `engine/internal/worker/`:
 - `NoOpWorkerProvisioner` — throws `ProvisioningException` (never called unless provisioner advertises capabilities)
 - `NoOpWorkerStatusListener` — silently ignores all lifecycle events
 - `NoOpCaseChannelProvider` — returns sentinel channels with `backendType = "none"`; `postToChannel` and `closeChannel` are no-ops; `listChannels` returns empty list
-- `EmptyWorkerContextProvider` — returns minimal context with empty `channels` and `priorWorkers` lists
+- `EmptyWorkerContextProvider` — injects `CaseChannelProvider`; populates `channels` via `listChannels(caseId)` and `caseId` on the context; `priorWorkers` is empty (no ledger query)
 - Four `@Alternative` reactive mirrors for optional reactive pipeline use
 
 **Causal chain:** When a worker completes, `CaseLedgerEventCapture` writes a `WORKER_EXECUTION_COMPLETED` ledger entry. The `WorkerSummary` for that worker carries this entry's UUID as `ledgerEntryId`. New workers set `causedByEntryId` on their own ledger entries to this value, completing the causal chain across workers on a case.
@@ -342,15 +345,16 @@ WorkerContext.channels()  ← workers post to the case's channels
 
 ### SPI Call Sites
 
-All seven engine SPI call sites, in lifecycle order:
+All engine SPI call sites, in lifecycle order:
 
-| SPI method | Called in | When |
+| SPI method / action | Called in | When |
 |---|---|---|
 | `CaseChannelProvider.openChannel` | `CaseStartedEventHandler.onCaseStarted` | Case transitions to RUNNING |
 | `CaseChannelProvider.openChannel` + `postToChannel` | `WorkerScheduleEventHandler.dispatchCommand` | Worker scheduled — opens worker-specific channel, posts Qhorus COMMAND |
-| `WorkerContextProvider.buildContext` | `WorkerScheduleEventHandler.onWorkerScheduleEventHandler` | Before Quartz job is submitted |
+| `WorkerContextProvider.buildContext` | `WorkerScheduleEventHandler.onWorkerScheduleEventHandler` | Before Quartz job is submitted (timing contract) |
 | `WorkerProvisioner.provision` | `CaseContextChangedEventHandler.tryProvision` | No pre-defined workers match capability AND provisioner advertises it |
 | `WorkerStatusListener.onWorkerStarted` | `WorkerExecutionJobListener.jobToBeExecuted` | Quartz job begins execution |
+| `WorkerContextProvider.buildContext` + `WorkerExecutionContext.set` | `QuartzWorkerExecutionJob.execute` | Immediately before worker function is invoked — populates channels, sets thread-local |
 | `WorkerStatusListener.onWorkerCompleted` | `WorkflowExecutionCompletedHandler` | Worker function returns successfully |
 | `WorkerStatusListener.onWorkerStalled` | `WorkerRetriesExhaustedEventHandler` | All retries exhausted; case transitions to FAULTED |
 | `CaseChannelProvider.closeChannel` | `CaseStatusChangedHandler` | Case reaches terminal state (COMPLETED / FAULTED / CANCELLED) |

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -299,7 +299,8 @@ public class CaseContextChangedEventHandler {
       Map<String, Object> inputData =
           caseInstance.getCaseContext().evalObjectTemplate(capability.getInputSchema());
       WorkRequest workRequest = WorkRequest.of(capability.getName(), inputData);
-      WorkerContext workerContext = workerContextProvider.buildContext(null, workRequest);
+      WorkerContext workerContext =
+          workerContextProvider.buildContext(null, caseInstance.getUuid(), workRequest);
       ProvisionContext provisionContext =
           new ProvisionContext(
               caseInstance.getUuid(),

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -97,7 +97,7 @@ public class WorkerScheduleEventHandler {
         instance.getCaseContext().evalObjectTemplate(capability.getInputSchema());
 
     workerContextProvider.buildContext(
-        worker.getName(), WorkRequest.of(capability.getName(), inputData));
+        worker.getName(), instance.getUuid(), WorkRequest.of(capability.getName(), inputData));
 
     EventLog eventLog = buildEventLog(instance, worker, capability, inputData, inputDataHash);
 

--- a/engine/src/main/java/io/casehub/engine/internal/worker/EmptyReactiveWorkerContextProvider.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/EmptyReactiveWorkerContextProvider.java
@@ -16,34 +16,45 @@
 package io.casehub.engine.internal.worker;
 
 import io.casehub.api.context.PropagationContext;
+import io.casehub.api.model.CaseChannel;
 import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkerContext;
+import io.casehub.api.spi.ReactiveCaseChannelProvider;
 import io.casehub.api.spi.ReactiveWorkerContextProvider;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Reactive default WorkerContextProvider. Returns a minimal context with the task capability as the
- * description and an empty prior-workers list.
+ * description, prior-worker history omitted, and open channels populated from {@link
+ * ReactiveCaseChannelProvider#listChannels(UUID)}.
  *
- * <p>Marked {@code @Alternative} — not the primary bean. Replace with a real implementation that
- * queries the ledger for prior worker history when context propagation is needed.
+ * <p>Marked {@code @Alternative} — not the primary bean.
  */
 @Alternative
 @ApplicationScoped
 public class EmptyReactiveWorkerContextProvider implements ReactiveWorkerContextProvider {
 
+  @Inject
+  ReactiveCaseChannelProvider reactiveCaseChannelProvider; // package-private for test injection
+
   @Override
-  public Uni<WorkerContext> buildContext(String workerId, WorkRequest task) {
-    return Uni.createFrom()
-        .item(
+  public Uni<WorkerContext> buildContext(String workerId, UUID caseId, WorkRequest task) {
+    Uni<List<CaseChannel>> channelsUni =
+        caseId != null
+            ? reactiveCaseChannelProvider.listChannels(caseId)
+            : Uni.createFrom().item(List.of());
+    return channelsUni.map(
+        channels ->
             new WorkerContext(
                 task.capability(),
-                null,
-                null,
+                caseId,
+                channels,
                 List.of(),
                 PropagationContext.createRoot(),
                 Map.of()));

--- a/engine/src/main/java/io/casehub/engine/internal/worker/EmptyWorkerContextProvider.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/EmptyWorkerContextProvider.java
@@ -16,23 +16,32 @@
 package io.casehub.engine.internal.worker;
 
 import io.casehub.api.context.PropagationContext;
+import io.casehub.api.model.CaseChannel;
 import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkerContext;
+import io.casehub.api.spi.CaseChannelProvider;
 import io.casehub.api.spi.WorkerContextProvider;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Default WorkerContextProvider. Returns a minimal context with the task capability as the
- * description and an empty prior-workers list.
+ * description, prior-worker history omitted, and open channels populated from {@link
+ * CaseChannelProvider#listChannels(UUID)}.
  */
 @ApplicationScoped
 public class EmptyWorkerContextProvider implements WorkerContextProvider {
 
+  @Inject CaseChannelProvider caseChannelProvider; // package-private for test injection
+
   @Override
-  public WorkerContext buildContext(String workerId, WorkRequest task) {
+  public WorkerContext buildContext(String workerId, UUID caseId, WorkRequest task) {
+    List<CaseChannel> channels =
+        caseId != null ? caseChannelProvider.listChannels(caseId) : List.of();
     return new WorkerContext(
-        task.capability(), null, null, List.of(), PropagationContext.createRoot(), Map.of());
+        task.capability(), caseId, channels, List.of(), PropagationContext.createRoot(), Map.of());
   }
 }

--- a/engine/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
+++ b/engine/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
@@ -30,6 +30,7 @@ import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.WorkerContext;
+import io.casehub.api.model.WorkerExecutionContext;
 import io.casehub.api.spi.CaseChannelProvider;
 import io.casehub.api.spi.ProvisioningException;
 import io.casehub.api.spi.WorkerContextProvider;
@@ -55,7 +56,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Verifies that WorkerStatusListener, WorkerContextProvider, CaseChannelProvider, and
  * WorkerProvisioner are called at the correct lifecycle points by the engine. Refs
- * casehubio/engine#152, casehubio/engine#191.
+ * casehubio/engine#152, casehubio/engine#191, casehubio/engine#220.
  */
 @QuarkusTest
 class SpiWiringIntegrationTest {
@@ -63,6 +64,7 @@ class SpiWiringIntegrationTest {
   @Inject SimpleCaseHubBean simpleCaseHubBean;
   @Inject CaseFaultedStateTest.AlwaysFailingCaseHubBean alwaysFailingBean;
   @Inject ProvisionerTriggerCaseHubBean provisionerTriggerBean;
+  @Inject RecordingContextCaseHubBean recordingContextBean;
   @Inject CaseInstanceCache caseInstanceCache;
   @Inject RecordingWorkerStatusListener statusListener;
   @Inject RecordingCaseChannelProvider channelProvider;
@@ -199,8 +201,27 @@ class SpiWiringIntegrationTest {
   }
 
   // ------------------------------------------------------------------ //
-  // WorkerContextProvider                                                 //
+  // WorkerContextProvider + WorkerExecutionContext                        //
   // ------------------------------------------------------------------ //
+
+  @Test
+  void workerExecutionContext_channelsAccessibleDuringExecution() {
+    RecordingExecutionContextWorker.capturedChannels.clear();
+    recordingContextBean
+        .startCase(Map.of("documentId", "doc-exec-ctx-1", "status", "processing"))
+        .toCompletableFuture()
+        .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingExecutionContextWorker.capturedChannels)
+                    .as(
+                        "WorkerExecutionContext.current() must be non-null with channels during"
+                            + " worker function execution")
+                    .isNotEmpty());
+  }
 
   @Test
   void buildContextCalledBeforeWorkerExecution() {
@@ -330,10 +351,10 @@ class SpiWiringIntegrationTest {
     }
 
     @Override
-    public WorkerContext buildContext(String workerId, WorkRequest task) {
+    public WorkerContext buildContext(String workerId, UUID caseId, WorkRequest task) {
       buildContextCallCount.incrementAndGet();
       seenCapabilities.add(task.capability());
-      return new WorkerContext(task.capability(), null, null, List.of(), null, Map.of());
+      return new WorkerContext(task.capability(), caseId, null, List.of(), null, Map.of());
     }
   }
 
@@ -450,6 +471,58 @@ class SpiWiringIntegrationTest {
                   .name("trigger-on-pending")
                   .capability(capability)
                   .on(new ContextChangeTrigger(".status == \"pending\""))
+                  .build())
+          .build();
+    }
+  }
+
+  // ------------------------------------------------------------------ //
+  // WorkerExecutionContext wiring                                         //
+  // ------------------------------------------------------------------ //
+
+  /** Worker that captures the channels visible via WorkerExecutionContext during execution. */
+  public static class RecordingExecutionContextWorker {
+    static final List<List<CaseChannel>> capturedChannels = new CopyOnWriteArrayList<>();
+  }
+
+  @ApplicationScoped
+  public static class RecordingContextCaseHubBean extends CaseHub {
+
+    @Override
+    public CaseDefinition getDefinition() {
+      Capability capability =
+          Capability.builder()
+              .name("recordContext")
+              .inputSchema("{ documentId: .documentId }")
+              .outputSchema("{ recorded: true }")
+              .build();
+
+      Worker worker =
+          Worker.builder()
+              .name("execution-context-recorder")
+              .capabilities(capability)
+              .function(
+                  (java.util.function.Function<Map<String, Object>, Map<String, Object>>)
+                      input -> {
+                        WorkerContext ctx = WorkerExecutionContext.current();
+                        if (ctx != null) {
+                          RecordingExecutionContextWorker.capturedChannels.add(ctx.channels());
+                        }
+                        return Map.of("recorded", true);
+                      })
+              .build();
+
+      return CaseDefinition.builder()
+          .namespace("test")
+          .name("Execution Context Recording Case")
+          .version("1.0.0")
+          .capabilities(capability)
+          .workers(worker)
+          .bindings(
+              Binding.builder()
+                  .name("trigger-on-processing")
+                  .capability(capability)
+                  .on(new ContextChangeTrigger(".status == \"processing\""))
                   .build())
           .build();
     }

--- a/engine/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
@@ -18,6 +18,8 @@ package io.casehub.engine.internal.worker;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.casehub.api.context.PropagationContext;
 import io.casehub.api.model.CaseChannel;
@@ -25,7 +27,10 @@ import io.casehub.api.model.ProvisionContext;
 import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.WorkerContext;
+import io.casehub.api.spi.CaseChannelProvider;
 import io.casehub.api.spi.ProvisioningException;
+import io.casehub.api.spi.ReactiveCaseChannelProvider;
+import io.smallrye.mutiny.Uni;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -131,22 +136,55 @@ class DefaultWorkerSpiImplementationsTest {
   @Test
   void emptyContextProvider_buildContext_taskDescriptionMatchesCapability() {
     var provider = new EmptyWorkerContextProvider();
-    WorkerContext ctx = provider.buildContext("worker-1", WorkRequest.of("researcher", Map.of()));
+    WorkerContext ctx =
+        provider.buildContext("worker-1", null, WorkRequest.of("researcher", Map.of()));
     assertThat(ctx.taskDescription()).isEqualTo("researcher");
   }
 
   @Test
   void emptyContextProvider_buildContext_priorWorkersIsEmptyNotNull() {
     var provider = new EmptyWorkerContextProvider();
-    WorkerContext ctx = provider.buildContext("worker-1", WorkRequest.of("task", Map.of()));
+    WorkerContext ctx = provider.buildContext("worker-1", null, WorkRequest.of("task", Map.of()));
     assertThat(ctx.priorWorkers()).isNotNull().isEmpty();
   }
 
   @Test
   void emptyContextProvider_buildContext_propagationContextIsNotNull() {
     var provider = new EmptyWorkerContextProvider();
-    WorkerContext ctx = provider.buildContext("worker-1", WorkRequest.of("task", Map.of()));
+    WorkerContext ctx = provider.buildContext("worker-1", null, WorkRequest.of("task", Map.of()));
     assertThat(ctx.propagationContext()).isNotNull();
+  }
+
+  @Test
+  void emptyContextProvider_buildContext_caseIdPopulated() {
+    var provider = new EmptyWorkerContextProvider();
+    UUID caseId = UUID.randomUUID();
+    provider.caseChannelProvider = mock(CaseChannelProvider.class);
+    when(provider.caseChannelProvider.listChannels(caseId)).thenReturn(List.of());
+    WorkerContext ctx = provider.buildContext("worker-1", caseId, WorkRequest.of("task", Map.of()));
+    assertThat(ctx.caseId()).isEqualTo(caseId);
+  }
+
+  @Test
+  void emptyContextProvider_buildContext_channelsPopulatedFromProvider() {
+    UUID caseId = UUID.randomUUID();
+    CaseChannel channel =
+        new CaseChannel(caseId + "/coord", "coord", "coordination", "none", Map.of());
+    CaseChannelProvider mockProvider = mock(CaseChannelProvider.class);
+    when(mockProvider.listChannels(caseId)).thenReturn(List.of(channel));
+
+    var provider = new EmptyWorkerContextProvider();
+    provider.caseChannelProvider = mockProvider;
+
+    WorkerContext ctx = provider.buildContext("worker-1", caseId, WorkRequest.of("task", Map.of()));
+    assertThat(ctx.channels()).containsExactly(channel);
+  }
+
+  @Test
+  void emptyContextProvider_buildContext_nullCaseId_channelsEmpty() {
+    var provider = new EmptyWorkerContextProvider();
+    WorkerContext ctx = provider.buildContext("worker-1", null, WorkRequest.of("task", Map.of()));
+    assertThat(ctx.channels()).isEmpty();
   }
 
   // --- NoOpReactiveWorkerProvisioner ---
@@ -233,7 +271,7 @@ class DefaultWorkerSpiImplementationsTest {
     var provider = new EmptyReactiveWorkerContextProvider();
     WorkerContext ctx =
         provider
-            .buildContext("worker-1", WorkRequest.of("researcher", Map.of()))
+            .buildContext("worker-1", null, WorkRequest.of("researcher", Map.of()))
             .await()
             .indefinitely();
     assertThat(ctx.taskDescription()).isEqualTo("researcher");
@@ -243,7 +281,10 @@ class DefaultWorkerSpiImplementationsTest {
   void emptyReactiveContextProvider_buildContext_priorWorkersIsEmpty() {
     var provider = new EmptyReactiveWorkerContextProvider();
     WorkerContext ctx =
-        provider.buildContext("worker-1", WorkRequest.of("task", Map.of())).await().indefinitely();
+        provider
+            .buildContext("worker-1", null, WorkRequest.of("task", Map.of()))
+            .await()
+            .indefinitely();
     assertThat(ctx.priorWorkers()).isNotNull().isEmpty();
   }
 
@@ -251,7 +292,41 @@ class DefaultWorkerSpiImplementationsTest {
   void emptyReactiveContextProvider_buildContext_propagationContextIsNotNull() {
     var provider = new EmptyReactiveWorkerContextProvider();
     WorkerContext ctx =
-        provider.buildContext("w", WorkRequest.of("task", Map.of())).await().indefinitely();
+        provider.buildContext("w", null, WorkRequest.of("task", Map.of())).await().indefinitely();
     assertThat(ctx.propagationContext()).isNotNull();
+  }
+
+  @Test
+  void emptyReactiveContextProvider_buildContext_caseIdPopulated() {
+    UUID caseId = UUID.randomUUID();
+    ReactiveCaseChannelProvider mockProvider = mock(ReactiveCaseChannelProvider.class);
+    when(mockProvider.listChannels(caseId)).thenReturn(Uni.createFrom().item(List.of()));
+    var provider = new EmptyReactiveWorkerContextProvider();
+    provider.reactiveCaseChannelProvider = mockProvider;
+    WorkerContext ctx =
+        provider
+            .buildContext("worker-1", caseId, WorkRequest.of("task", Map.of()))
+            .await()
+            .indefinitely();
+    assertThat(ctx.caseId()).isEqualTo(caseId);
+  }
+
+  @Test
+  void emptyReactiveContextProvider_buildContext_channelsPopulatedFromProvider() {
+    UUID caseId = UUID.randomUUID();
+    CaseChannel channel =
+        new CaseChannel(caseId + "/coord", "coord", "coordination", "none", Map.of());
+    ReactiveCaseChannelProvider mockProvider = mock(ReactiveCaseChannelProvider.class);
+    when(mockProvider.listChannels(caseId)).thenReturn(Uni.createFrom().item(List.of(channel)));
+
+    var provider = new EmptyReactiveWorkerContextProvider();
+    provider.reactiveCaseChannelProvider = mockProvider;
+
+    WorkerContext ctx =
+        provider
+            .buildContext("worker-1", caseId, WorkRequest.of("task", Map.of()))
+            .await()
+            .indefinitely();
+    assertThat(ctx.channels()).containsExactly(channel);
   }
 }

--- a/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJob.java
+++ b/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJob.java
@@ -21,7 +21,11 @@ import static io.casehub.engine.internal.event.EventBusAddresses.WORKER_EXECUTIO
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerContext;
+import io.casehub.api.model.WorkerExecutionContext;
+import io.casehub.api.spi.WorkerContextProvider;
 import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.model.CaseInstance;
@@ -56,6 +60,8 @@ class QuartzWorkerExecutionJob implements Job {
   @Inject WorkflowExecutor workflowExecutor;
 
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
+
+  @Inject WorkerContextProvider workerContextProvider;
 
   @Inject Vertx vertx;
 
@@ -132,12 +138,16 @@ class QuartzWorkerExecutionJob implements Job {
 
     int timeoutMs = executionConfig.getEffectiveTimeout(worker.getExecutionPolicy().timeoutMs());
 
+    WorkerContext workerContext =
+        workerContextProvider.buildContext(
+            workflowId, eventLog.getCaseId(), WorkRequest.of(capabilityName, inputData));
+
     Map<String, Object> outputData;
     try {
       if (worker.getFunction().getValue() instanceof Workflow workflow) {
-        outputData = workflow(workflow, inputData, timeoutMs);
+        outputData = workflow(workflow, inputData, workerContext, timeoutMs);
       } else if (worker.getFunction().getValue() instanceof Function function) {
-        outputData = function(function, inputData, timeoutMs);
+        outputData = function(function, inputData, workerContext, timeoutMs);
       } else {
         throw new RuntimeException(
             "Worker function is not a workflow: "
@@ -164,15 +174,11 @@ class QuartzWorkerExecutionJob implements Job {
   }
 
   private Map<String, Object> workflow(
-      Workflow workflow, Map<String, Object> inputData, int timeoutMs)
+      Workflow workflow, Map<String, Object> inputData, WorkerContext workerContext, int timeoutMs)
       throws TimeoutException, InterruptedException, ExecutionException {
-    CompletableFuture<WorkflowModel> cf = workflowExecutor.execute(workflow, inputData);
-
     LOG.debugf("Executing workflow with timeout: %d ms", timeoutMs);
-
-    // Use get() with timeout instead of join() to handle timeouts
+    CompletableFuture<WorkflowModel> cf = workflowExecutor.execute(workflow, inputData);
     WorkflowModel workflowModel = cf.get(timeoutMs, TimeUnit.MILLISECONDS);
-
     return workflowModel
         .asMap()
         .orElseThrow(() -> new RuntimeException("Failed to convert workflow model to map"));
@@ -181,14 +187,22 @@ class QuartzWorkerExecutionJob implements Job {
   private Map<String, Object> function(
       Function<Map<String, Object>, Map<String, Object>> function,
       Map<String, Object> inputData,
+      WorkerContext workerContext,
       int timeoutMs)
       throws TimeoutException, InterruptedException, ExecutionException {
 
     LOG.debugf("Executing function with timeout: %d ms", timeoutMs);
 
-    // Execute function in a separate thread with timeout
     CompletableFuture<Map<String, Object>> cf =
-        CompletableFuture.supplyAsync(() -> function.apply(inputData));
+        CompletableFuture.supplyAsync(
+            () -> {
+              WorkerExecutionContext.set(workerContext);
+              try {
+                return function.apply(inputData);
+              } finally {
+                WorkerExecutionContext.clear();
+              }
+            });
 
     return cf.get(timeoutMs, TimeUnit.MILLISECONDS);
   }


### PR DESCRIPTION
## What

Completes engine#220 — the part that didn't make it into the squash merge of #224.

PR #224 landed `WorkerContext.channels` (the field). This PR wires it end-to-end so workers can actually read their case's open channels at runtime.

## Three changes

**1. `WorkerContextProvider.buildContext()` gains `UUID caseId`** (blocking + reactive SPIs)

Without the case ID, the provider cannot call `listChannels(caseId)` — it has no way to know which channels belong to the current case. This is a breaking change for SPI implementors; the `EmptyWorkerContextProvider` default handles the migration.

**2. `EmptyWorkerContextProvider` injects `CaseChannelProvider`, populates channels**

`WorkerContext.channels()` now returns real channel references instead of an empty list. `EmptyReactiveWorkerContextProvider` updated in parallel.

**3. `WorkerExecutionContext` — new thread-local holder**

Worker functions (`Function<Map, Map>`) have no context parameter. This thread-local, set inside the `CompletableFuture.supplyAsync` lambda immediately before the function runs and cleared in `finally`, gives workers runtime access:

```java
WorkerContext ctx = WorkerExecutionContext.current();
List<CaseChannel> channels = ctx.channels(); // channels open for this case
```

Key gotcha: setting the ThreadLocal on the Quartz thread before `supplyAsync` is invisible to the lambda (ForkJoinPool thread). Must set it inside the lambda.

## Tests

- `WorkerExecutionContextTest` — 6 unit tests (thread-local semantics, thread isolation)
- Contract tests updated for new `buildContext(String, UUID, WorkRequest)` signature
- `DefaultWorkerSpiImplementationsTest` — channel-population tests with Mockito
- `SpiWiringIntegrationTest` — `workerExecutionContext_channelsAccessibleDuringExecution` E2E test

## Why this matters

Without this, the channel infrastructure existed but workers had no runtime access to it. Workers could receive tasks but had no way to post back to their case's communication channels during execution.

Refs casehubio/engine#220
Related: casehubio/qhorus#131

🤖 Generated with [Claude Code](https://claude.ai/claude-code)