### PR TITLE
feat: add triggerChannelId + triggerCorrelationId to ProvisionContext (engine#229)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ To add a new operational SPI: define the interface in `api/spi/`, add a no-op de
 
 `WorkerProvisioner.provision()` is called only when `workerProvisioner.getCapabilities()` contains the required capability. `ProvisioningException` is caught and logged; the binding stays eligible for the next context-change tick. The no-op default returns empty capabilities, so it is never called unless a real provisioner is wired in.
 
+**`ProvisionContext` fields:** `caseId`, `taskType`, `workerContext` (nullable), `propagationContext`, `triggerChannelId` (nullable String), `triggerCorrelationId` (nullable String). The trigger fields carry the Qhorus channel ID and correlation ID of the COMMAND that caused provisioning — allowing provisioner implementations to establish causal linkage in the ledger. Engine-internal call sites pass `null` for both until engine#231 threads Qhorus trigger context through the CaseFile-update API.
+
 `WorkerExecutionContext.current()` returns the active `WorkerContext` (including `channels`) inside a worker's function body. Cleared in a `finally` block after the function returns.
 
 **To test SPI wiring:** use `@Alternative @Priority(1) @ApplicationScoped` static inner classes in `@QuarkusTest` with `static` recording fields reset in `@BeforeEach`. This activates the recording bean globally across the test suite without Mockito. See `SpiWiringIntegrationTest` for the pattern. To test provisioner wiring, define a `CaseHub` subclass with a capability binding and no workers — the engine will fall through to `tryProvision()`.

--- a/api/src/main/java/io/casehub/api/model/ProvisionContext.java
+++ b/api/src/main/java/io/casehub/api/model/ProvisionContext.java
@@ -26,9 +26,18 @@ import java.util.UUID;
  * be injected into the worker's startup prompt, and the propagation context for distributed
  * tracing. {@code workerContext} is nullable — callers that have not yet built one may pass {@code
  * null}.
+ *
+ * <p>{@code triggerChannelId} and {@code triggerCorrelationId} carry the Qhorus channel ID and
+ * {@code correlationId} of the COMMAND message that triggered this provisioning, when known. Both
+ * are nullable: engine-internal call sites currently pass {@code null} because the engine does not
+ * yet receive Qhorus trigger context at the point of provisioning (see engine#231 for the follow-on
+ * work to thread this through the CaseFile-update API). Provisioner implementations that received a
+ * Qhorus COMMAND may use these fields to establish causal linkage in the ledger (see claudony#94).
  */
 public record ProvisionContext(
     UUID caseId,
     String taskType,
     WorkerContext workerContext,
-    PropagationContext propagationContext) {}
+    PropagationContext propagationContext,
+    String triggerChannelId,
+    String triggerCorrelationId) {}

--- a/api/src/test/java/io/casehub/api/model/ProvisionContextTest.java
+++ b/api/src/test/java/io/casehub/api/model/ProvisionContextTest.java
@@ -32,17 +32,34 @@ class ProvisionContextTest {
         new WorkerContext(
             "task", caseId, null, List.of(), PropagationContext.createRoot(), Map.of());
     var prop = PropagationContext.createRoot();
-    var pc = new ProvisionContext(caseId, "code-reviewer", wc, prop);
+    var pc = new ProvisionContext(caseId, "code-reviewer", wc, prop, null, null);
     assertThat(pc.caseId()).isEqualTo(caseId);
     assertThat(pc.taskType()).isEqualTo("code-reviewer");
     assertThat(pc.workerContext()).isEqualTo(wc);
     assertThat(pc.propagationContext()).isEqualTo(prop);
+    assertThat(pc.triggerChannelId()).isNull();
+    assertThat(pc.triggerCorrelationId()).isNull();
   }
 
   @Test
   void nullWorkerContext_isPermitted() {
     var pc =
-        new ProvisionContext(UUID.randomUUID(), "task-type", null, PropagationContext.createRoot());
+        new ProvisionContext(
+            UUID.randomUUID(), "task-type", null, PropagationContext.createRoot(), null, null);
     assertThat(pc.workerContext()).isNull();
+  }
+
+  @Test
+  void triggerFields_arePopulatedWhenProvided() {
+    var pc =
+        new ProvisionContext(
+            UUID.randomUUID(),
+            "task-type",
+            null,
+            PropagationContext.createRoot(),
+            "ch-abc-123",
+            "corr-xyz-456");
+    assertThat(pc.triggerChannelId()).isEqualTo("ch-abc-123");
+    assertThat(pc.triggerCorrelationId()).isEqualTo("corr-xyz-456");
   }
 }

