### PR TITLE
feat(api): add AI Agent worker type with LangChain4j integration

### DIFF
--- a/EVENT_LOG_API.md
+++ b/EVENT_LOG_API.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-REST API endpoint для получения событий (EventLog) конкретного case с возможностью фильтрации по типам событий и типам потоков, отсортированных по порядковому номеру (seq).
+REST API endpoint for retrieving events (EventLog) of a specific case with the ability to filter by event types and stream types, sorted by sequence number (seq).
 
 ## Endpoint
 
@@ -12,19 +12,19 @@ GET /api/cases/{caseId}/events
 
 ### Path Parameters
 
-- `caseId` (UUID, required) - идентификатор case
+- `caseId` (UUID, required) - case identifier
 
 ### Query Parameters
 
-- `eventType` (string, optional, repeatable) - фильтр по типу события. Можно указать несколько значений.
-  - Допустимые значения: `CASE_STARTED`, `CASE_COMPLETED`, `CASE_FAULTED`, `CASE_CANCELLED`, `CASE_STATUS_CHANGED`, `TASK_CREATED`, `TASK_COMPLETED`, `TASK_FAILED`, `TASK_CANCELLED`, `WORKER_SCHEDULED`, `WORKER_EXECUTION_STARTED`, `WORKER_EXECUTION_COMPLETED`, `WORKER_EXECUTION_FAILED`, `WORK_SUBMITTED`, `WORK_COMPLETED`, `SIGNAL_RECEIVED`, `MILESTONE_REACHED`, `MILESTONE_ACTIVATED`, `MILESTONE_COMPLETED`, `MILESTONE_SLA_VIOLATED`, `GOAL_REACHED`, `SUBCASE_STARTED`, `SUBCASE_COMPLETED`
+- `eventType` (string, optional, repeatable) - filter by event type. Multiple values can be specified.
+  - Allowed values: `CASE_STARTED`, `CASE_COMPLETED`, `CASE_FAULTED`, `CASE_CANCELLED`, `CASE_STATUS_CHANGED`, `TASK_CREATED`, `TASK_COMPLETED`, `TASK_FAILED`, `TASK_CANCELLED`, `WORKER_SCHEDULED`, `WORKER_EXECUTION_STARTED`, `WORKER_EXECUTION_COMPLETED`, `WORKER_EXECUTION_FAILED`, `WORK_SUBMITTED`, `WORK_COMPLETED`, `SIGNAL_RECEIVED`, `MILESTONE_REACHED`, `MILESTONE_ACTIVATED`, `MILESTONE_COMPLETED`, `MILESTONE_SLA_VIOLATED`, `GOAL_REACHED`, `SUBCASE_STARTED`, `SUBCASE_COMPLETED`
 
-- `streamType` (string, optional, repeatable) - фильтр по типу потока. Можно указать несколько значений.
-  - Допустимые значения: `CASE`, `WORKER`, `TIMER`, `SYSTEM`
+- `streamType` (string, optional, repeatable) - filter by stream type. Multiple values can be specified.
+  - Allowed values: `CASE`, `WORKER`, `TIMER`, `SYSTEM`
 
 ## Response
 
-Массив объектов EventLogDTO, отсортированных по полю `seq` в порядке возрастания.
+Array of EventLogDTO objects sorted by `seq` field in ascending order.
 
 ### EventLogDTO Structure
 
@@ -44,25 +44,25 @@ GET /api/cases/{caseId}/events
 
 ## Examples
 
-### Получить все события case
+### Get all case events
 
 ```bash
 curl http://localhost:8080/api/cases/550e8400-e29b-41d4-a716-446655440000/events
 ```
 
-### Получить только события типа WORKER
+### Get only WORKER stream type events
 
 ```bash
 curl "http://localhost:8080/api/cases/550e8400-e29b-41d4-a716-446655440000/events?streamType=WORKER"
 ```
 
-### Получить события запуска и завершения worker'ов
+### Get worker execution started and completed events
 
 ```bash
 curl "http://localhost:8080/api/cases/550e8400-e29b-41d4-a716-446655440000/events?eventType=WORKER_EXECUTION_STARTED&eventType=WORKER_EXECUTION_COMPLETED"
 ```
 
