### PR TITLE
feat: add MessageType to CaseChannelProvider.postToChannel() (engine#221)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Eight interfaces in `api/src/main/java/io/casehub/api/spi/` (four blocking + fou
 
 - `WorkerProvisioner` / `ReactiveWorkerProvisioner` — provision and terminate workers
 - `WorkerStatusListener` / `ReactiveWorkerStatusListener` — lifecycle callbacks (started, completed, stalled)
-- `CaseChannelProvider` / `ReactiveCaseChannelProvider` — open/close/post to backend-agnostic channels
+- `CaseChannelProvider` / `ReactiveCaseChannelProvider` — open/close/post to backend-agnostic channels. **`postToChannel` takes a 4th `MessageType` parameter** (from `casehub-qhorus-api`, managed in root `pom.xml`); the 3-arg overload is a `default` delegating with `null`. Call sites that know the intent pass `MessageType.COMMAND` etc. explicitly — `WorkerScheduleEventHandler.dispatchCommand` does this.
 - `WorkerContextProvider` / `ReactiveWorkerContextProvider` — build startup context from ledger lineage
 
 **Default implementations** in `engine/src/main/java/io/casehub/engine/internal/worker/`:
@@ -96,6 +96,7 @@ To add a new operational SPI: define the interface in `api/spi/`, add a no-op de
 | `WorkerStatusListener.onWorkerCompleted` | `WorkflowExecutionCompletedHandler` | Worker function returns |
 | `WorkerStatusListener.onWorkerStalled` | `WorkerRetriesExhaustedEventHandler` | All retries exhausted |
 | `CaseChannelProvider.openChannel` | `CaseStartedEventHandler` | Case starts |
+| `CaseChannelProvider.openChannel` + `postToChannel(..., MessageType.COMMAND)` | `WorkerScheduleEventHandler.dispatchCommand` | Worker scheduled — opens channel, posts COMMAND |
 | `CaseChannelProvider.closeChannel` | `CaseStatusChangedHandler` | Case reaches terminal state |
 | `WorkerContextProvider.buildContext` | `WorkerScheduleEventHandler` | Before Quartz job is submitted (timing contract) |
 | `WorkerContextProvider.buildContext` + `WorkerExecutionContext.set` | `QuartzWorkerExecutionJob` | Immediately before worker function — sets thread-local with channels |

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,6 +34,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-qhorus-api</artifactId>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/api/src/main/java/io/casehub/api/spi/CaseChannelProvider.java
+++ b/api/src/main/java/io/casehub/api/spi/CaseChannelProvider.java
@@ -16,6 +16,7 @@
 package io.casehub.api.spi;
 
 import io.casehub.api.model.CaseChannel;
+import io.casehub.qhorus.api.message.MessageType;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,8 +44,22 @@ public interface CaseChannelProvider {
    * @param channel the channel reference returned by {@link #openChannel}
    * @param from sender identity (worker ID or "human")
    * @param content message content
+   * @param type the intent type of the message (e.g. {@link MessageType#COMMAND}); {@code null} if
+   *     unspecified
    */
-  void postToChannel(CaseChannel channel, String from, String content);
+  void postToChannel(CaseChannel channel, String from, String content, MessageType type);
+
+  /**
+   * Post a message to a channel. Delegates to {@link #postToChannel(CaseChannel, String, String,
+   * MessageType)} with {@code type = null}.
+   *
+   * @param channel the channel reference returned by {@link #openChannel}
+   * @param from sender identity (worker ID or "human")
+   * @param content message content
+   */
+  default void postToChannel(CaseChannel channel, String from, String content) {
+    postToChannel(channel, from, content, null);
+  }
 
   /**
    * Close a channel. No-op if the channel is unknown or already closed.

--- a/api/src/main/java/io/casehub/api/spi/ReactiveCaseChannelProvider.java
+++ b/api/src/main/java/io/casehub/api/spi/ReactiveCaseChannelProvider.java
@@ -16,6 +16,7 @@
 package io.casehub.api.spi;
 
 import io.casehub.api.model.CaseChannel;
+import io.casehub.qhorus.api.message.MessageType;
 import io.smallrye.mutiny.Uni;
 import java.util.List;
 import java.util.UUID;
@@ -43,9 +44,24 @@ public interface ReactiveCaseChannelProvider {
    * @param channel the channel reference returned by {@link #openChannel}
    * @param from sender identity (worker ID or "human")
    * @param content message content
+   * @param type the intent type of the message (e.g. {@link MessageType#COMMAND}); {@code null} if
+   *     unspecified
    * @return a {@code Uni} completing with {@code null} on success
    */
-  Uni<Void> postToChannel(CaseChannel channel, String from, String content);
+  Uni<Void> postToChannel(CaseChannel channel, String from, String content, MessageType type);
+
+  /**
+   * Post a message to a channel. Delegates to {@link #postToChannel(CaseChannel, String, String,
+   * MessageType)} with {@code type = null}.
+   *
+   * @param channel the channel reference returned by {@link #openChannel}
+   * @param from sender identity (worker ID or "human")
+   * @param content message content
+   * @return a {@code Uni} completing with {@code null} on success
+   */
+  default Uni<Void> postToChannel(CaseChannel channel, String from, String content) {
+    return postToChannel(channel, from, content, null);
+  }
 
   /**
    * Close a channel. No-op if the channel is unknown or already closed.

--- a/api/src/test/java/io/casehub/api/spi/CaseChannelProviderContractTest.java
+++ b/api/src/test/java/io/casehub/api/spi/CaseChannelProviderContractTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.casehub.api.model.CaseChannel;
+import io.casehub.qhorus.api.message.MessageType;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -33,10 +34,18 @@ class CaseChannelProviderContractTest {
   }
 
   @Test
-  void interface_hasPostToChannelMethod() throws Exception {
+  void interface_hasPostToChannelDefaultMethod() throws Exception {
     assertThat(
             CaseChannelProvider.class.getMethod(
                 "postToChannel", CaseChannel.class, String.class, String.class))
+        .isNotNull();
+  }
+
+  @Test
+  void interface_hasPostToChannelMethodWithType() throws Exception {
+    assertThat(
+            CaseChannelProvider.class.getMethod(
+                "postToChannel", CaseChannel.class, String.class, String.class, MessageType.class))
         .isNotNull();
   }
 
@@ -67,7 +76,25 @@ class CaseChannelProviderContractTest {
   }
 
   @Test
-  void noOp_postToChannel_isNoOp() {
+  void noOp_postToChannel_withCommandType_isNoOp() {
+    CaseChannelProvider provider = new NoOpStub();
+    CaseChannel ch = provider.openChannel(UUID.randomUUID(), "p");
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                provider.postToChannel(
+                    ch, "casehub-engine:orchestrator", "cmd", MessageType.COMMAND));
+  }
+
+  @Test
+  void noOp_postToChannel_withNullType_isNoOp() {
+    CaseChannelProvider provider = new NoOpStub();
+    CaseChannel ch = provider.openChannel(UUID.randomUUID(), "p");
+    assertThatNoException().isThrownBy(() -> provider.postToChannel(ch, "system", "msg", null));
+  }
+
+  @Test
+  void noOp_postToChannel_defaultDelegatesToTypedMethod() {
     CaseChannelProvider provider = new NoOpStub();
     CaseChannel ch = provider.openChannel(UUID.randomUUID(), "p");
     assertThatNoException().isThrownBy(() -> provider.postToChannel(ch, "alice", "hello"));
@@ -94,7 +121,7 @@ class CaseChannelProviderContractTest {
     }
 
     @Override
-    public void postToChannel(CaseChannel ch, String from, String content) {}
+    public void postToChannel(CaseChannel ch, String from, String content, MessageType type) {}
 
     @Override
     public void closeChannel(CaseChannel ch) {}

--- a/api/src/test/java/io/casehub/api/spi/ReactiveCaseChannelProviderContractTest.java
+++ b/api/src/test/java/io/casehub/api/spi/ReactiveCaseChannelProviderContractTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.casehub.api.model.CaseChannel;
+import io.casehub.qhorus.api.message.MessageType;
 import io.smallrye.mutiny.Uni;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,22 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class ReactiveCaseChannelProviderContractTest {
+
+  @Test
+  void interface_hasPostToChannelDefaultMethod() throws Exception {
+    assertThat(
+            ReactiveCaseChannelProvider.class.getMethod(
+                "postToChannel", CaseChannel.class, String.class, String.class))
+        .isNotNull();
+  }
+
+  @Test
+  void interface_hasPostToChannelMethodWithType() throws Exception {
+    assertThat(
+            ReactiveCaseChannelProvider.class.getMethod(
+                "postToChannel", CaseChannel.class, String.class, String.class, MessageType.class))
+        .isNotNull();
+  }
 
   @Test
   void noOp_openChannel_returnsSentinelChannel() {
@@ -45,7 +62,28 @@ class ReactiveCaseChannelProviderContractTest {
   }
 
   @Test
-  void noOp_postToChannel_completesSuccessfully() {
+  void noOp_postToChannel_withCommandType_completesSuccessfully() {
+    ReactiveCaseChannelProvider provider = new NoOpStub();
+    CaseChannel ch = provider.openChannel(UUID.randomUUID(), "p").await().indefinitely();
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                provider
+                    .postToChannel(ch, "casehub-engine:orchestrator", "cmd", MessageType.COMMAND)
+                    .await()
+                    .indefinitely());
+  }
+
+  @Test
+  void noOp_postToChannel_withNullType_completesSuccessfully() {
+    ReactiveCaseChannelProvider provider = new NoOpStub();
+    CaseChannel ch = provider.openChannel(UUID.randomUUID(), "p").await().indefinitely();
+    assertThatNoException()
+        .isThrownBy(() -> provider.postToChannel(ch, "system", "msg", null).await().indefinitely());
+  }
+
+  @Test
+  void noOp_postToChannel_defaultDelegatesToTypedMethod() {
     ReactiveCaseChannelProvider provider = new NoOpStub();
     CaseChannel ch = provider.openChannel(UUID.randomUUID(), "p").await().indefinitely();
     assertThatNoException()
@@ -68,7 +106,8 @@ class ReactiveCaseChannelProviderContractTest {
     }
 
     @Override
-    public Uni<Void> postToChannel(CaseChannel channel, String from, String content) {
+    public Uni<Void> postToChannel(
+        CaseChannel channel, String from, String content, MessageType type) {
       return Uni.createFrom().voidItem();
     }
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -310,7 +310,7 @@ Four dual-stack SPI interfaces (blocking + reactive) enable external systems to 
 |---|---|---|
 | `WorkerProvisioner` | `ReactiveWorkerProvisioner` | Provision/terminate workers when no pre-defined workers match a capability |
 | `WorkerStatusListener` | `ReactiveWorkerStatusListener` | Lifecycle callbacks: `started()`, `completed()`, `stalled()` |
-| `CaseChannelProvider` | `ReactiveCaseChannelProvider` | Open/close/post to backend-agnostic channels (Qhorus, Slack, etc.) |
+| `CaseChannelProvider` | `ReactiveCaseChannelProvider` | Open/close/post to backend-agnostic channels (Qhorus, Slack, etc.). `postToChannel` takes a 4th `MessageType` parameter (from `casehub-qhorus-api`) expressing message intent; a 3-arg default delegates with `null` for backward compatibility |
 | `WorkerContextProvider` | `ReactiveWorkerContextProvider` | Build startup context from `CaseLedgerEntry` lineage — includes prior worker summaries, causal chain metadata |
 
 **Model types** in `api/model/`:
@@ -321,6 +321,8 @@ Four dual-stack SPI interfaces (blocking + reactive) enable external systems to 
 - `ProvisionContext` — input to `WorkerProvisioner.provision()`, contains the work request and case metadata
 
 **Channel layering:** casehub-engine does not own the Channel concept — that belongs to Qhorus. `CaseChannelProvider` is a thin bridge associating channels with case lifecycle: open on case start, close on terminal state, post for worker messages. Backend variety (Qhorus, Slack, WhatsApp, DB) is entirely a Qhorus concern — zero engine changes when a new backend is added. See casehubio/qhorus#131 for the generalised Channel design and casehubio/engine#220 for the SPI contract.
+
+**`casehub-qhorus-api` dependency:** The `api` module depends on `casehub-qhorus-api` (managed in root `pom.xml`) to import `MessageType` for the `postToChannel` signature. `MessageType` encodes the intent of a channel message at the protocol level (e.g. `COMMAND`, `RESPONSE`). See engine#230 for the longer-term plan to extract `MessageType` to a dedicated protocol artifact.
 
 ```
 Backend (Qhorus / Slack / WhatsApp / DB)
@@ -350,7 +352,7 @@ All engine SPI call sites, in lifecycle order:
 | SPI method / action | Called in | When |
 |---|---|---|
 | `CaseChannelProvider.openChannel` | `CaseStartedEventHandler.onCaseStarted` | Case transitions to RUNNING |
-| `CaseChannelProvider.openChannel` + `postToChannel` | `WorkerScheduleEventHandler.dispatchCommand` | Worker scheduled — opens worker-specific channel, posts Qhorus COMMAND |
+| `CaseChannelProvider.openChannel` + `postToChannel(..., MessageType.COMMAND)` | `WorkerScheduleEventHandler.dispatchCommand` | Worker scheduled — opens worker-specific channel, posts Qhorus COMMAND with explicit `MessageType` |
 | `WorkerContextProvider.buildContext` | `WorkerScheduleEventHandler.onWorkerScheduleEventHandler` | Before Quartz job is submitted (timing contract) |
 | `WorkerProvisioner.provision` | `CaseContextChangedEventHandler.tryProvision` | No pre-defined workers match capability AND provisioner advertises it |
 | `WorkerStatusListener.onWorkerStarted` | `WorkerExecutionJobListener.jobToBeExecuted` | Quartz job begins execution |

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -34,6 +34,7 @@ import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.utils.WorkerExecutionKeys;
 import io.casehub.engine.spi.EventLogRepository;
 import io.casehub.engine.spi.scheduler.WorkerExecutionManager;
+import io.casehub.qhorus.api.message.MessageType;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
@@ -219,7 +220,10 @@ public class WorkerScheduleEventHandler {
             "input",
             inputData);
     caseChannelProvider.postToChannel(
-        channel, "casehub-engine:orchestrator", OBJECT_MAPPER.valueToTree(command).toString());
+        channel,
+        "casehub-engine:orchestrator",
+        OBJECT_MAPPER.valueToTree(command).toString(),
+        MessageType.COMMAND);
     LOG.debugf(
         "COMMAND dispatched: caseId=%s worker=%s capability=%s correlationId=%d",
         instance.getUuid(), worker.getName(), capability.getName(), eventLogId);

--- a/engine/src/main/java/io/casehub/engine/internal/worker/NoOpCaseChannelProvider.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/NoOpCaseChannelProvider.java
@@ -17,6 +17,7 @@ package io.casehub.engine.internal.worker;
 
 import io.casehub.api.model.CaseChannel;
 import io.casehub.api.spi.CaseChannelProvider;
+import io.casehub.qhorus.api.message.MessageType;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,7 @@ public class NoOpCaseChannelProvider implements CaseChannelProvider {
   }
 
   @Override
-  public void postToChannel(CaseChannel channel, String from, String content) {
+  public void postToChannel(CaseChannel channel, String from, String content, MessageType type) {
     // intentional no-op
   }
 

--- a/engine/src/main/java/io/casehub/engine/internal/worker/NoOpReactiveCaseChannelProvider.java
+++ b/engine/src/main/java/io/casehub/engine/internal/worker/NoOpReactiveCaseChannelProvider.java
@@ -17,6 +17,7 @@ package io.casehub.engine.internal.worker;
 
 import io.casehub.api.model.CaseChannel;
 import io.casehub.api.spi.ReactiveCaseChannelProvider;
+import io.casehub.qhorus.api.message.MessageType;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
@@ -42,7 +43,8 @@ public class NoOpReactiveCaseChannelProvider implements ReactiveCaseChannelProvi
   }
 
   @Override
-  public Uni<Void> postToChannel(CaseChannel channel, String from, String content) {
+  public Uni<Void> postToChannel(
+      CaseChannel channel, String from, String content, MessageType type) {
     return Uni.createFrom().voidItem();
   }
 

--- a/engine/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
+++ b/engine/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
@@ -37,6 +37,7 @@ import io.casehub.api.spi.WorkerContextProvider;
 import io.casehub.api.spi.WorkerProvisioner;
 import io.casehub.api.spi.WorkerStatusListener;
 import io.casehub.engine.spi.cache.CaseInstanceCache;
+import io.casehub.qhorus.api.message.MessageType;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -198,6 +199,7 @@ class SpiWiringIntegrationTest {
     assertThat(RecordingCaseChannelProvider.postedFroms)
         .as("COMMAND sender must identify casehub-engine as the orchestrator")
         .anyMatch(f -> f.startsWith("casehub-engine:orchestrator"));
+    assertThat(RecordingCaseChannelProvider.postedTypes).contains(MessageType.COMMAND);
   }
 
   // ------------------------------------------------------------------ //
@@ -367,6 +369,7 @@ class SpiWiringIntegrationTest {
     static final Set<UUID> closedCaseIds = ConcurrentHashMap.newKeySet();
     static final List<String> postedContents = new CopyOnWriteArrayList<>();
     static final List<String> postedFroms = new CopyOnWriteArrayList<>();
+    static final List<MessageType> postedTypes = new CopyOnWriteArrayList<>();
     private final Map<UUID, List<CaseChannel>> openChannels = new ConcurrentHashMap<>();
 
     static void reset() {
@@ -374,6 +377,7 @@ class SpiWiringIntegrationTest {
       closedCaseIds.clear();
       postedContents.clear();
       postedFroms.clear();
+      postedTypes.clear();
     }
 
     @Override
@@ -386,9 +390,10 @@ class SpiWiringIntegrationTest {
     }
 
     @Override
-    public void postToChannel(CaseChannel channel, String from, String content) {
+    public void postToChannel(CaseChannel channel, String from, String content, MessageType type) {
       postedFroms.add(from);
       postedContents.add(content);
+      postedTypes.add(type);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,11 @@
             </dependency>
             <dependency>
                 <groupId>io.casehub</groupId>
+                <artifactId>casehub-qhorus-api</artifactId>
+                <version>${version.io.casehub}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.casehub</groupId>
                 <artifactId>casehub-ledger</artifactId>
                 <version>${version.io.casehub.ledger}</version>
             </dependency>


### PR DESCRIPTION
## Summary

- Adds `MessageType` (from `casehub-qhorus-api`) as a 4th parameter to `CaseChannelProvider.postToChannel()` and `ReactiveCaseChannelProvider.postToChannel()`
- The existing 3-arg signature becomes a `default` method delegating with `type = null` — backward-compatible for callers; direct implementors (e.g. Claudony's `ClaudonyCaseChannelProvider`) must add the 4-arg override
- `WorkerScheduleEventHandler.dispatchCommand()` now passes `MessageType.COMMAND` explicitly — the engine expresses intent at the protocol level rather than encoding it as a string in the JSON payload body
- `casehub-qhorus-api` added to engine dependency management (see engine#230 for the future plan to extract `MessageType` to a dedicated `casehubio/protocol` repo)

## Test plan

- [x] `CaseChannelProviderContractTest` — new typed tests: COMMAND type, null type, default-delegates-to-typed, interface shape (both 3-arg default and 4-arg abstract)
- [x] `ReactiveCaseChannelProviderContractTest` — same tests for reactive variant
- [x] `SpiWiringIntegrationTest` — `RecordingCaseChannelProvider` captures `MessageType` per post; asserts `MessageType.COMMAND` flows through on worker schedule dispatch
- [x] `mvn test -pl api` — 162 tests, 0 failures
- [x] `mvn test -pl engine` — 490 tests, 0 failures

Closes #221
Refs #230

🤖 Generated with [Claude Code](https://claude.ai/claude-code)