--- a/api/src/test/java/io/casehub/api/spi/ReactiveWorkerProvisionerContractTest.java
+++ b/api/src/test/java/io/casehub/api/spi/ReactiveWorkerProvisionerContractTest.java
@@ -59,7 +59,9 @@ class ReactiveWorkerProvisionerContractTest {
             "task",
             new WorkerContext(
                 "t", null, null, List.of(), PropagationContext.createRoot(), Map.of()),
-            PropagationContext.createRoot());
+            PropagationContext.createRoot(),
+            null,
+            null);
     assertThatThrownBy(() -> provisioner.provision(Set.of("cap"), ctx).await().indefinitely())
         .isInstanceOf(ProvisioningException.class);
   }

--- a/api/src/test/java/io/casehub/api/spi/WorkerProvisionerContractTest.java
+++ b/api/src/test/java/io/casehub/api/spi/WorkerProvisionerContractTest.java
@@ -68,7 +68,9 @@ class WorkerProvisionerContractTest {
             "researcher",
             new WorkerContext(
                 "task", null, null, List.of(), PropagationContext.createRoot(), Map.of()),
-            PropagationContext.createRoot());
+            PropagationContext.createRoot(),
+            null,
+            null);
     assertThatThrownBy(() -> noOp.provision(Set.of("research"), ctx))
         .isInstanceOf(ProvisioningException.class);
   }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -318,7 +318,7 @@ Four dual-stack SPI interfaces (blocking + reactive) enable external systems to 
 - `WorkerSummary` — prior worker's execution summary, includes `ledgerEntryId` (UUID of the `WORKER_EXECUTION_COMPLETED` ledger entry)
 - `WorkerContext` — startup context handed to a worker at execution time; includes `channels` (all open channels for the case, from `CaseChannelProvider.listChannels(caseId)`), `priorWorkers` list, `caseId`, and causal chain metadata
 - `WorkerExecutionContext` — thread-local holder set by `QuartzWorkerExecutionJob` immediately before calling the worker function; cleared in a `finally` block after execution. Workers call `WorkerExecutionContext.current()` to access their `WorkerContext` (including channels) at runtime
-- `ProvisionContext` — input to `WorkerProvisioner.provision()`, contains the work request and case metadata
+- `ProvisionContext` — input to `WorkerProvisioner.provision()`, contains the work request and case metadata. Fields: `caseId`, `taskType`, `workerContext` (nullable), `propagationContext`, `triggerChannelId` (nullable String — Qhorus channel ID of the COMMAND that triggered provisioning), `triggerCorrelationId` (nullable String — Qhorus correlation ID). Engine-internal call sites pass `null` for both trigger fields until engine#231 threads Qhorus trigger context through the CaseFile-update API
 
 **Channel layering:** casehub-engine does not own the Channel concept — that belongs to Qhorus. `CaseChannelProvider` is a thin bridge associating channels with case lifecycle: open on case start, close on terminal state, post for worker messages. Backend variety (Qhorus, Slack, WhatsApp, DB) is entirely a Qhorus concern — zero engine changes when a new backend is added. See casehubio/qhorus#131 for the generalised Channel design and casehubio/engine#220 for the SPI contract.
 
@@ -433,6 +433,8 @@ Entries that exhaust max-attempts stay PENDING_REVIEW for manual triage.
 - ✅ Immutable audit ledger (`casehub-ledger`, Q2 2026)
 - ✅ DLQ replay — explicit API and optional auto-replay scheduler (Q2 2026)
 - ✅ Worker Provisioner SPI wiring — all 4 blocking SPIs integrated (Q2 2026)