-### Комбинированный фильтр: события CASE потока типа CASE_STARTED или CASE_COMPLETED
+### Combined filter: CASE stream events of type CASE_STARTED or CASE_COMPLETED
 
 ```bash
 curl "http://localhost:8080/api/cases/550e8400-e29b-41d4-a716-446655440000/events?streamType=CASE&eventType=CASE_STARTED&eventType=CASE_COMPLETED"
@@ -72,7 +72,7 @@ curl "http://localhost:8080/api/cases/550e8400-e29b-41d4-a716-446655440000/event
 
 ### Repository Layer
 
-Новый метод в `EventLogRepository`:
+New method in `EventLogRepository`:
 
 ```java
 Uni<List<EventLog>> findByCaseWithFilters(
@@ -82,17 +82,17 @@ Uni<List<EventLog>> findByCaseWithFilters(
 );
 ```
 
-- Если `eventTypes` или `streamTypes` равны `null` или пустым, соответствующий фильтр не применяется
-- Результаты всегда сортируются по `seq` в порядке возрастания
-- Реализовано в `JpaEventLogRepository` и `InMemoryEventLogRepository`
+- If `eventTypes` or `streamTypes` are `null` or empty, the corresponding filter is not applied
+- Results are always sorted by `seq` in ascending order
+- Implemented in `JpaEventLogRepository` and `InMemoryEventLogRepository`
 
 ### REST Layer
 
-- `EventLogResource` - JAX-RS ресурс
-- `EventLogDTO` - DTO для сериализации EventLog
+- `EventLogResource` - JAX-RS resource
+- `EventLogDTO` - DTO for EventLog serialization
 
 ## Testing
 
-Реализация протестирована в:
+Implementation is tested in:
 - `JpaEventLogRepositoryTest` (Hibernate persistence)
 - `InMemoryEventLogRepositoryTest` (in-memory persistence)

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>casehub-engine-schema</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
 
         <!-- Test -->
         <dependency>
@@ -58,6 +62,31 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-ollama</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-anthropic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-mistral-ai</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-google-ai-gemini</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/api/src/main/java/io/casehub/api/model/Worker.java
+++ b/api/src/main/java/io/casehub/api/model/Worker.java
@@ -16,6 +16,7 @@
 package io.casehub.api.model;
 
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.model.ai.Agent;
 import io.casehub.api.model.holder.WorkerFunctionHolder;
 import io.casehub.api.plan.PlanElement;
 import io.serverlessworkflow.api.types.Workflow;
@@ -47,6 +48,10 @@ public class Worker implements PlanElement {
 
   public Worker(String name, List<Capability> capabilities, File file) {
     this(name, capabilities, new WorkerFunctionHolder<>(file));
+  }
+
+  public Worker(String name, List<Capability> capabilities, Agent agent) {
+    this(name, capabilities, new WorkerFunctionHolder<>(agent));
   }
 
   private Worker(
@@ -134,6 +139,11 @@ public class Worker implements PlanElement {
 
     public Builder function(File file) {
       this.functionHolder = new WorkerFunctionHolder<>(file);
+      return this;
+    }
+
+    public Builder function(Agent agent) {
+      this.functionHolder = new WorkerFunctionHolder<>(agent);
       return this;
     }
 

--- a/api/src/main/java/io/casehub/api/model/ai/Agent.java
+++ b/api/src/main/java/io/casehub/api/model/ai/Agent.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.input.PromptTemplate;
+import java.util.List;
+import java.util.Map;
+
+public final class Agent {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private final String systemPrompt;
+  private final String userMessageTemplate;
+  private final JqTransformer inputTransformer;
+  private final JqTransformer outputTransformer;
+  private final ChatModel model;
+  private final JsonSchema responseSchema;
+
+  Agent(
+      String systemPrompt,
+      String userMessageTemplate,
+      JqTransformer inputTransformer,
+      JqTransformer outputTransformer,
+      ChatModel model,
+      JsonSchema responseSchema) {
+    this.systemPrompt = systemPrompt;
+    this.userMessageTemplate = userMessageTemplate;
+    this.inputTransformer = inputTransformer;
+    this.outputTransformer = outputTransformer;
+    this.model = model;
+    this.responseSchema = responseSchema;
+  }
+
+  public static AgentBuilder builder() {
+    return new AgentBuilder();
+  }
+
+  public Map<String, Object> execute(Map<String, Object> input) {
+    JsonNode inputNode = MAPPER.convertValue(input, JsonNode.class);
+    JsonNode transformed = inputTransformer.apply(inputNode);
+
+    String userText;
+    if (userMessageTemplate != null) {
+      try {
+        Map<String, Object> variables = MAPPER.convertValue(transformed, MAP_TYPE);
+        userText = PromptTemplate.from(userMessageTemplate).apply(variables).text();
+      } catch (Exception e) {
+        throw new AgentException("Failed to apply userMessage template: " + e.getMessage(), e);
+      }
+    } else {
+      userText = transformed.toString();
+    }
+
+    ChatRequest request =
+        ChatRequest.builder()
+            .messages(List.of(SystemMessage.from(systemPrompt), UserMessage.from(userText)))
+            .responseFormat(buildResponseFormat())
+            .build();
+
+    ChatResponse response = model.chat(request);
+    String responseText = response.aiMessage().text();
+
+    JsonNode responseJson;
+    try {
+      responseJson = MAPPER.readTree(responseText);
+    } catch (Exception e) {
+      throw new AgentException("LLM returned invalid JSON: " + responseText, e);
+    }
+
+    return MAPPER.convertValue(outputTransformer.apply(responseJson), MAP_TYPE);
+  }
+
+  private ResponseFormat buildResponseFormat() {
+    ResponseFormat.Builder builder = ResponseFormat.builder().type(ResponseFormatType.JSON);
+    if (responseSchema != null) {
+      builder.jsonSchema(responseSchema);
+    }
+    return builder.build();
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/AgentBuilder.java
+++ b/api/src/main/java/io/casehub/api/model/ai/AgentBuilder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+import dev.langchain4j.internal.JsonSchemaElementUtils;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+public final class AgentBuilder {
+
+  private String systemPrompt;
+  private String inputSchema;
+  private String outputSchema;
+  private String userMessageTemplate;
+  private ModelType modelType;
+  private ChatModel model;
+  private ChatModelProvider chatModelProvider;
+  private JsonSchema responseSchema;
+
+  AgentBuilder() {}
+
+  public AgentBuilder systemPrompt(String systemPrompt) {
+    this.systemPrompt = systemPrompt;
+    return this;
+  }
+
+  public AgentBuilder inputSchema(String jqExpression) {
+    this.inputSchema = jqExpression;
+    return this;
+  }
+
+  public AgentBuilder outputSchema(String jqExpression) {
+    this.outputSchema = jqExpression;
+    return this;
+  }
+
+  public AgentBuilder userMessage(String template) {
+    this.userMessageTemplate = template;
+    return this;
+  }
+
+  public AgentBuilder model(ModelType modelType) {
+    this.modelType = modelType;
+    return this;
+  }
+
+  public AgentBuilder responseSchema(JsonSchema responseSchema) {
+    this.responseSchema = responseSchema;
+    return this;
+  }
+
+  public AgentBuilder responseSchema(Class<?> responseType) {
+    JsonSchemaElement element;
+    if (Collection.class.isAssignableFrom(responseType) || responseType.isArray()) {
+      element = JsonArraySchema.builder().items(new JsonStringSchema()).build();
+    } else {
+      element = JsonSchemaElementUtils.jsonSchemaElementFrom(responseType);
+    }
+    if (!(element instanceof JsonObjectSchema)) {
+      element = JsonObjectSchema.builder().addProperty("value", element).required("value").build();
+    }
+    this.responseSchema =
+        JsonSchema.builder().name(responseType.getSimpleName()).rootElement(element).build();
+    return this;
+  }
+
+  public AgentBuilder model(ChatModelProvider provider) {
+    this.chatModelProvider = Objects.requireNonNull(provider, "provider must not be null");
+    return this;
+  }
+
+  // package-private — for tests only
+  AgentBuilder model(ChatModel model) {
+    this.model = model;
+    return this;
+  }
+
+  public Agent build() {
+    if (systemPrompt == null) throw new IllegalStateException("systemPrompt is required");
+    if (inputSchema == null) throw new IllegalStateException("inputSchema is required");
+    if (outputSchema == null) throw new IllegalStateException("outputSchema is required");
+
+    ChatModel resolvedModel = model;
+    if (resolvedModel == null && chatModelProvider != null) {
+      resolvedModel = chatModelProvider.get();
+    }
+    if (resolvedModel == null) {
+      if (modelType == null) throw new IllegalStateException("model is required");
+      resolvedModel =
+          ServiceLoader.load(ChatModelProvider.class).stream()
+              .map(ServiceLoader.Provider::get)
+              .filter(p -> p.type() == modelType)
+              .findFirst()
+              .orElseThrow(
+                  () -> new IllegalStateException("No ChatModelProvider found for: " + modelType))
+              .get();
+    }
+
+    return new Agent(
+        systemPrompt,
+        userMessageTemplate,
+        new JqTransformer(inputSchema),
+        new JqTransformer(outputSchema),
+        resolvedModel,
+        responseSchema);
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/AgentException.java
+++ b/api/src/main/java/io/casehub/api/model/ai/AgentException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+public class AgentException extends RuntimeException {
+
+  public AgentException(String message) {
+    super(message);
+  }
+
+  public AgentException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/ChatModelProvider.java
+++ b/api/src/main/java/io/casehub/api/model/ai/ChatModelProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+import dev.langchain4j.model.chat.ChatModel;
+
+public interface ChatModelProvider {
+  ModelType type();
+
+  ChatModel get();
+}

--- a/api/src/main/java/io/casehub/api/model/ai/JqTransformer.java
+++ b/api/src/main/java/io/casehub/api/model/ai/JqTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
+import net.thisptr.jackson.jq.BuiltinFunctionLoader;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.Versions;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+
+public final class JqTransformer {
+
+  private final JsonQuery query;
+
+  public JqTransformer(String jqExpression) {
+    try {
+      Scope initScope = Scope.newEmptyScope();
+      BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_6, initScope);
+      this.query = JsonQuery.compile(jqExpression, Versions.JQ_1_6);
+    } catch (JsonQueryException e) {
+      throw new IllegalArgumentException("Invalid jq expression: " + jqExpression, e);
+    }
+  }
+
+  public JsonNode apply(JsonNode input) {
+    List<JsonNode> results = new ArrayList<>();
+    try {
+      Scope callScope = Scope.newEmptyScope();
+      BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_6, callScope);
+      query.apply(callScope, input, results::add);
+    } catch (JsonQueryException e) {
+      throw new AgentException("jq transformation failed", e);
+    }
+    if (results.isEmpty()) {
+      throw new AgentException("jq expression produced no output");
+    }
+    return results.get(0);
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/ModelType.java
+++ b/api/src/main/java/io/casehub/api/model/ai/ModelType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+public enum ModelType {
+  OPENAI,
+  OLLAMA,
+  ANTHROPIC,
+  MISTRAL,
+  GOOGLE_AI_GEMINI
+}

--- a/api/src/main/java/io/casehub/api/model/ai/anthropic/AnthropicChatModelProvider.java
+++ b/api/src/main/java/io/casehub/api/model/ai/anthropic/AnthropicChatModelProvider.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.anthropic;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.AgentException;
+import io.casehub.api.model.ai.ChatModelProvider;
+import io.casehub.api.model.ai.ModelType;
+
+public final class AnthropicChatModelProvider implements ChatModelProvider {
+
+  private final String apiKey;
+  private final String modelName;
+  private final Double temperature;
+  private final Double topP;
+  private final Integer topK;
+  private final Integer maxTokens;
+
+  // no-arg constructor for ServiceLoader — reads from env vars
+  public AnthropicChatModelProvider() {
+    this.apiKey = System.getenv("ANTHROPIC_API_KEY");
+    this.modelName = "claude-3-5-sonnet-20241022";
+    this.temperature = null;
+    this.topP = null;
+    this.topK = null;
+    this.maxTokens = null;
+  }
+
+  private AnthropicChatModelProvider(Builder b) {
+    this.apiKey = b.apiKey;
+    this.modelName = b.modelName;
+    this.temperature = b.temperature;
+    this.topP = b.topP;
+    this.topK = b.topK;
+    this.maxTokens = b.maxTokens;
+  }
+
+  @Override
+  public ModelType type() {
+    return ModelType.ANTHROPIC;
+  }
+
+  @Override
+  public ChatModel get() {
+    try {
+      Class<?> modelClass = Class.forName("dev.langchain4j.model.anthropic.AnthropicChatModel");
+      Object anthropicBuilder = modelClass.getMethod("builder").invoke(null);
+      Class<?> builderClass = anthropicBuilder.getClass();
+
+      invoke(builderClass, anthropicBuilder, "apiKey", String.class, apiKey);
+      invoke(builderClass, anthropicBuilder, "modelName", String.class, modelName);
+      if (temperature != null)
+        invoke(builderClass, anthropicBuilder, "temperature", Double.class, temperature);
+      if (topP != null) invoke(builderClass, anthropicBuilder, "topP", Double.class, topP);
+      if (topK != null) invoke(builderClass, anthropicBuilder, "topK", Integer.class, topK);
+      if (maxTokens != null)
+        invoke(builderClass, anthropicBuilder, "maxTokens", Integer.class, maxTokens);
+
+      return (ChatModel) builderClass.getMethod("build").invoke(anthropicBuilder);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new AgentException("Failed to build AnthropicChatModel: " + cause.getMessage(), cause);
+    } catch (Exception e) {
+      throw new AgentException("Failed to build AnthropicChatModel: " + e.getMessage(), e);
+    }
+  }
+
+  private static void invoke(
+      Class<?> builderClass, Object builder, String method, Class<?> type, Object value)
+      throws Exception {
+    builderClass.getMethod(method, type).invoke(builder, value);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String apiKey;
+    private String modelName = "claude-3-5-sonnet-20241022";
+    private Double temperature;
+    private Double topP;
+    private Integer topK;
+    private Integer maxTokens;
+
+    public Builder apiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    public Builder modelName(String modelName) {
+      this.modelName = modelName;
+      return this;
+    }
+
+    public Builder temperature(double temperature) {
+      this.temperature = temperature;
+      return this;
+    }
+
+    public Builder topP(double topP) {
+      this.topP = topP;
+      return this;
+    }
+
+    public Builder topK(int topK) {
+      this.topK = topK;
+      return this;
+    }
+
+    public Builder maxTokens(int maxTokens) {
+      this.maxTokens = maxTokens;
+      return this;
+    }
+
+    public AnthropicChatModelProvider build() {
+      if (apiKey == null) throw new IllegalStateException("apiKey is required");
+      return new AnthropicChatModelProvider(this);
+    }
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/gemini/GoogleAiGeminiChatModelProvider.java
+++ b/api/src/main/java/io/casehub/api/model/ai/gemini/GoogleAiGeminiChatModelProvider.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.gemini;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.AgentException;
+import io.casehub.api.model.ai.ChatModelProvider;
+import io.casehub.api.model.ai.ModelType;
+
+public final class GoogleAiGeminiChatModelProvider implements ChatModelProvider {
+
+  private final String apiKey;
+  private final String modelName;
+  private final Double temperature;
+  private final Double topP;
+  private final Integer maxOutputTokens;
+
+  // no-arg constructor for ServiceLoader — reads from env vars
+  public GoogleAiGeminiChatModelProvider() {
+    this.apiKey = System.getenv("GOOGLE_API_KEY");
+    this.modelName = "gemini-2.0-flash";
+    this.temperature = null;
+    this.topP = null;
+    this.maxOutputTokens = null;
+  }
+
+  private GoogleAiGeminiChatModelProvider(Builder b) {
+    this.apiKey = b.apiKey;
+    this.modelName = b.modelName;
+    this.temperature = b.temperature;
+    this.topP = b.topP;
+    this.maxOutputTokens = b.maxOutputTokens;
+  }
+
+  @Override
+  public ModelType type() {
+    return ModelType.GOOGLE_AI_GEMINI;
+  }
+
+  @Override
+  public ChatModel get() {
+    try {
+      Class<?> modelClass = Class.forName("dev.langchain4j.model.googleai.GoogleAiGeminiChatModel");
+      Object geminiBuilder = modelClass.getMethod("builder").invoke(null);
+      Class<?> builderClass = geminiBuilder.getClass();
+
+      invoke(builderClass, geminiBuilder, "apiKey", String.class, apiKey);
+      invoke(builderClass, geminiBuilder, "modelName", String.class, modelName);
+      if (temperature != null)
+        invoke(builderClass, geminiBuilder, "temperature", Double.class, temperature);
+      if (topP != null) invoke(builderClass, geminiBuilder, "topP", Double.class, topP);
+      if (maxOutputTokens != null)
+        invoke(builderClass, geminiBuilder, "maxOutputTokens", Integer.class, maxOutputTokens);
+
+      return (ChatModel) builderClass.getMethod("build").invoke(geminiBuilder);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new AgentException(
+          "Failed to build GoogleAiGeminiChatModel: " + cause.getMessage(), cause);
+    } catch (Exception e) {
+      throw new AgentException("Failed to build GoogleAiGeminiChatModel: " + e.getMessage(), e);
+    }
+  }
+
+  private static void invoke(
+      Class<?> builderClass, Object builder, String method, Class<?> type, Object value)
+      throws Exception {
+    builderClass.getMethod(method, type).invoke(builder, value);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String apiKey;
+    private String modelName = "gemini-2.0-flash";
+    private Double temperature;
+    private Double topP;
+    private Integer maxOutputTokens;
+
+    public Builder apiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    public Builder modelName(String modelName) {
+      this.modelName = modelName;
+      return this;
+    }
+
+    public Builder temperature(double temperature) {
+      this.temperature = temperature;
+      return this;
+    }
+
+    public Builder topP(double topP) {
+      this.topP = topP;
+      return this;
+    }
+
+    public Builder maxOutputTokens(int maxOutputTokens) {
+      this.maxOutputTokens = maxOutputTokens;
+      return this;
+    }
+
+    public GoogleAiGeminiChatModelProvider build() {
+      if (apiKey == null) throw new IllegalStateException("apiKey is required");
+      return new GoogleAiGeminiChatModelProvider(this);
+    }
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/mistral/MistralAiChatModelProvider.java
+++ b/api/src/main/java/io/casehub/api/model/ai/mistral/MistralAiChatModelProvider.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.mistral;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.AgentException;
+import io.casehub.api.model.ai.ChatModelProvider;
+import io.casehub.api.model.ai.ModelType;
+
+public final class MistralAiChatModelProvider implements ChatModelProvider {
+
+  private final String apiKey;
+  private final String modelName;
+  private final Double temperature;
+  private final Double topP;
+  private final Integer maxTokens;
+
+  // no-arg constructor for ServiceLoader — reads from env vars
+  public MistralAiChatModelProvider() {
+    this.apiKey = System.getenv("MISTRAL_API_KEY");
+    this.modelName = "mistral-small-latest";
+    this.temperature = null;
+    this.topP = null;
+    this.maxTokens = null;
+  }
+
+  private MistralAiChatModelProvider(Builder b) {
+    this.apiKey = b.apiKey;
+    this.modelName = b.modelName;
+    this.temperature = b.temperature;
+    this.topP = b.topP;
+    this.maxTokens = b.maxTokens;
+  }
+
+  @Override
+  public ModelType type() {
+    return ModelType.MISTRAL;
+  }
+
+  @Override
+  public ChatModel get() {
+    try {
+      Class<?> modelClass = Class.forName("dev.langchain4j.model.mistralai.MistralAiChatModel");
+      Object mistralBuilder = modelClass.getMethod("builder").invoke(null);
+      Class<?> builderClass = mistralBuilder.getClass();
+
+      invoke(builderClass, mistralBuilder, "apiKey", String.class, apiKey);
+      invoke(builderClass, mistralBuilder, "modelName", String.class, modelName);
+      if (temperature != null)
+        invoke(builderClass, mistralBuilder, "temperature", Double.class, temperature);
+      if (topP != null) invoke(builderClass, mistralBuilder, "topP", Double.class, topP);
+      if (maxTokens != null)
+        invoke(builderClass, mistralBuilder, "maxTokens", Integer.class, maxTokens);
+
+      return (ChatModel) builderClass.getMethod("build").invoke(mistralBuilder);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new AgentException("Failed to build MistralAiChatModel: " + cause.getMessage(), cause);
+    } catch (Exception e) {
+      throw new AgentException("Failed to build MistralAiChatModel: " + e.getMessage(), e);
+    }
+  }
+
+  private static void invoke(
+      Class<?> builderClass, Object builder, String method, Class<?> type, Object value)
+      throws Exception {
+    builderClass.getMethod(method, type).invoke(builder, value);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String apiKey;
+    private String modelName = "mistral-small-latest";
+    private Double temperature;
+    private Double topP;
+    private Integer maxTokens;
+
+    public Builder apiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    public Builder modelName(String modelName) {
+      this.modelName = modelName;
+      return this;
+    }
+
+    public Builder temperature(double temperature) {
+      this.temperature = temperature;
+      return this;
+    }
+
+    public Builder topP(double topP) {
+      this.topP = topP;
+      return this;
+    }
+
+    public Builder maxTokens(int maxTokens) {
+      this.maxTokens = maxTokens;
+      return this;
+    }
+
+    public MistralAiChatModelProvider build() {
+      if (apiKey == null) throw new IllegalStateException("apiKey is required");
+      return new MistralAiChatModelProvider(this);
+    }
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/ollama/OllamaChatModelProvider.java
+++ b/api/src/main/java/io/casehub/api/model/ai/ollama/OllamaChatModelProvider.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.ollama;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.AgentException;
+import io.casehub.api.model.ai.ChatModelProvider;
+import io.casehub.api.model.ai.ModelType;
+
+public final class OllamaChatModelProvider implements ChatModelProvider {
+
+  private final String baseUrl;
+  private final String modelName;
+  private final Double temperature;
+  private final Double topP;
+  private final Integer numPredict;
+
+  // no-arg constructor for ServiceLoader — reads from env vars
+  public OllamaChatModelProvider() {
+    String envBaseUrl = System.getenv("OLLAMA_BASE_URL");
+    this.baseUrl = envBaseUrl != null ? envBaseUrl : "http://localhost:11434";
+    this.modelName = System.getenv("OLLAMA_MODEL");
+    this.temperature = null;
+    this.topP = null;
+    this.numPredict = null;
+  }
+
+  private OllamaChatModelProvider(Builder b) {
+    this.baseUrl = b.baseUrl;
+    this.modelName = b.modelName;
+    this.temperature = b.temperature;
+    this.topP = b.topP;
+    this.numPredict = b.numPredict;
+  }
+
+  @Override
+  public ModelType type() {
+    return ModelType.OLLAMA;
+  }
+
+  @Override
+  public ChatModel get() {
+    try {
+      Class<?> modelClass = Class.forName("dev.langchain4j.model.ollama.OllamaChatModel");
+      Object ollamaBuilder = modelClass.getMethod("builder").invoke(null);
+      Class<?> builderClass = ollamaBuilder.getClass();
+
+      invoke(builderClass, ollamaBuilder, "baseUrl", String.class, baseUrl);
+      invoke(builderClass, ollamaBuilder, "modelName", String.class, modelName);
+      if (temperature != null)
+        invoke(builderClass, ollamaBuilder, "temperature", Double.class, temperature);
+      if (topP != null) invoke(builderClass, ollamaBuilder, "topP", Double.class, topP);
+      if (numPredict != null)
+        invoke(builderClass, ollamaBuilder, "numPredict", Integer.class, numPredict);
+
+      return (ChatModel) builderClass.getMethod("build").invoke(ollamaBuilder);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new AgentException("Failed to build OllamaChatModel: " + cause.getMessage(), cause);
+    } catch (Exception e) {
+      throw new AgentException("Failed to build OllamaChatModel: " + e.getMessage(), e);
+    }
+  }
+
+  private static void invoke(
+      Class<?> builderClass, Object builder, String method, Class<?> type, Object value)
+      throws Exception {
+    builderClass.getMethod(method, type).invoke(builder, value);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String baseUrl = "http://localhost:11434";
+    private String modelName;
+    private Double temperature;
+    private Double topP;
+    private Integer numPredict;
+
+    public Builder baseUrl(String baseUrl) {
+      this.baseUrl = baseUrl;
+      return this;
+    }
+
+    public Builder modelName(String modelName) {
+      this.modelName = modelName;
+      return this;
+    }
+
+    public Builder temperature(double temperature) {
+      this.temperature = temperature;
+      return this;
+    }
+
+    public Builder topP(double topP) {
+      this.topP = topP;
+      return this;
+    }
+
+    public Builder numPredict(int numPredict) {
+      this.numPredict = numPredict;
+      return this;
+    }
+
+    public OllamaChatModelProvider build() {
+      if (modelName == null) throw new IllegalStateException("modelName is required");
+      return new OllamaChatModelProvider(this);
+    }
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/openai/OpenAiChatModelProvider.java
+++ b/api/src/main/java/io/casehub/api/model/ai/openai/OpenAiChatModelProvider.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.openai;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.AgentException;
+import io.casehub.api.model.ai.ChatModelProvider;
+import io.casehub.api.model.ai.ModelType;
+
+public final class OpenAiChatModelProvider implements ChatModelProvider {
+
+  private final String apiKey;
+  private final String modelName;
+  private final Double temperature;
+  private final Double topP;
+  private final Integer maxTokens;
+  private final Integer maxCompletionTokens;
+
+  // no-arg constructor for ServiceLoader — reads from env vars
+  public OpenAiChatModelProvider() {
+    this.apiKey = System.getenv("OPENAI_API_KEY");
+    this.modelName = "gpt-4o-mini";
+    this.temperature = null;
+    this.topP = null;
+    this.maxTokens = null;
+    this.maxCompletionTokens = null;
+  }
+
+  private OpenAiChatModelProvider(Builder b) {
+    this.apiKey = b.apiKey;
+    this.modelName = b.modelName;
+    this.temperature = b.temperature;
+    this.topP = b.topP;
+    this.maxTokens = b.maxTokens;
+    this.maxCompletionTokens = b.maxCompletionTokens;
+  }
+
+  @Override
+  public ModelType type() {
+    return ModelType.OPENAI;
+  }
+
+  @Override
+  public ChatModel get() {
+    try {
+      Class<?> modelClass = Class.forName("dev.langchain4j.model.openai.OpenAiChatModel");
+      Object openAiBuilder = modelClass.getMethod("builder").invoke(null);
+      Class<?> builderClass = openAiBuilder.getClass();
+
+      invoke(builderClass, openAiBuilder, "apiKey", String.class, apiKey);
+      invoke(builderClass, openAiBuilder, "modelName", String.class, modelName);
+      if (temperature != null)
+        invoke(builderClass, openAiBuilder, "temperature", Double.class, temperature);
+      if (topP != null) invoke(builderClass, openAiBuilder, "topP", Double.class, topP);
+      if (maxTokens != null)
+        invoke(builderClass, openAiBuilder, "maxTokens", Integer.class, maxTokens);
+      if (maxCompletionTokens != null)
+        invoke(
+            builderClass, openAiBuilder, "maxCompletionTokens", Integer.class, maxCompletionTokens);
+
+      return (ChatModel) builderClass.getMethod("build").invoke(openAiBuilder);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new AgentException("Failed to build OpenAiChatModel: " + cause.getMessage(), cause);
+    } catch (Exception e) {
+      throw new AgentException("Failed to build OpenAiChatModel: " + e.getMessage(), e);
+    }
+  }
+
+  private static void invoke(
+      Class<?> builderClass, Object builder, String method, Class<?> type, Object value)
+      throws Exception {
+    builderClass.getMethod(method, type).invoke(builder, value);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String apiKey;
+    private String modelName = "gpt-4o-mini";
+    private Double temperature;
+    private Double topP;
+    private Integer maxTokens;
+    private Integer maxCompletionTokens;
+
+    public Builder apiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    public Builder modelName(String modelName) {
+      this.modelName = modelName;
+      return this;
+    }
+
+    public Builder temperature(double temperature) {
+      this.temperature = temperature;
+      return this;
+    }
+
+    public Builder topP(double topP) {
+      this.topP = topP;
+      return this;
+    }
+
+    public Builder maxTokens(int maxTokens) {
+      this.maxTokens = maxTokens;
+      return this;
+    }
+
+    public Builder maxCompletionTokens(int maxCompletionTokens) {
+      this.maxCompletionTokens = maxCompletionTokens;
+      return this;
+    }
+
+    public OpenAiChatModelProvider build() {
+      if (apiKey == null) throw new IllegalStateException("apiKey is required");
+      return new OpenAiChatModelProvider(this);
+    }
+  }
+}

--- a/api/src/main/resources/services/io.casehub.api.model.ai.ChatModelProvider
+++ b/api/src/main/resources/services/io.casehub.api.model.ai.ChatModelProvider
@@ -1,0 +1,5 @@
+io.casehub.api.model.ai.openai.OpenAiChatModelProvider
+io.casehub.api.model.ai.ollama.OllamaChatModelProvider
+io.casehub.api.model.ai.anthropic.AnthropicChatModelProvider
+io.casehub.api.model.ai.mistral.MistralAiChatModelProvider
+io.casehub.api.model.ai.gemini.GoogleAiGeminiChatModelProvider

--- a/api/src/test/java/io/casehub/api/model/AgentWorkerTest.java
+++ b/api/src/test/java/io/casehub/api/model/AgentWorkerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.casehub.api.model.ai.Agent;
+import io.casehub.api.model.ai.ChatModelProvider;
+import io.casehub.api.model.ai.ModelType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AgentWorkerTest {
+
+  private ChatModelProvider fixedResponseProvider(String jsonResponse) {
+    return new ChatModelProvider() {
+      @Override
+      public ModelType type() {
+        return ModelType.OPENAI;
+      }
+
+      @Override
+      public ChatModel get() {
+        return new ChatModel() {
+          @Override
+          public ChatResponse doChat(ChatRequest request) {
+            return ChatResponse.builder().aiMessage(AiMessage.from(jsonResponse)).build();
+          }
+        };
+      }
+    };
+  }
+
+  @Test
+  void workerCanBeCreatedWithAgent() {
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("You are a helpful assistant")
+            .inputSchema("{ text: .input }")
+            .outputSchema("{ result: .output }")
+            .model(fixedResponseProvider("{\"output\": \"processed\"}"))
+            .build();
+
+    Capability textProcessing =
+        new Capability("text-processing", "{ input: .text }", "{ text: .result }");
+
+    Worker worker =
+        Worker.builder()
+            .name("ai-text-processor")
+            .capabilities(textProcessing)
+            .function(agent)
+            .description("AI-powered text processing worker")
+            .build();
+
+    assertEquals("ai-text-processor", worker.getName());
+    assertEquals("AI-powered text processing worker", worker.getDescription());
+    assertEquals(1, worker.getCapabilities().size());
+    assertEquals("text-processing", worker.getCapabilities().get(0).getName());
+
+    assertNotNull(worker.getFunction());
+    assertInstanceOf(Agent.class, worker.getFunction().getValue());
+  }
+
+  @Test
+  void workerExecutesAgentCorrectly() {
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("You translate text to uppercase")
+            .inputSchema(".")
+            .outputSchema(".")
+            .model(fixedResponseProvider("{\"result\": \"HELLO WORLD\"}"))
+            .build();
+
+    Capability textTransform = new Capability("transform", ".", ".");
+
+    Worker worker =
+        Worker.builder()
+            .name("uppercase-transformer")
+            .capabilities(textTransform)
+            .function(agent)
+            .build();
+
+    Agent extractedAgent = (Agent) worker.getFunction().getValue();
+    Map<String, Object> result = extractedAgent.execute(Map.of("text", "hello world"));
+
+    assertEquals("HELLO WORLD", result.get("result"));
+  }
+
+  @Test
+  void agentWorkerSupportsExecutionPolicy() {
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("Test agent")
+            .inputSchema(".")
+            .outputSchema(".")
+            .model(fixedResponseProvider("{}"))
+            .build();
+
+    ExecutionPolicy policy =
+        new ExecutionPolicy(5000, new RetryPolicy(3, 1000, BackoffStrategy.EXPONENTIAL));
+
+    Worker worker =
+        Worker.builder()
+            .name("policy-test")
+            .capabilities(List.of(new Capability("test", ".", ".")))
+            .function(agent)
+            .executionPolicy(policy)
+            .build();
+
+    assertEquals(5000, worker.getExecutionPolicy().timeoutMs());
+    assertEquals(3, worker.getExecutionPolicy().retries().maxAttempts());
+    assertEquals(
+        BackoffStrategy.EXPONENTIAL, worker.getExecutionPolicy().retries().backoffStrategy());
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ai/AgentExceptionTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/AgentExceptionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+class AgentExceptionTest {
+
+  @Test
+  void wrapsMessage() {
+    AgentException ex = new AgentException("something went wrong");
+    assertEquals("something went wrong", ex.getMessage());
+  }
+
+  @Test
+  void wrapsCause() {
+    RuntimeException cause = new RuntimeException("root cause");
+    AgentException ex = new AgentException("wrapped", cause);
+    assertEquals("wrapped", ex.getMessage());
+    assertSame(cause, ex.getCause());
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ai/AgentTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/AgentTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class AgentTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private ChatModel fixedResponseModel(String jsonResponse) {
+    return new ChatModel() {
+      @Override
+      public ChatResponse doChat(ChatRequest request) {
+        return ChatResponse.builder().aiMessage(AiMessage.from(jsonResponse)).build();
+      }
+    };
+  }
+
+  @Test
+  void executesModelAndAppliesOutputSchema() {
+    ChatModel model = fixedResponseModel("{\"value\": 42, \"extra\": \"ignored\"}");
+
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("You are helpful.")
+            .inputSchema(".")
+            .outputSchema("{ value: .value }")
+            .model(model)
+            .build();
+
+    Map<String, Object> result = agent.execute(Map.of("question", "what?"));
+
+    assertEquals(42, result.get("value"));
+    assertNull(result.get("extra"));
+  }
+
+  @Test
+  void passesSystemPromptAndTransformedInputToModel() throws Exception {
+    AtomicReference<ChatRequest> capturedRequest = new AtomicReference<>();
+
+    ChatModel capturingModel =
+        new ChatModel() {
+          @Override
+          public ChatResponse doChat(ChatRequest request) {
+            capturedRequest.set(request);
+            return ChatResponse.builder().aiMessage(AiMessage.from("{\"result\": \"ok\"}")).build();
+          }
+        };
+
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("System instruction here.")
+            .inputSchema("{ documentId: .documentId }")
+            .outputSchema(".")
+            .model(capturingModel)
+            .build();
+
+    agent.execute(Map.of("documentId", "doc-1", "extra", "ignored"));
+
+    ChatRequest request = capturedRequest.get();
+    assertNotNull(request);
+
+    SystemMessage systemMsg = (SystemMessage) request.messages().get(0);
+    assertEquals("System instruction here.", systemMsg.text());
+
+    UserMessage userMsg = (UserMessage) request.messages().get(1);
+    Map<String, Object> sentMap = MAPPER.readValue(userMsg.singleText(), MAP_TYPE);
+    assertEquals("doc-1", sentMap.get("documentId"));
+    assertNull(sentMap.get("extra"));
+  }
+
+  @Test
+  void builderThrowsWhenSystemPromptMissing() {
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                Agent.builder()
+                    .inputSchema(".")
+                    .outputSchema(".")
+                    .model(fixedResponseModel("{}"))
+                    .build());
+    assertTrue(ex.getMessage().contains("systemPrompt"));
+  }
+
+  @Test
+  void builderThrowsWhenInputSchemaMissing() {
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                Agent.builder()
+                    .systemPrompt("prompt")
+                    .outputSchema(".")
+                    .model(fixedResponseModel("{}"))
+                    .build());
+    assertTrue(ex.getMessage().contains("inputSchema"));
+  }
+
+  @Test
+  void builderThrowsWhenOutputSchemaMissing() {
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                Agent.builder()
+                    .systemPrompt("prompt")
+                    .inputSchema(".")
+                    .model(fixedResponseModel("{}"))
+                    .build());
+    assertTrue(ex.getMessage().contains("outputSchema"));
+  }
+
+  @Test
+  void builderThrowsWhenModelMissing() {
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                Agent.builder().systemPrompt("prompt").inputSchema(".").outputSchema(".").build());
+    assertTrue(ex.getMessage().contains("model"));
+  }
+
+  @Test
+  void throwsAgentExceptionWhenLlmReturnsInvalidJson() {
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("prompt")
+            .inputSchema(".")
+            .outputSchema(".")
+            .model(fixedResponseModel("this is not json"))
+            .build();
+
+    assertThrows(AgentException.class, () -> agent.execute(Map.of("key", "value")));
+  }
+
+  @Test
+  void userMessageTemplateIsFilledFromJqResult() {
+    AtomicReference<ChatRequest> capturedRequest = new AtomicReference<>();
+    ChatModel model =
+        new ChatModel() {
+          @Override
+          public ChatResponse doChat(ChatRequest request) {
+            capturedRequest.set(request);
+            return ChatResponse.builder().aiMessage(AiMessage.from("{\"answer\": \"ok\"}")).build();
+          }
+        };
+
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("You are helpful")
+            .userMessage("Answer about Quarkus {{version}}: {{question}}")
+            .inputSchema("{ question: .q, version: .v }")
+            .outputSchema(".")
+            .model(model)
+            .build();
+
+    agent.execute(Map.of("q", "What is Dev Services?", "v", "3.x"));
+
+    UserMessage userMsg = (UserMessage) capturedRequest.get().messages().get(1);
+    assertEquals("Answer about Quarkus 3.x: What is Dev Services?", userMsg.singleText());
+  }
+
+  @Test
+  void withoutUserMessageTemplateUsesJsonFallback() {
+    AtomicReference<ChatRequest> capturedRequest = new AtomicReference<>();
+    ChatModel model =
+        new ChatModel() {
+          @Override
+          public ChatResponse doChat(ChatRequest request) {
+            capturedRequest.set(request);
+            return ChatResponse.builder().aiMessage(AiMessage.from("{\"answer\": \"ok\"}")).build();
+          }
+        };
+
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("You are helpful")
+            .inputSchema("{ question: .q }")
+            .outputSchema(".")
+            .model(model)
+            .build();
+
+    agent.execute(Map.of("q", "What is CDI?"));
+
+    UserMessage userMsg = (UserMessage) capturedRequest.get().messages().get(1);
+    String userText = userMsg.singleText();
+    assertTrue(userText.contains("What is CDI?"));
+    assertTrue(userText.startsWith("{"));
+  }
+
+  @Test
+  void userMessageTemplateMissingPlaceholderThrowsAgentException() {
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("You are helpful")
+            .userMessage("Hello {{name}}")
+            .inputSchema("{ question: .q }")
+            .outputSchema(".")
+            .model(fixedResponseModel("{\"answer\": \"ok\"}"))
+            .build();
+
+    assertThrows(AgentException.class, () -> agent.execute(Map.of("q", "test")));
+  }
+
+  @Test
+  void acceptsCustomChatModelProvider() {
+    AtomicReference<ChatRequest> capturedRequest = new AtomicReference<>();
+    ChatModel mockModel =
+        new ChatModel() {
+          @Override
+          public ChatResponse doChat(ChatRequest request) {
+            capturedRequest.set(request);
+            return ChatResponse.builder().aiMessage(AiMessage.from("{\"result\": \"ok\"}")).build();
+          }
+        };
+
+    ChatModelProvider provider =
+        new ChatModelProvider() {
+          @Override
+          public ModelType type() {
+            return ModelType.OPENAI;
+          }
+
+          @Override
+          public ChatModel get() {
+            return mockModel;
+          }
+        };
+
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("test")
+            .inputSchema(".")
+            .outputSchema(".")
+            .model(provider)
+            .build();
+
+    agent.execute(Map.of("key", "value"));
+    assertNotNull(capturedRequest.get());
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ai/JqTransformerTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/JqTransformerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class JqTransformerTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void extractsFields() throws Exception {
+    JqTransformer transformer = new JqTransformer("{ documentId: .documentId, status: .status }");
+    JsonNode input =
+        mapper.readTree(
+            "{\"documentId\": \"abc\", \"status\": \"active\", \"extra\": \"ignored\"}");
+
+    JsonNode result = transformer.apply(input);
+
+    assertEquals("abc", result.get("documentId").asText());
+    assertEquals("active", result.get("status").asText());
+    assertNull(result.get("extra"));
+  }
+
+  @Test
+  void identityFilter() throws Exception {
+    JqTransformer transformer = new JqTransformer(".");
+    JsonNode input = mapper.readTree("{\"key\": \"value\"}");
+
+    JsonNode result = transformer.apply(input);
+
+    assertEquals(input, result);
+  }
+
+  @Test
+  void invalidJqThrowsOnConstruction() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new JqTransformer("this is not valid jq !!!"));
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ai/anthropic/AnthropicChatModelProviderTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/anthropic/AnthropicChatModelProviderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.anthropic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.ModelType;
+import org.junit.jupiter.api.Test;
+
+class AnthropicChatModelProviderTest {
+
+  @Test
+  void typeIsAnthropic() {
+    AnthropicChatModelProvider provider =
+        AnthropicChatModelProvider.builder().apiKey("test-key").build();
+    assertEquals(ModelType.ANTHROPIC, provider.type());
+  }
+
+  @Test
+  void builderWithMinimalFieldsBuildsModel() {
+    AnthropicChatModelProvider provider =
+        AnthropicChatModelProvider.builder().apiKey("test-key").build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderWithAllFieldsBuildsModel() {
+    AnthropicChatModelProvider provider =
+        AnthropicChatModelProvider.builder()
+            .apiKey("test-key")
+            .modelName("claude-3-5-sonnet-20241022")
+            .temperature(0.7)
+            .topP(0.9)
+            .topK(40)
+            .maxTokens(1000)
+            .build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderRequiresApiKey() {
+    assertThrows(IllegalStateException.class, () -> AnthropicChatModelProvider.builder().build());
+  }
+
+  @Test
+  void builderWithCustomModelNameBuildsModel() {
+    AnthropicChatModelProvider provider =
+        AnthropicChatModelProvider.builder()
+            .apiKey("test-key")
+            .modelName("claude-3-haiku-20240307")
+            .build();
+    assertNotNull(provider.get());
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ai/gemini/GoogleAiGeminiChatModelProviderTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/gemini/GoogleAiGeminiChatModelProviderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.gemini;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.ModelType;
+import org.junit.jupiter.api.Test;
+
+class GoogleAiGeminiChatModelProviderTest {
+
+  @Test
+  void typeIsGoogleAiGemini() {
+    GoogleAiGeminiChatModelProvider provider =
+        GoogleAiGeminiChatModelProvider.builder().apiKey("test-key").build();
+    assertEquals(ModelType.GOOGLE_AI_GEMINI, provider.type());
+  }
+
+  @Test
+  void builderWithMinimalFieldsBuildsModel() {
+    GoogleAiGeminiChatModelProvider provider =
+        GoogleAiGeminiChatModelProvider.builder().apiKey("test-key").build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderWithAllFieldsBuildsModel() {
+    GoogleAiGeminiChatModelProvider provider =
+        GoogleAiGeminiChatModelProvider.builder()
+            .apiKey("test-key")
+            .modelName("gemini-2.0-flash")
+            .temperature(0.7)
+            .topP(0.9)
+            .maxOutputTokens(1000)
+            .build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderRequiresApiKey() {
+    assertThrows(
+        IllegalStateException.class, () -> GoogleAiGeminiChatModelProvider.builder().build());
+  }
+
+  @Test
+  void builderWithCustomModelNameBuildsModel() {
+    GoogleAiGeminiChatModelProvider provider =
+        GoogleAiGeminiChatModelProvider.builder()
+            .apiKey("test-key")
+            .modelName("gemini-1.5-pro")
+            .build();
+    assertNotNull(provider.get());
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ai/mistral/MistralAiChatModelProviderTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/mistral/MistralAiChatModelProviderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.mistral;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.ModelType;
+import org.junit.jupiter.api.Test;
+
+class MistralAiChatModelProviderTest {
+
+  @Test
+  void typeIsMistral() {
+    MistralAiChatModelProvider provider =
+        MistralAiChatModelProvider.builder().apiKey("test-key").build();
+    assertEquals(ModelType.MISTRAL, provider.type());
+  }
+
+  @Test
+  void builderWithMinimalFieldsBuildsModel() {
+    MistralAiChatModelProvider provider =
+        MistralAiChatModelProvider.builder().apiKey("test-key").build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderWithAllFieldsBuildsModel() {
+    MistralAiChatModelProvider provider =
+        MistralAiChatModelProvider.builder()
+            .apiKey("test-key")
+            .modelName("mistral-large-latest")
+            .temperature(0.7)
+            .topP(0.9)
+            .maxTokens(1000)
+            .build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderRequiresApiKey() {
+    assertThrows(IllegalStateException.class, () -> MistralAiChatModelProvider.builder().build());
+  }
+
+  @Test
+  void builderWithCustomModelNameBuildsModel() {
+    MistralAiChatModelProvider provider =
+        MistralAiChatModelProvider.builder()
+            .apiKey("test-key")
+            .modelName("mistral-small-latest")
+            .build();
+    assertNotNull(provider.get());
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ai/ollama/OllamaChatModelProviderTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/ollama/OllamaChatModelProviderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.ollama;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.ModelType;
+import org.junit.jupiter.api.Test;
+
+class OllamaChatModelProviderTest {
+
+  @Test
+  void typeIsOllama() {
+    OllamaChatModelProvider provider =
+        OllamaChatModelProvider.builder().modelName("llama3").build();
+    assertEquals(ModelType.OLLAMA, provider.type());
+  }
+
+  @Test
+  void builderWithMinimalFieldsBuildsModel() {
+    OllamaChatModelProvider provider =
+        OllamaChatModelProvider.builder().modelName("llama3").build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderWithAllFieldsBuildsModel() {
+    OllamaChatModelProvider provider =
+        OllamaChatModelProvider.builder()
+            .baseUrl("http://localhost:11434")
+            .modelName("llama3")
+            .temperature(0.7)
+            .topP(0.9)
+            .numPredict(500)
+            .build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderRequiresModelName() {
+    assertThrows(IllegalStateException.class, () -> OllamaChatModelProvider.builder().build());
+  }
+
+  @Test
+  void builderWithDefaultBaseUrlBuildsModel() {
+    OllamaChatModelProvider provider =
+        OllamaChatModelProvider.builder().modelName("llama3").build();
+    assertNotNull(provider.get());
+  }
+}

--- a/api/src/test/java/io/casehub/api/model/ai/openai/OpenAiChatModelProviderTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/openai/OpenAiChatModelProviderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.ai.openai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.casehub.api.model.ai.ModelType;
+import org.junit.jupiter.api.Test;
+
+class OpenAiChatModelProviderTest {
+
+  @Test
+  void typeIsOpenAi() {
+    OpenAiChatModelProvider provider = OpenAiChatModelProvider.builder().apiKey("test-key").build();
+    assertEquals(ModelType.OPENAI, provider.type());
+  }
+
+  @Test
+  void builderWithMinimalFieldsBuildsModel() {
+    OpenAiChatModelProvider provider = OpenAiChatModelProvider.builder().apiKey("test-key").build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderWithAllFieldsBuildsModel() {
+    OpenAiChatModelProvider provider =
+        OpenAiChatModelProvider.builder()
+            .apiKey("test-key")
+            .modelName("gpt-4o")
+            .temperature(0.5)
+            .topP(0.9)
+            .maxTokens(500)
+            .maxCompletionTokens(200)
+            .build();
+    ChatModel model = provider.get();
+    assertNotNull(model);
+  }
+
+  @Test
+  void builderRequiresApiKey() {
+    assertThrows(IllegalStateException.class, () -> OpenAiChatModelProvider.builder().build());
+  }
+
+  @Test
+  void builderWithCustomModelNameBuildsModel() {
+    OpenAiChatModelProvider provider =
+        OpenAiChatModelProvider.builder().apiKey("test-key").modelName("gpt-4o").build();
+    assertNotNull(provider.get());
+  }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -174,7 +174,7 @@ Quartz fires job
       → load EventLog by ID
       → load CaseInstance (cache or restore)
       → resolve Worker and Capability from CaseDefinition
-      → execute worker function (Workflow or Function<Map,Map>)
+      → execute worker function (Workflow, Function<Map,Map>, or Agent)
       → publish WorkflowExecutionCompleted → WORKER_EXECUTION_FINISHED bus
   → WorkflowExecutionCompletedHandler.onWorkflowExecutionCompletedHandler()
       → snapshot CaseContext (before)
@@ -191,6 +191,63 @@ Quartz fires job
 **Conflict resolution on output:** Each output key is written through the `ContextDiffStrategy`-selected resolver configured on the binding (`LAST_WRITER_WINS` default, `FIRST_WRITER_WINS`, or `FAIL`).
 
 **Idempotency:** `WorkerScheduleEventHandler` holds a Vert.x local lock on `(caseId, workerId, inputDataHash)` and checks for existing `WORKER_SCHEDULED / WORKER_EXECUTION_STARTED / WORKER_EXECUTION_COMPLETED` events before submitting to Quartz. Duplicate `CONTEXT_CHANGED` events that arrive while a worker is in flight are silently dropped.
+
+## Worker Function Types
+
+Workers can be implemented using three function types:
+
+### Workflow
+
+Serverless Workflow execution via `io.serverlessworkflow.api.types.Workflow`. The workflow model is executed by `WorkflowExecutor` and returns a `WorkflowModel` containing the output state.
+
+### Function
+
+Java function with signature `Function<Map<String, Object>, Map<String, Object>>`. The function receives input data derived from the CaseContext via the capability's `inputSchema` and returns output data that is merged back via the `outputSchema`.
+
+### Agent
+
+AI-powered worker using LangChain4j models. Agents transform input data using JQ expressions, invoke an LLM with a system prompt, and transform the LLM response back to output data.
+
+**Agent architecture:**
+
+```
+CaseContext
+  → inputSchema (JQ) → transformed input
+  → system prompt + user message template
+  → ChatModel.chat(request)
+  → LLM response (JSON)
+  → outputSchema (JQ) → output data
+  → merge to CaseContext
+```
+
+**Key components:**
+- `Agent` — core execution class; applies JQ transformations, builds ChatRequest, invokes model
+- `ChatModelProvider` — SPI interface (ServiceLoader-based) for pluggable LLM backends
+- `ModelType` enum — OPENAI, OLLAMA, ANTHROPIC, MISTRAL_AI, GOOGLE_AI_GEMINI
+- `JqTransformer` — applies JQ expressions for input/output mapping
+- Provider implementations use reflection to avoid compile-time dependencies on vendor SDKs
+
+**Execution:**
+- Runs in `CompletableFuture.supplyAsync()` with timeout enforcement
+- `WorkerExecutionContext` thread-local is set before Agent.execute() and cleared in finally block
+- Same retry/failure semantics as Function and Workflow types
+
+**Builder API:**
+
+```java
+Agent agent = Agent.builder()
+    .systemPrompt("Analyze sentiment...")
+    .inputSchema("{ text: .text }")
+    .outputSchema("{ sentiment: .sentiment }")
+    .model(ModelType.OPENAI)  // or ChatModelProvider, or ChatModel
+    .build();
+
+Worker worker = Worker.builder()
+    .name("sentiment-analyzer")
+    .capabilities(capability)
+    .function(agent)
+    .build();
+```
 
 ## Failure and Retry Lifecycle
 
@@ -345,6 +402,12 @@ WorkerExecutionContext.current() ← accessed by the worker function at runtime
 **Causal chain:** When a worker completes, `CaseLedgerEventCapture` writes a `WORKER_EXECUTION_COMPLETED` ledger entry. The `WorkerSummary` for that worker carries this entry's UUID as `ledgerEntryId`. New workers set `causedByEntryId` on their own ledger entries to this value, completing the causal chain across workers on a case.
 
 **SPI placement rule:** Operational SPIs (worker provisioning, lifecycle, channels) go in `api/spi/`; persistence SPIs (`CaseMetaModelRepository`, etc.) go in `engine-model/spi/`.
+
+### AI Agent Dependencies
+
+The `api` module depends on `dev.langchain4j:langchain4j` (core) for the Agent worker type. Test scope includes provider implementations: `langchain4j-open-ai`, `langchain4j-ollama`, `langchain4j-anthropic`, `langchain4j-mistral-ai`, `langchain4j-google-ai-gemini`.
+
+Provider implementations use reflection to load vendor SDKs at runtime, avoiding compile-time dependencies. The `ChatModelProvider` SPI is registered via `META-INF/services/io.casehub.api.model.ai.ChatModelProvider`.
 
 ### SPI Call Sites
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,8 @@
         <maven.deploy.skip>false</maven.deploy.skip>
 
         <version.com.squareup.okhttp3.mockwebserver>5.3.2</version.com.squareup.okhttp3.mockwebserver>
-        <version.io.quarkiverse.langchain4j>1.5.0</version.io.quarkiverse.langchain4j>
+        <version.io.quarkiverse.langchain4j>1.9.2</version.io.quarkiverse.langchain4j>
+        <version.dev.langchain4j>1.14.1</version.dev.langchain4j>
 
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
         <checkstyle.header.extensions>java</checkstyle.header.extensions>
@@ -155,20 +156,11 @@
                 <artifactId>zjsonpatch</artifactId>
                 <version>${version.io.fabric8.zjsonpatch}</version>
             </dependency>
-
-            <!-- test dependencies -->
             <dependency>
-                <groupId>io.quarkiverse.langchain4j</groupId>
-                <artifactId>quarkus-langchain4j-ollama</artifactId>
-                <version>${version.io.quarkiverse.langchain4j}</version>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j</artifactId>
+                <version>${version.dev.langchain4j}</version>
             </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>mockwebserver</artifactId>
-                <version>${version.com.squareup.okhttp3.mockwebserver}</version>
-            </dependency>
-
-            <!-- casehubio ecosystem -->
             <dependency>
                 <groupId>io.casehub</groupId>
                 <artifactId>casehub-work-api</artifactId>
@@ -198,6 +190,50 @@
                 <groupId>io.casehub</groupId>
                 <artifactId>casehub-ledger-api</artifactId>
                 <version>${version.io.casehub.ledger}</version>
+            </dependency>
+
+            <!-- test dependencies -->
+            <dependency>
+                <groupId>io.quarkiverse.langchain4j</groupId>
+                <artifactId>quarkus-langchain4j-ollama</artifactId>
+                <scope>test</scope>
+                <version>${version.io.quarkiverse.langchain4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-open-ai</artifactId>
+                <version>${version.dev.langchain4j}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-ollama</artifactId>
+                <version>${version.dev.langchain4j}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-anthropic</artifactId>
+                <version>${version.dev.langchain4j}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-mistral-ai</artifactId>
+                <version>${version.dev.langchain4j}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-google-ai-gemini</artifactId>
+                <version>${version.dev.langchain4j}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>mockwebserver</artifactId>
+                <scope>test</scope>
+                <version>${version.com.squareup.okhttp3.mockwebserver}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/runtime/src/test/java/io/casehub/engine/AgentWorkerExecutionTest.java
+++ b/runtime/src/test/java/io/casehub/engine/AgentWorkerExecutionTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.AllOfGoalExpression;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalBasedCompletion;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.ai.Agent;
+import io.casehub.api.model.ai.ChatModelProvider;
+import io.casehub.api.model.ai.ModelType;
+import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.engine.spi.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class AgentWorkerExecutionTest {
+
+  @Inject AgentCaseHub agentCaseHub;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @Test
+  public void agentWorkerExecutesAndCompletesCase() {
+    AtomicReference<UUID> caseIdRef = new AtomicReference<>();
+    AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    Map<String, Object> initialContext =
+        Map.of(
+            "text", "This is a great product!",
+            "status", "pending");
+
+    agentCaseHub
+        .startCase(initialContext)
+        .thenAccept(caseIdRef::set)
+        .exceptionally(
+            ex -> {
+              errorRef.set(ex);
+              return null;
+            });
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              if (errorRef.get() != null) throw new AssertionError(errorRef.get());
+              assertNotNull(caseIdRef.get());
+            });
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              var instance = caseInstanceCache.get(caseIdRef.get());
+              assertNotNull(instance);
+              assertEquals(CaseStatus.COMPLETED, instance.getState());
+
+              // Verify agent processed the sentiment
+              Map<String, Object> context = instance.getCaseContext().getData();
+              assertNotNull(context.get("sentiment"));
+              assertEquals("POSITIVE", context.get("sentiment"));
+            });
+  }
+
+  @ApplicationScoped
+  public static class AgentCaseHub extends CaseHub {
+
+    private static final CaseDefinition DEFINITION = createDefinition();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return DEFINITION;
+    }
+
+    private static CaseDefinition createDefinition() {
+      // Mock ChatModelProvider that returns fixed sentiment
+      ChatModelProvider mockProvider =
+          new ChatModelProvider() {
+            @Override
+            public ModelType type() {
+              return ModelType.OPENAI;
+            }
+
+            @Override
+            public ChatModel get() {
+              return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest request) {
+                  return ChatResponse.builder()
+                      .aiMessage(AiMessage.from("{\"sentiment\": \"POSITIVE\"}"))
+                      .build();
+                }
+              };
+            }
+          };
+
+      // Create AI Agent
+      Agent sentimentAgent =
+          Agent.builder()
+              .systemPrompt(
+                  "You are a sentiment analyzer. Analyze the text and return POSITIVE, NEGATIVE, or NEUTRAL.")
+              .inputSchema("{ text: .text }")
+              .outputSchema("{ sentiment: .sentiment }")
+              .model(mockProvider)
+              .build();
+
+      // Create capability
+      Capability sentimentCapability =
+          new Capability(
+              "analyzeSentiment",
+              "{ text: .text }",
+              "{ sentiment: .sentiment, status: \"analyzed\" }");
+
+      // Create worker with Agent
+      Worker aiWorker =
+          Worker.builder()
+              .name("sentiment-worker")
+              .capabilities(sentimentCapability)
+              .function(sentimentAgent)
+              .description("AI-powered sentiment analysis worker")
+              .build();
+
+      // Create binding to trigger on pending status
+      Binding binding =
+          Binding.builder()
+              .name("trigger-sentiment-analysis")
+              .capability(sentimentCapability)
+              .on(new ContextChangeTrigger(new JQExpressionEvaluator(".status == \"pending\"")))
+              .build();
+
+      // Create goal
+      Goal analysisComplete =
+          new Goal(
+              "analysisComplete",
+              new JQExpressionEvaluator(".status == \"analyzed\""),
+              GoalKind.SUCCESS);
+
+      // Create case definition
+      CaseDefinition definition = new CaseDefinition("test", "AI Sentiment Analysis", "1.0.0");
+      definition.setDsl("0.1");
+      definition.setTitle("AI Agent Worker Test Case");
+
+      definition.getCapabilities().add(sentimentCapability);
+      definition.getWorkers().add(aiWorker);
+      definition.getBindings().add(binding);
+      definition.getGoals().add(analysisComplete);
+
+      // Set completion criteria
+      definition.setCompletion(
+          new GoalBasedCompletion(new AllOfGoalExpression(List.of(analysisComplete)), null));
+
+      return definition;
+    }
+  }
+}

--- a/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJob.java
+++ b/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJob.java
@@ -25,6 +25,7 @@ import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.WorkerContext;
 import io.casehub.api.model.WorkerExecutionContext;
+import io.casehub.api.model.ai.Agent;
 import io.casehub.api.spi.WorkerContextProvider;
 import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
 import io.casehub.engine.internal.history.EventLog;
@@ -148,9 +149,11 @@ class QuartzWorkerExecutionJob implements Job {
         outputData = workflow(workflow, inputData, workerContext, timeoutMs);
       } else if (worker.getFunction().getValue() instanceof Function function) {
         outputData = function(function, inputData, workerContext, timeoutMs);
+      } else if (worker.getFunction().getValue() instanceof Agent agent) {
+        outputData = agent(agent, inputData, workerContext, timeoutMs);
       } else {
         throw new RuntimeException(
-            "Worker function is not a workflow: "
+            "Worker function is not a workflow, function, or agent: "
                 + worker.getName()
                 + " "
                 + worker.getFunction().getValue().getClass().getCanonicalName());
@@ -199,6 +202,26 @@ class QuartzWorkerExecutionJob implements Job {
               WorkerExecutionContext.set(workerContext);
               try {
                 return function.apply(inputData);
+              } finally {
+                WorkerExecutionContext.clear();
+              }
+            });
+
+    return cf.get(timeoutMs, TimeUnit.MILLISECONDS);
+  }
+
+  private Map<String, Object> agent(
+      Agent agent, Map<String, Object> inputData, WorkerContext workerContext, int timeoutMs)
+      throws TimeoutException, InterruptedException, ExecutionException {
+
+    LOG.debugf("Executing agent with timeout: %d ms", timeoutMs);
+
+    CompletableFuture<Map<String, Object>> cf =
+        CompletableFuture.supplyAsync(
+            () -> {
+              WorkerExecutionContext.set(workerContext);
+              try {
+                return agent.execute(inputData);
               } finally {
                 WorkerExecutionContext.clear();
               }

--- a/scheduler-quartz/src/test/java/io/casehub/engine/scheduler/quartz/AgentExecutionTest.java
+++ b/scheduler-quartz/src/test/java/io/casehub/engine/scheduler/quartz/AgentExecutionTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.scheduler.quartz;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerContext;
+import io.casehub.api.model.ai.Agent;
+import io.casehub.api.model.ai.ChatModelProvider;
+import io.casehub.api.model.ai.ModelType;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AgentExecutionTest {
+
+  private QuartzWorkerExecutionJob job;
+
+  @BeforeEach
+  void setUp() {
+    job = new QuartzWorkerExecutionJob();
+  }
+
+  @Test
+  void agentMethodExecutesSuccessfully() throws Exception {
+    ChatModelProvider mockProvider = createMockProvider("{\"sentiment\": \"POSITIVE\"}");
+
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("Analyze sentiment")
+            .inputSchema("{ text: .text }")
+            .outputSchema("{ sentiment: .sentiment }")
+            .model(mockProvider)
+            .build();
+
+    Map<String, Object> input = Map.of("text", "I love this product!");
+    WorkerContext context = new WorkerContext(null, null, null, null, null, null);
+    int timeout = 5000;
+
+    Map<String, Object> result = invokeAgentMethod(agent, input, context, timeout);
+
+    assertNotNull(result);
+    assertEquals("POSITIVE", result.get("sentiment"));
+  }
+
+  @Test
+  void agentMethodHandlesTimeout() {
+    ChatModelProvider slowProvider =
+        new ChatModelProvider() {
+          @Override
+          public ModelType type() {
+            return ModelType.OPENAI;
+          }
+
+          @Override
+          public ChatModel get() {
+            return new ChatModel() {
+              @Override
+              public ChatResponse doChat(ChatRequest request) {
+                try {
+                  Thread.sleep(10000); // 10 seconds
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+                return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("{\"result\": \"ok\"}"))
+                    .build();
+              }
+            };
+          }
+        };
+
+    Agent agent =
+        Agent.builder()
+            .systemPrompt("Test")
+            .inputSchema(".")
+            .outputSchema(".")
+            .model(slowProvider)
+            .build();
+
+    Map<String, Object> input = Map.of("key", "value");
+    WorkerContext context = new WorkerContext(null, null, null, null, null, null);
+    int timeout = 100; // Very short timeout
+
+    // CompletableFuture.get(timeout) throws TimeoutException directly, not wrapped in
+    // ExecutionException
+    assertThrows(TimeoutException.class, () -> invokeAgentMethod(agent, input, context, timeout));
+  }
+
+  @Test
+  void agentWorkerIntegrationWithWorkerClass() throws Exception {
+    ChatModelProvider mockProvider = createMockProvider("{\"classification\": \"technical\"}");
+
+    Agent classifier =
+        Agent.builder()
+            .systemPrompt("Classify documents")
+            .inputSchema("{ content: .content }")
+            .outputSchema("{ classification: .classification }")
+            .model(mockProvider)
+            .build();
+
+    Capability docClassification =
+        new Capability("classify", "{ content: .document }", "{ type: .classification }");
+
+    Worker worker =
+        Worker.builder()
+            .name("doc-classifier")
+            .capabilities(docClassification)
+            .function(classifier)
+            .build();
+
+    assertEquals("doc-classifier", worker.getName());
+    assertNotNull(worker.getFunction().getValue());
+    assertEquals(Agent.class, worker.getFunction().getValue().getClass());
+  }
+
+  // Helper methods
+
+  private ChatModelProvider createMockProvider(String response) {
+    return new ChatModelProvider() {
+      @Override
+      public ModelType type() {
+        return ModelType.OPENAI;
+      }
+
+      @Override
+      public ChatModel get() {
+        return new ChatModel() {
+          @Override
+          public ChatResponse doChat(ChatRequest request) {
+            return ChatResponse.builder().aiMessage(AiMessage.from(response)).build();
+          }
+        };
+      }
+    };
+  }
+
+  private Map<String, Object> invokeAgentMethod(
+      Agent agent, Map<String, Object> input, WorkerContext context, int timeout) throws Exception {
+    Method agentMethod =
+        QuartzWorkerExecutionJob.class.getDeclaredMethod(
+            "agent", Agent.class, Map.class, WorkerContext.class, int.class);
+    agentMethod.setAccessible(true);
+
+    try {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> result =
+          (Map<String, Object>) agentMethod.invoke(job, agent, input, context, timeout);
+      return result;
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      // Re-throw the original exception
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
Introduces Agent as a third worker function type alongside Workflow and Function. Agents use LangChain4j models to execute AI-powered tasks with JQ-based input/output transformation.

Key components:
- Agent class with JQ transformers for data mapping
- ChatModelProvider SPI with 5 implementations (OpenAI, Ollama, Anthropic, Mistral AI, Google AI Gemini)
- Reflection-based provider loading avoids compile-time vendor SDK dependencies
- Integration with QuartzWorkerExecutionJob execution layer
- WorkerExecutionContext thread-local propagation
- Timeout enforcement via CompletableFuture

Testing:
- 7 comprehensive tests covering Agent execution, timeout handling, provider loading
- AgentWorkerExecutionTest (E2E integration test)
- AgentExecutionTest (Quartz job execution test)

Also translates EVENT_LOG_API.md from Russian to English.

Closes #244