### PR TITLE
feat(api): add caseId to WorkResult for precise per-case listener lookup

### DIFF
--- a/api/src/main/java/io/casehub/api/model/WorkResult.java
+++ b/api/src/main/java/io/casehub/api/model/WorkResult.java
@@ -16,20 +16,38 @@
 package io.casehub.api.model;
 
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Result of orchestrated work returned by {@code WorkOrchestrator.submit()}. The {@code
  * correlationKey} is the idempotency hash used to match this result to its submission.
+ *
+ * <p>{@code caseId} is set when the result is produced by the case engine and identifies the case
+ * that owned the worker. Listeners can use it for precise per-case lookups. Null when the result is
+ * produced outside the engine context (e.g. direct WorkOrchestrator calls).
  */
 public record WorkResult(
-    String correlationKey, WorkStatus status, Map<String, Object> output, String workerId) {
+    String correlationKey,
+    WorkStatus status,
+    Map<String, Object> output,
+    String workerId,
+    UUID caseId) {
 
   public static WorkResult completed(
       String correlationKey, Map<String, Object> output, String workerId) {
-    return new WorkResult(correlationKey, WorkStatus.COMPLETED, output, workerId);
+    return new WorkResult(correlationKey, WorkStatus.COMPLETED, output, workerId, null);
+  }
+
+  public static WorkResult completed(
+      String correlationKey, Map<String, Object> output, String workerId, UUID caseId) {
+    return new WorkResult(correlationKey, WorkStatus.COMPLETED, output, workerId, caseId);
   }
 
   public static WorkResult faulted(String correlationKey, String workerId) {
-    return new WorkResult(correlationKey, WorkStatus.FAULTED, Map.of(), workerId);
+    return new WorkResult(correlationKey, WorkStatus.FAULTED, Map.of(), workerId, null);
+  }
+
+  public static WorkResult faulted(String correlationKey, String workerId, UUID caseId) {
+    return new WorkResult(correlationKey, WorkStatus.FAULTED, Map.of(), workerId, caseId);
   }
 }

--- a/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/engine/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -94,7 +94,8 @@ public class WorkflowExecutionCompletedHandler {
             () ->
                 workerStatusListener.onWorkerCompleted(
                     worker.getName(),
-                    WorkResult.completed(event.idempotency(), rawOutput, worker.getName())))
+                    WorkResult.completed(
+                        event.idempotency(), rawOutput, worker.getName(), caseInstance.getUuid())))
         .invoke(
             () ->
                 lifecycleEvents.fireAsync(

--- a/engine/src/main/java/io/casehub/engine/internal/work/CaseResumptionService.java
+++ b/engine/src/main/java/io/casehub/engine/internal/work/CaseResumptionService.java
@@ -69,7 +69,7 @@ public class CaseResumptionService {
         correlationKey != null && correlationKey.equals(caseInstance.getWaitingForWorkId());
 
     if (!isWaiting || !isMatchingWork) {
-      completeRegisteredFuture(correlationKey, workerId, rawOutput);
+      completeRegisteredFuture(correlationKey, workerId, rawOutput, caseInstance.getUuid());
       return Uni.createFrom().voidItem();
     }
 
@@ -92,14 +92,17 @@ public class CaseResumptionService {
 
     return caseInstanceRepository
         .updateStateAndAppendEvent(caseInstance, completedLog)
-        .invoke(() -> completeRegisteredFuture(correlationKey, workerId, rawOutput));
+        .invoke(
+            () ->
+                completeRegisteredFuture(
+                    correlationKey, workerId, rawOutput, caseInstance.getUuid()));
   }
 
   private void completeRegisteredFuture(
-      String correlationKey, String workerId, Map<String, Object> output) {
+      String correlationKey, String workerId, Map<String, Object> output, java.util.UUID caseId) {
     if (correlationKey != null && pendingWorkRegistry.hasPending(correlationKey)) {
       pendingWorkRegistry.complete(
-          correlationKey, WorkResult.completed(correlationKey, output, workerId));
+          correlationKey, WorkResult.completed(correlationKey, output, workerId, caseId));
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds optional `caseId` field to `WorkResult` (null-safe, fully backwards-compatible via 3-arg factory overloads)
- `WorkflowExecutionCompletedHandler` and `CaseResumptionService` now pass `caseInstance.getUuid()` when constructing results
- Enables `WorkerStatusListener` implementations to perform precise `caseId:role` lookups rather than relying on last-write-wins `byRole` fallback

Refs casehubio/claudony#93

🤖 Generated with [Claude Code](https://claude.com/claude-code)