+- ✅ `triggerChannelId` + `triggerCorrelationId` in `ProvisionContext` — causal linkage from Qhorus COMMAND to provisioning (engine#229, Q2 2026)
+- [ ] Thread Qhorus trigger context through CaseFile-update API into `ProvisionContext` (engine#231)
 - [ ] Human worker integration (Q2/Q3 2026)
 - [ ] Escalation rules and thresholds (Q3 2026)
 
@@ -453,5 +455,7 @@ Entries that exhaust max-attempts stay PENDING_REVIEW for manual triage.
 - **casehubio/engine#121** — Original design discussion (closed by ADR-0003)
 - **casehubio/engine#131** — WorkBroker integration epic
 - **casehubio/engine#145** — casehub-ledger integration epic
+- **casehubio/engine#229** — `triggerChannelId` + `triggerCorrelationId` in `ProvisionContext`
+- **casehubio/engine#231** — Thread Qhorus trigger context through CaseFile-update API (follow-on)
 - **casehubio/engine#191** — Worker Provisioner SPI wiring
 - **mdproctor/casehub-ledger#39** — CaseLedgerEntry tracking issue

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -306,7 +306,9 @@ public class CaseContextChangedEventHandler {
               caseInstance.getUuid(),
               capability.getName(),
               workerContext,
-              PropagationContext.createRoot());
+              PropagationContext.createRoot(),
+              null, // triggerChannelId — see engine#231 to thread Qhorus trigger context through
+              null); // triggerCorrelationId — see engine#231
       Worker provisioned = workerProvisioner.provision(provisionerCaps, provisionContext);
       LOG.infof(
           "WorkerProvisioner provisioned worker '%s' for capability '%s' on case %s",

--- a/engine/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
+++ b/engine/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
@@ -64,7 +64,7 @@ class DefaultWorkerSpiImplementationsTest {
         new WorkerContext("desc", null, null, List.of(), PropagationContext.createRoot(), Map.of());
     var ctx =
         new ProvisionContext(
-            UUID.randomUUID(), "task", workerContext, PropagationContext.createRoot());
+            UUID.randomUUID(), "task", workerContext, PropagationContext.createRoot(), null, null);
     assertThatThrownBy(() -> provisioner.provision(java.util.Set.of("cap"), ctx))
         .isInstanceOf(ProvisioningException.class)
         .hasMessageContaining("WorkerProvisioner");
@@ -198,7 +198,9 @@ class DefaultWorkerSpiImplementationsTest {
             "task",
             new WorkerContext(
                 "desc", null, null, List.of(), PropagationContext.createRoot(), Map.of()),
-            PropagationContext.createRoot());
+            PropagationContext.createRoot(),
+            null,
+            null);
     assertThatThrownBy(() -> provisioner.provision(Set.of("cap"), ctx).await().indefinitely())
         .isInstanceOf(ProvisioningException.class);
   }


### PR DESCRIPTION
## Summary

- Adds `triggerChannelId` and `triggerCorrelationId` (both nullable `String`) to `ProvisionContext`
- These fields allow `WorkerProvisioner` implementations (e.g. Claudony's `ClaudonyWorkerProvisioner`) to link a `CaseLedgerEntry` back to the Qhorus COMMAND that triggered provisioning, completing the W3C PROV-DM causal chain
- Engine call site (`CaseContextChangedEventHandler.tryProvision()`) passes `null` for both — the engine does not receive Qhorus trigger context today; see engine#231 for the follow-on that threads this through the CaseFile-update API
- All 5 `ProvisionContext` construction sites updated

## Test plan

- [x] `ProvisionContextTest` — new test: `triggerFields_arePopulatedWhenProvided`; existing tests updated to 6-arg constructor with null-field assertions
- [x] All existing `ProvisionContext` construction sites compile and pass
- [x] `mvn test -pl api` — 156 tests, 0 failures
- [x] `mvn test -pl engine` — 490 tests, 0 failures

Closes #229
Refs #231

🤖 Generated with [Claude Code](https://claude.ai/claude-code)