### PR TITLE
fix(recovery): preserve SubCase outputMapping data after restart

### DIFF
--- a/blackboard/src/main/java/io/casehub/blackboard/subcase/SubCaseCompletionListener.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/subcase/SubCaseCompletionListener.java
@@ -138,8 +138,9 @@ public class SubCaseCompletionListener {
           cancelRemainingChildren(group, childCaseId);
         }
 
-        applyOutputMapping(startedEntry, childCaseId, parentCaseId);
-        writeCompletedLog(parentCaseId, childCaseId, groupId, groupStatus);
+        Map<String, Object> appliedData =
+            applyOutputMapping(startedEntry, childCaseId, parentCaseId);
+        writeCompletedLog(parentCaseId, childCaseId, groupId, groupStatus, appliedData);
 
         CaseInstance parent = caseInstanceCache.get(parentCaseId);
         if (parent == null) {
@@ -160,7 +161,7 @@ public class SubCaseCompletionListener {
             .atMost(Duration.ofSeconds(10));
       } else {
         // REJECTED — threshold is unreachable; cancel the parent to prevent indefinite WAITING
-        writeCompletedLog(parentCaseId, childCaseId, groupId, groupStatus);
+        writeCompletedLog(parentCaseId, childCaseId, groupId, groupStatus, null);
         LOG.warnf(
             "SubCaseGroup REJECTED: parentCaseId=%s groupId=%s — threshold unreachable. Cancelling parent case.",
             parentCaseId, groupId);
@@ -173,7 +174,7 @@ public class SubCaseCompletionListener {
         }
       }
     } else {
-      writeCompletedLog(parentCaseId, childCaseId, groupId, groupStatus);
+      writeCompletedLog(parentCaseId, childCaseId, groupId, groupStatus, null);
     }
   }
 
@@ -194,15 +195,16 @@ public class SubCaseCompletionListener {
       return;
     }
 
+    Map<String, Object> appliedData = null;
     if (outputMapping != null) {
-      applyOutputMappingToParent(childCaseId, parent, outputMapping);
+      appliedData = applyOutputMappingToParent(childCaseId, parent, outputMapping);
     }
 
     LOG.infof(
         "SubCaseCompletionListener (ungrouped): child %s (%s) → parent %s",
         childCaseId, childStatus, parentCaseId);
 
-    writeCompletedLog(parentCaseId, childCaseId, null, null);
+    writeCompletedLog(parentCaseId, childCaseId, null, null, appliedData);
 
     caseResumptionService
         .resumeIfWaiting(
@@ -215,28 +217,34 @@ public class SubCaseCompletionListener {
         .atMost(Duration.ofSeconds(10));
   }
 
-  private void applyOutputMapping(EventLog startedEntry, UUID childCaseId, UUID parentCaseId) {
+  private Map<String, Object> applyOutputMapping(
+      EventLog startedEntry, UUID childCaseId, UUID parentCaseId) {
     String outputMapping =
         startedEntry.getMetadata().has("outputMapping")
             ? startedEntry.getMetadata().get("outputMapping").asText()
             : null;
-    if (outputMapping == null) return;
+    if (outputMapping == null) return null;
     CaseInstance parent = caseInstanceCache.get(parentCaseId);
     if (parent != null) {
-      applyOutputMappingToParent(childCaseId, parent, outputMapping);
+      return applyOutputMappingToParent(childCaseId, parent, outputMapping);
     }
+    return null;
   }
 
-  private void applyOutputMappingToParent(
+  private Map<String, Object> applyOutputMappingToParent(
       UUID childCaseId, CaseInstance parent, String outputMapping) {
     CaseInstance child = caseInstanceCache.get(childCaseId);
     if (child != null) {
       Map<String, Object> mapped = child.getCaseContext().evalObjectTemplate(outputMapping);
-      if (mapped != null) mapped.forEach((k, v) -> parent.getCaseContext().set(k, v));
+      if (mapped != null) {
+        mapped.forEach((k, v) -> parent.getCaseContext().set(k, v));
+        return mapped;
+      }
     } else {
       LOG.warnf(
           "SubCaseCompletionListener: child %s not in cache — outputMapping skipped", childCaseId);
     }
+    return null;
   }
 
   private void cancelRemainingChildren(SubCaseGroup group, UUID justCompletedChildId) {
@@ -254,7 +262,11 @@ public class SubCaseCompletionListener {
   }
 
   private void writeCompletedLog(
-      UUID parentCaseId, UUID childCaseId, String groupId, GroupStatus groupStatus) {
+      UUID parentCaseId,
+      UUID childCaseId,
+      String groupId,
+      GroupStatus groupStatus,
+      Map<String, Object> appliedData) {
     EventLog log = new EventLog();
     log.setCaseId(parentCaseId);
     log.setWorkerId(childCaseId.toString());
@@ -266,6 +278,10 @@ public class SubCaseCompletionListener {
     if (groupId != null) meta.put("groupId", groupId);
     if (groupStatus != null) meta.put("groupStatus", groupStatus.name());
     log.setMetadata(meta);
+    // Save applied outputMapping data in payload for recovery after restart
+    if (appliedData != null && !appliedData.isEmpty()) {
+      log.setPayload(OBJECT_MAPPER.valueToTree(appliedData));
+    }
     eventLogRepository.append(log).await().atMost(Duration.ofSeconds(10));
   }
 

--- a/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaCaseInstanceRepository.java
+++ b/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaCaseInstanceRepository.java
@@ -40,6 +40,7 @@ public class JpaCaseInstanceRepository extends AbstractJpaRepository
                               CaseInstanceEntity entity = new CaseInstanceEntity();
                               entity.uuid = instance.getUuid();
                               entity.state = instance.getState();
+                              entity.parentCaseId = instance.getParentCaseId();
                               entity.parentPlanItemId = instance.getParentPlanItemId();
                               entity.waitingForWorkId = instance.getWaitingForWorkId();
                               if (instance.getCaseMetaModel() != null) {
@@ -68,6 +69,7 @@ public class JpaCaseInstanceRepository extends AbstractJpaRepository
                         .invoke(
                             entity -> {
                               entity.state = instance.getState();
+                              entity.parentCaseId = instance.getParentCaseId();
                               entity.parentPlanItemId = instance.getParentPlanItemId();
                               entity.waitingForWorkId = instance.getWaitingForWorkId();
                             })
@@ -106,6 +108,7 @@ public class JpaCaseInstanceRepository extends AbstractJpaRepository
                             .chain(
                                 entity -> {
                                   entity.state = instance.getState();
+                                  entity.parentCaseId = instance.getParentCaseId();
                                   entity.parentPlanItemId = instance.getParentPlanItemId();
                                   entity.waitingForWorkId = instance.getWaitingForWorkId();
                                   return Panache.getSession().chain(s -> s.merge(entity));
@@ -124,6 +127,7 @@ public class JpaCaseInstanceRepository extends AbstractJpaRepository
     instance.id = entity.id;
     instance.setUuid(entity.uuid);
     instance.setState(entity.state);
+    instance.setParentCaseId(entity.parentCaseId);
     instance.setParentPlanItemId(entity.parentPlanItemId);
     instance.setWaitingForWorkId(entity.waitingForWorkId);
     if (entity.caseMetaModel != null) {

--- a/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaSubCaseGroupRepository.java
+++ b/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaSubCaseGroupRepository.java
@@ -123,9 +123,11 @@ public class JpaSubCaseGroupRepository implements SubCaseGroupRepository {
 
   @Override
   public Uni<Optional<SubCaseGroup>> findByChildCaseId(UUID childCaseId) {
-    return SubCaseGroupEntity.<SubCaseGroupEntity>find("?1 member of childCaseIds", childCaseId)
-        .firstResult()
-        .map(e -> Optional.ofNullable(e == null ? null : toDomain(e)));
+    return Panache.withSession(
+        () ->
+            SubCaseGroupEntity.<SubCaseGroupEntity>find("?1 member of childCaseIds", childCaseId)
+                .firstResult()
+                .map(e -> Optional.ofNullable(e == null ? null : toDomain(e))));
   }
 
   private SubCaseGroup toDomain(SubCaseGroupEntity e) {

--- a/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaCaseInstanceRepositoryTest.java
+++ b/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaCaseInstanceRepositoryTest.java
@@ -29,6 +29,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.vertx.VertxContextSupport;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -140,5 +141,151 @@ class JpaCaseInstanceRepositoryTest {
     instance.setState(status);
     instance.setCaseMetaModel(meta);
     return instance;
+  }
+
+  // ========== Edge Case Tests ==========
+
+  @Test
+  void save_handlesNullParentCaseId() {
+    CaseInstance instance = newInstance(savedMeta, CaseStatus.RUNNING);
+    instance.setParentCaseId(null); // NULL parent is valid for root cases
+
+    CaseInstance saved = run(() -> instanceRepository.save(instance));
+
+    assertThat(saved.id).isNotNull();
+    assertThat(saved.getParentCaseId()).isNull();
+  }
+
+  @Test
+  void save_handlesNonNullParentCaseId() {
+    UUID parentCaseId = UUID.randomUUID();
+    CaseInstance instance = newInstance(savedMeta, CaseStatus.RUNNING);
+    instance.setParentCaseId(parentCaseId);
+
+    CaseInstance saved = run(() -> instanceRepository.save(instance));
+
+    assertThat(saved.id).isNotNull();
+    assertThat(saved.getParentCaseId()).isEqualTo(parentCaseId);
+  }
+
+  @Test
+  void update_preservesParentCaseId() {
+    UUID parentCaseId = UUID.randomUUID();
+    CaseInstance instance = newInstance(savedMeta, CaseStatus.RUNNING);
+    instance.setParentCaseId(parentCaseId);
+    run(() -> instanceRepository.save(instance));
+
+    instance.setState(CaseStatus.COMPLETED);
+    run(() -> instanceRepository.update(instance));
+
+    CaseInstance reloaded = run(() -> instanceRepository.findByUuid(instance.getUuid()));
+    assertThat(reloaded.getState()).isEqualTo(CaseStatus.COMPLETED);
+    assertThat(reloaded.getParentCaseId()).isEqualTo(parentCaseId);
+  }
+
+  @Test
+  void update_canChangeMultipleFields() {
+    CaseInstance instance = newInstance(savedMeta, CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(instance));
+
+    UUID newParentCaseId = UUID.randomUUID();
+    instance.setState(CaseStatus.FAULTED);
+    instance.setParentCaseId(newParentCaseId);
+    run(() -> instanceRepository.update(instance));
+
+    CaseInstance reloaded = run(() -> instanceRepository.findByUuid(instance.getUuid()));
+    assertThat(reloaded.getState()).isEqualTo(CaseStatus.FAULTED);
+    assertThat(reloaded.getParentCaseId()).isEqualTo(newParentCaseId);
+  }
+
+  @Test
+  void findByUuid_returnsInstanceWithAllFields() {
+    UUID parentCaseId = UUID.randomUUID();
+    UUID instanceUuid = UUID.randomUUID();
+    CaseInstance instance = newInstance(savedMeta, CaseStatus.SUSPENDED);
+    instance.setUuid(instanceUuid);
+    instance.setParentCaseId(parentCaseId);
+    run(() -> instanceRepository.save(instance));
+
+    CaseInstance found = run(() -> instanceRepository.findByUuid(instanceUuid));
+
+    assertThat(found).isNotNull();
+    assertThat(found.getUuid()).isEqualTo(instanceUuid);
+    assertThat(found.getState()).isEqualTo(CaseStatus.SUSPENDED);
+    assertThat(found.getParentCaseId()).isEqualTo(parentCaseId);
+    assertThat(found.getCaseMetaModel()).isNotNull();
+    assertThat(found.getCaseMetaModel().getId()).isEqualTo(savedMeta.getId());
+  }
+
+  @Test
+  void updateStateAndAppendEvent_bothOperationsSucceed() {
+    CaseInstance instance = newInstance(savedMeta, CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(instance));
+
+    instance.setState(CaseStatus.COMPLETED);
+    io.casehub.engine.internal.history.EventLog eventLog =
+        new io.casehub.engine.internal.history.EventLog();
+    eventLog.setCaseId(instance.getUuid());
+    eventLog.setEventType(CaseHubEventType.CASE_COMPLETED);
+    eventLog.setStreamType(EventStreamType.CASE);
+    eventLog.setTimestamp(
+        java.time.Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MICROS));
+
+    run(() -> instanceRepository.updateStateAndAppendEvent(instance, eventLog));
+
+    // Verify both operations persisted
+    CaseInstance updated = run(() -> instanceRepository.findByUuid(instance.getUuid()));
+    assertThat(updated.getState()).isEqualTo(CaseStatus.COMPLETED);
+
+    io.casehub.engine.internal.history.EventLog foundEvent =
+        run(() -> eventLogRepository.findById(eventLog.id));
+    assertThat(foundEvent).isNotNull();
+    assertThat(foundEvent.getEventType()).isEqualTo(CaseHubEventType.CASE_COMPLETED);
+  }
+
+  @Test
+  void save_withAllStates() {
+    for (CaseStatus status : CaseStatus.values()) {
+      String unique = UUID.randomUUID().toString().substring(0, 8);
+      CaseMetaModel meta = new CaseMetaModel();
+      meta.setName("state-test-" + unique);
+      meta.setNamespace("test-ns");
+      meta.setVersion("1.0");
+      CaseMetaModel savedMetaForStatus = run(() -> metaModelRepository.save(meta));
+
+      CaseInstance instance = newInstance(savedMetaForStatus, status);
+      CaseInstance saved = run(() -> instanceRepository.save(instance));
+
+      assertThat(saved.getState()).isEqualTo(status);
+    }
+  }
+
+  @Test
+  void findByUuid_concurrentReads() throws InterruptedException {
+    CaseInstance instance = newInstance(savedMeta, CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(instance));
+    final UUID uuid = instance.getUuid();
+
+    int threadCount = 5;
+    List<CaseInstance> results = new java.util.concurrent.CopyOnWriteArrayList<>();
+    List<Thread> threads = new java.util.ArrayList<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      Thread t =
+          new Thread(
+              () -> {
+                CaseInstance found = run(() -> instanceRepository.findByUuid(uuid));
+                results.add(found);
+              });
+      threads.add(t);
+      t.start();
+    }
+
+    for (Thread t : threads) {
+      t.join();
+    }
+
+    assertThat(results).hasSize(threadCount);
+    assertThat(results).allMatch(r -> r != null && r.getUuid().equals(uuid));
   }
 }

--- a/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaCaseMetaModelRepositoryTest.java
+++ b/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaCaseMetaModelRepositoryTest.java
@@ -17,6 +17,7 @@ package io.casehub.persistence.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.engine.internal.model.CaseMetaModel;
 import io.casehub.engine.spi.CaseMetaModelRepository;
 import io.quarkus.test.junit.QuarkusTest;
@@ -30,6 +31,8 @@ import org.junit.jupiter.api.Test;
 class JpaCaseMetaModelRepositoryTest {
 
   @Inject CaseMetaModelRepository repository;
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   /**
    * Panache.withSession/withTransaction requires a Vert.x duplicated context marked as safe. JUnit
@@ -95,5 +98,197 @@ class JpaCaseMetaModelRepositoryTest {
     m.setNamespace(namespace);
     m.setVersion(version);
     return m;
+  }
+
+  // ========== Edge Case Tests ==========
+
+  @Test
+  void save_handlesNullOptionalFields() {
+    CaseMetaModel meta = metaModel("null-fields", "ns", "1.0");
+    meta.setTitle(null);
+    meta.setDsl(null);
+    meta.setDefinition(null);
+
+    CaseMetaModel saved = run(() -> repository.save(meta));
+
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getTitle()).isNull();
+    assertThat(saved.getDsl()).isNull();
+    assertThat(saved.getDefinition()).isNull();
+  }
+
+  @Test
+  void save_handlesLongTitle() {
+    String longTitle = "A".repeat(500); // 500 characters - max allowed by schema
+    CaseMetaModel meta = metaModel("long-title", "ns", "1.0");
+    meta.setTitle(longTitle);
+
+    CaseMetaModel saved = run(() -> repository.save(meta));
+
+    assertThat(saved.getTitle()).isEqualTo(longTitle);
+  }
+
+  @Test
+  void save_handlesLargeDefinition() throws Exception {
+    String largeJson = "{\"key\": \"" + "value".repeat(10000) + "\"}"; // ~50KB
+    com.fasterxml.jackson.databind.JsonNode largeDefinition = OBJECT_MAPPER.readTree(largeJson);
+
+    CaseMetaModel meta = metaModel("large-def", "ns", "1.0");
+    meta.setDefinition(largeDefinition);
+
+    CaseMetaModel saved = run(() -> repository.save(meta));
+
+    CaseMetaModel found = run(() -> repository.findByKey("ns", "large-def", "1.0"));
+    assertThat(found.getDefinition().toString()).isEqualTo(largeDefinition.toString());
+  }
+
+  @Test
+  void save_duplicateKey_fails() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    CaseMetaModel first = metaModel("dup-test-" + unique, "dup-ns", "1.0");
+    run(() -> repository.save(first));
+
+    CaseMetaModel duplicate = metaModel("dup-test-" + unique, "dup-ns", "1.0");
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> run(() -> repository.save(duplicate)))
+        .isInstanceOf(Exception.class);
+  }
+
+  @Test
+  void findByKey_isCaseSensitive_namespace() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    run(() -> repository.save(metaModel("case-test-" + unique, "Namespace", "1.0")));
+
+    CaseMetaModel found =
+        run(() -> repository.findByKey("namespace", "case-test-" + unique, "1.0"));
+
+    assertThat(found).isNull(); // Different case should not match
+  }
+
+  @Test
+  void findByKey_isCaseSensitive_name() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    run(() -> repository.save(metaModel("CaseName-" + unique, "ns", "1.0")));
+
+    CaseMetaModel found = run(() -> repository.findByKey("ns", "casename-" + unique, "1.0"));
+
+    assertThat(found).isNull(); // Different case should not match
+  }
+
+  @Test
+  void findByKey_isCaseSensitive_version() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    run(() -> repository.save(metaModel("version-test-" + unique, "ns", "1.0.0")));
+
+    CaseMetaModel found = run(() -> repository.findByKey("ns", "version-test-" + unique, "1.0.0"));
+
+    assertThat(found).isNotNull(); // Exact match should work
+  }
+
+  @Test
+  void save_allowsSameNameInDifferentNamespaces() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    String sameName = "shared-name-" + unique;
+
+    CaseMetaModel first = metaModel(sameName, "ns1", "1.0");
+    CaseMetaModel second = metaModel(sameName, "ns2", "1.0");
+
+    run(() -> repository.save(first));
+    run(() -> repository.save(second));
+
+    CaseMetaModel foundInNs1 = run(() -> repository.findByKey("ns1", sameName, "1.0"));
+    CaseMetaModel foundInNs2 = run(() -> repository.findByKey("ns2", sameName, "1.0"));
+
+    assertThat(foundInNs1).isNotNull();
+    assertThat(foundInNs2).isNotNull();
+    assertThat(foundInNs1.getId()).isNotEqualTo(foundInNs2.getId());
+  }
+
+  @Test
+  void save_allowsDifferentVersionsOfSameCase() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    String sameName = "versioned-" + unique;
+
+    CaseMetaModel v1 = metaModel(sameName, "ns", "1.0");
+    CaseMetaModel v2 = metaModel(sameName, "ns", "2.0");
+
+    run(() -> repository.save(v1));
+    run(() -> repository.save(v2));
+
+    CaseMetaModel foundV1 = run(() -> repository.findByKey("ns", sameName, "1.0"));
+    CaseMetaModel foundV2 = run(() -> repository.findByKey("ns", sameName, "2.0"));
+
+    assertThat(foundV1).isNotNull();
+    assertThat(foundV2).isNotNull();
+    assertThat(foundV1.getId()).isNotEqualTo(foundV2.getId());
+  }
+
+  @Test
+  void save_concurrent_bothSucceed() throws InterruptedException {
+    int threadCount = 5;
+    java.util.List<CaseMetaModel> savedModels = new java.util.concurrent.CopyOnWriteArrayList<>();
+    java.util.List<Thread> threads = new java.util.ArrayList<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      final int index = i;
+      Thread t =
+          new Thread(
+              () -> {
+                String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+                CaseMetaModel meta = metaModel("concurrent-" + index + "-" + unique, "ns", "1.0");
+                CaseMetaModel saved = run(() -> repository.save(meta));
+                savedModels.add(saved);
+              });
+      threads.add(t);
+      t.start();
+    }
+
+    for (Thread t : threads) {
+      t.join();
+    }
+
+    assertThat(savedModels).hasSize(threadCount);
+    assertThat(savedModels).allMatch(m -> m.getId() != null);
+    // All IDs should be unique
+    assertThat(savedModels.stream().map(CaseMetaModel::getId).distinct().count())
+        .isEqualTo(threadCount);
+  }
+
+  @Test
+  void save_createdAt_isImmutable() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    CaseMetaModel meta = metaModel("immutable-" + unique, "ns", "1.0");
+
+    CaseMetaModel saved = run(() -> repository.save(meta));
+    java.time.Instant originalCreatedAt = saved.getCreatedAt();
+
+    // Reload from database
+    CaseMetaModel reloaded = run(() -> repository.findByKey("ns", "immutable-" + unique, "1.0"));
+
+    assertThat(reloaded.getCreatedAt()).isEqualTo(originalCreatedAt);
+  }
+
+  @Test
+  void findByKey_withSpecialCharactersInName() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    String specialName = "name-with-special_chars.and.dots-" + unique;
+
+    run(() -> repository.save(metaModel(specialName, "ns", "1.0")));
+    CaseMetaModel found = run(() -> repository.findByKey("ns", specialName, "1.0"));
+
+    assertThat(found).isNotNull();
+    assertThat(found.getName()).isEqualTo(specialName);
+  }
+
+  @Test
+  void findByKey_withSemanticVersioning() {
+    String unique = java.util.UUID.randomUUID().toString().substring(0, 8);
+    String name = "semver-" + unique;
+
+    run(() -> repository.save(metaModel(name, "ns", "1.2.3-alpha+build123")));
+    CaseMetaModel found = run(() -> repository.findByKey("ns", name, "1.2.3-alpha+build123"));
+
+    assertThat(found).isNotNull();
+    assertThat(found.getVersion()).isEqualTo("1.2.3-alpha+build123");
   }
 }

--- a/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaEventLogRepositoryTest.java
+++ b/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaEventLogRepositoryTest.java
@@ -27,6 +27,7 @@ import io.quarkus.vertx.VertxContextSupport;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -395,5 +396,164 @@ class JpaEventLogRepositoryTest {
     log.setStreamType(EventStreamType.WORKER);
     log.setTimestamp(Instant.now());
     return log;
+  }
+
+  // ========== Edge Case Tests ==========
+
+  @Test
+  void append_handlesNullPayload() {
+    UUID caseId = UUID.randomUUID();
+    EventLog log = event(caseId, "worker-null-payload", CaseHubEventType.WORKER_SCHEDULED);
+    log.setPayload(null);
+
+    run(() -> repository.append(log));
+
+    assertThat(log.id).isNotNull();
+    assertThat(log.getPayload()).isNull();
+  }
+
+  @Test
+  void append_handlesNullMetadata() {
+    UUID caseId = UUID.randomUUID();
+    EventLog log = event(caseId, "worker-null-meta", CaseHubEventType.WORKER_SCHEDULED);
+    log.setMetadata(null);
+
+    run(() -> repository.append(log));
+
+    assertThat(log.id).isNotNull();
+    assertThat(log.getMetadata()).isNull();
+  }
+
+  @Test
+  void append_handlesLargePayload() {
+    UUID caseId = UUID.randomUUID();
+    EventLog log = event(caseId, "worker-large", CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+
+    // Create a large JSON payload (~100KB)
+    com.fasterxml.jackson.databind.node.ObjectNode largePayload = OBJECT_MAPPER.createObjectNode();
+    for (int i = 0; i < 1000; i++) {
+      largePayload.put("key" + i, "value".repeat(100));
+    }
+    log.setPayload(largePayload);
+
+    run(() -> repository.append(log));
+
+    EventLog found = run(() -> repository.findById(log.id));
+    assertThat(found).isNotNull();
+    assertThat(found.getPayload()).isNotNull();
+    assertThat(found.getPayload().get("key999").asText()).contains("value");
+  }
+
+  @Test
+  void append_concurrent_sequenceMonotonicallyIncreases() {
+    UUID caseId = UUID.randomUUID();
+    int threadCount = 10;
+    List<EventLog> logs = new java.util.concurrent.CopyOnWriteArrayList<>();
+
+    // Create events concurrently
+    List<Thread> threads = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      final int index = i;
+      Thread t =
+          new Thread(
+              () -> {
+                EventLog log =
+                    event(caseId, "worker-concurrent-" + index, CaseHubEventType.WORKER_SCHEDULED);
+                run(() -> repository.append(log));
+                logs.add(log);
+              });
+      threads.add(t);
+      t.start();
+    }
+
+    // Wait for all threads
+    threads.forEach(
+        t -> {
+          try {
+            t.join();
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Verify all sequences are unique and monotonically increasing
+    List<Long> sequences = logs.stream().map(EventLog::getSeq).sorted().toList();
+    assertThat(sequences).hasSize(threadCount);
+    assertThat(sequences).doesNotHaveDuplicates();
+    assertThat(sequences).isSorted();
+  }
+
+  @Test
+  void findByCaseWithFilters_performanceWithManyEvents() {
+    UUID caseId = UUID.randomUUID();
+    int eventCount = 100; // 100 events for reasonable test time
+    String suffix = UUID.randomUUID().toString().substring(0, 8);
+
+    // Insert many events
+    for (int i = 0; i < eventCount; i++) {
+      EventLog log =
+          event(caseId, "worker-perf-" + suffix + "-" + i, CaseHubEventType.WORKER_SCHEDULED);
+      run(() -> repository.append(log));
+    }
+
+    long startTime = System.currentTimeMillis();
+    List<EventLog> result = run(() -> repository.findByCaseWithFilters(caseId, null, null));
+    long duration = System.currentTimeMillis() - startTime;
+
+    assertThat(result).hasSizeGreaterThanOrEqualTo(eventCount);
+    assertThat(result.stream().map(EventLog::getSeq).toList()).isSorted();
+    assertThat(duration).isLessThan(5000); // Should complete in < 5 seconds
+  }
+
+  @Test
+  void append_withNullCaseId_fails() {
+    EventLog log = new EventLog();
+    log.setCaseId(null);
+    log.setWorkerId("worker-null-case");
+    log.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    log.setStreamType(EventStreamType.WORKER);
+    log.setTimestamp(Instant.now());
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> run(() -> repository.append(log)))
+        .isInstanceOf(Exception.class);
+  }
+
+  @Test
+  void append_withNullEventType_fails() {
+    EventLog log = new EventLog();
+    log.setCaseId(UUID.randomUUID());
+    log.setWorkerId("worker-null-type");
+    log.setEventType(null);
+    log.setStreamType(EventStreamType.WORKER);
+    log.setTimestamp(Instant.now());
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> run(() -> repository.append(log)))
+        .isInstanceOf(Exception.class);
+  }
+
+  @Test
+  void append_withNullStreamType_fails() {
+    EventLog log = new EventLog();
+    log.setCaseId(UUID.randomUUID());
+    log.setWorkerId("worker-null-stream");
+    log.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    log.setStreamType(null);
+    log.setTimestamp(Instant.now());
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> run(() -> repository.append(log)))
+        .isInstanceOf(Exception.class);
+  }
+
+  @Test
+  void append_withNullTimestamp_fails() {
+    EventLog log = new EventLog();
+    log.setCaseId(UUID.randomUUID());
+    log.setWorkerId("worker-null-timestamp");
+    log.setEventType(CaseHubEventType.WORKER_SCHEDULED);
+    log.setStreamType(EventStreamType.WORKER);
+    log.setTimestamp(null);
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> run(() -> repository.append(log)))
+        .isInstanceOf(Exception.class);
   }
 }

--- a/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaSubCaseGroupRepositoryTest.java
+++ b/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaSubCaseGroupRepositoryTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.casehub.api.model.OnThresholdReached;
+import io.casehub.engine.internal.model.SubCaseGroup;
+import io.casehub.engine.spi.SubCaseGroupRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.vertx.VertxContextSupport;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class JpaSubCaseGroupRepositoryTest {
+
+  @Inject SubCaseGroupRepository repository;
+
+  @Test
+  void getOrCreate_createsNewGroup() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-create-" + UUID.randomUUID().toString().substring(0, 8);
+
+    SubCaseGroup result =
+        run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.CANCEL));
+
+    assertThat(result).isNotNull();
+    assertThat(result.getParentCaseId()).isEqualTo(parentCaseId);
+    assertThat(result.getGroupId()).isEqualTo(groupId);
+    assertThat(result.getInstanceCount()).isEqualTo(3);
+    assertThat(result.getRequiredCount()).isEqualTo(2);
+    assertThat(result.getCompletedCount()).isZero();
+    assertThat(result.getRejectedCount()).isZero();
+    assertThat(result.isPolicyTriggered()).isFalse();
+    assertThat(result.getOnThresholdReached()).isEqualTo(OnThresholdReached.CANCEL);
+    assertThat(result.getChildCaseIds()).isEmpty();
+  }
+
+  @Test
+  void getOrCreate_returnsExistingGroup() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-existing-" + UUID.randomUUID().toString().substring(0, 8);
+
+    SubCaseGroup first =
+        run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    run(() -> repository.incrementCompleted(parentCaseId, groupId));
+
+    SubCaseGroup second =
+        run(() -> repository.getOrCreate(parentCaseId, groupId, 5, 4, OnThresholdReached.CANCEL));
+
+    // Should return existing group, ignoring new parameters
+    assertThat(second.getParentCaseId()).isEqualTo(parentCaseId);
+    assertThat(second.getGroupId()).isEqualTo(groupId);
+    assertThat(second.getInstanceCount()).isEqualTo(3); // original value, not 5
+    assertThat(second.getRequiredCount()).isEqualTo(2); // original value, not 4
+    assertThat(second.getOnThresholdReached()).isEqualTo(OnThresholdReached.KEEP); // original
+    assertThat(second.getCompletedCount()).isEqualTo(1); // incremented earlier
+  }
+
+  @Test
+  void getOrCreate_setsDefaultOnThresholdReached() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-default-" + UUID.randomUUID().toString().substring(0, 8);
+
+    SubCaseGroup result = run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, null));
+
+    assertThat(result.getOnThresholdReached()).isEqualTo(OnThresholdReached.KEEP);
+  }
+
+  @Test
+  void getOrCreate_allowsDifferentGroupsForSameParent() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId1 = "group-1-" + UUID.randomUUID().toString().substring(0, 8);
+    String groupId2 = "group-2-" + UUID.randomUUID().toString().substring(0, 8);
+
+    SubCaseGroup g1 =
+        run(() -> repository.getOrCreate(parentCaseId, groupId1, 2, 1, OnThresholdReached.KEEP));
+    SubCaseGroup g2 =
+        run(() -> repository.getOrCreate(parentCaseId, groupId2, 3, 2, OnThresholdReached.CANCEL));
+
+    assertThat(g1.getGroupId()).isEqualTo(groupId1);
+    assertThat(g2.getGroupId()).isEqualTo(groupId2);
+    assertThat(g1.getInstanceCount()).isEqualTo(2);
+    assertThat(g2.getInstanceCount()).isEqualTo(3);
+  }
+
+  @Test
+  void getOrCreate_allowsSameGroupIdForDifferentParents() {
+    UUID parentCaseId1 = UUID.randomUUID();
+    UUID parentCaseId2 = UUID.randomUUID();
+    String groupId = "shared-group-" + UUID.randomUUID().toString().substring(0, 8);
+
+    SubCaseGroup g1 =
+        run(() -> repository.getOrCreate(parentCaseId1, groupId, 2, 1, OnThresholdReached.KEEP));
+    SubCaseGroup g2 =
+        run(() -> repository.getOrCreate(parentCaseId2, groupId, 3, 2, OnThresholdReached.CANCEL));
+
+    assertThat(g1.getParentCaseId()).isEqualTo(parentCaseId1);
+    assertThat(g2.getParentCaseId()).isEqualTo(parentCaseId2);
+    assertThat(g1.getInstanceCount()).isEqualTo(2);
+    assertThat(g2.getInstanceCount()).isEqualTo(3);
+  }
+
+  @Test
+  void registerChild_addsChildToGroup() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-child-" + UUID.randomUUID().toString().substring(0, 8);
+    UUID childCaseId = UUID.randomUUID();
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    SubCaseGroup result = run(() -> repository.registerChild(parentCaseId, groupId, childCaseId));
+
+    assertThat(result.getChildCaseIds()).containsExactly(childCaseId);
+  }
+
+  @Test
+  void registerChild_allowsMultipleChildren() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-multi-" + UUID.randomUUID().toString().substring(0, 8);
+    UUID child1 = UUID.randomUUID();
+    UUID child2 = UUID.randomUUID();
+    UUID child3 = UUID.randomUUID();
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    run(() -> repository.registerChild(parentCaseId, groupId, child1));
+    run(() -> repository.registerChild(parentCaseId, groupId, child2));
+    SubCaseGroup result = run(() -> repository.registerChild(parentCaseId, groupId, child3));
+
+    assertThat(result.getChildCaseIds()).containsExactlyInAnyOrder(child1, child2, child3);
+  }
+
+  @Test
+  void registerChild_failsForNonExistentGroup() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "non-existent-" + UUID.randomUUID().toString().substring(0, 8);
+    UUID childCaseId = UUID.randomUUID();
+
+    assertThatThrownBy(
+            () -> run(() -> repository.registerChild(parentCaseId, groupId, childCaseId)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Group not found");
+  }
+
+  @Test
+  void registerChild_idempotent() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-idempotent-" + UUID.randomUUID().toString().substring(0, 8);
+    UUID childCaseId = UUID.randomUUID();
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    run(() -> repository.registerChild(parentCaseId, groupId, childCaseId));
+    SubCaseGroup result = run(() -> repository.registerChild(parentCaseId, groupId, childCaseId));
+
+    assertThat(result.getChildCaseIds()).containsExactly(childCaseId);
+  }
+
+  @Test
+  void incrementCompleted_incrementsCounter() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-increment-" + UUID.randomUUID().toString().substring(0, 8);
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    SubCaseGroup result = run(() -> repository.incrementCompleted(parentCaseId, groupId));
+
+    assertThat(result.getCompletedCount()).isEqualTo(1);
+  }
+
+  @Test
+  void incrementCompleted_allowsMultipleIncrements() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-multi-inc-" + UUID.randomUUID().toString().substring(0, 8);
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 5, 3, OnThresholdReached.KEEP));
+    run(() -> repository.incrementCompleted(parentCaseId, groupId));
+    run(() -> repository.incrementCompleted(parentCaseId, groupId));
+    SubCaseGroup result = run(() -> repository.incrementCompleted(parentCaseId, groupId));
+
+    assertThat(result.getCompletedCount()).isEqualTo(3);
+  }
+
+  @Test
+  void incrementCompleted_failsForNonExistentGroup() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "non-existent-" + UUID.randomUUID().toString().substring(0, 8);
+
+    assertThatThrownBy(() -> run(() -> repository.incrementCompleted(parentCaseId, groupId)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Group not found");
+  }
+
+  @Test
+  void incrementRejected_incrementsCounter() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-reject-" + UUID.randomUUID().toString().substring(0, 8);
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    SubCaseGroup result = run(() -> repository.incrementRejected(parentCaseId, groupId));
+
+    assertThat(result.getRejectedCount()).isEqualTo(1);
+  }
+
+  @Test
+  void incrementRejected_allowsMultipleIncrements() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-multi-reject-" + UUID.randomUUID().toString().substring(0, 8);
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 5, 3, OnThresholdReached.KEEP));
+    run(() -> repository.incrementRejected(parentCaseId, groupId));
+    SubCaseGroup result = run(() -> repository.incrementRejected(parentCaseId, groupId));
+
+    assertThat(result.getRejectedCount()).isEqualTo(2);
+  }
+
+  @Test
+  void incrementRejected_failsForNonExistentGroup() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "non-existent-" + UUID.randomUUID().toString().substring(0, 8);
+
+    assertThatThrownBy(() -> run(() -> repository.incrementRejected(parentCaseId, groupId)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Group not found");
+  }
+
+  @Test
+  void incrementCompleted_and_incrementRejected_independent() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-independent-" + UUID.randomUUID().toString().substring(0, 8);
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 5, 3, OnThresholdReached.KEEP));
+    run(() -> repository.incrementCompleted(parentCaseId, groupId));
+    run(() -> repository.incrementRejected(parentCaseId, groupId));
+    run(() -> repository.incrementCompleted(parentCaseId, groupId));
+    SubCaseGroup result = run(() -> repository.incrementRejected(parentCaseId, groupId));
+
+    assertThat(result.getCompletedCount()).isEqualTo(2);
+    assertThat(result.getRejectedCount()).isEqualTo(2);
+  }
+
+  @Test
+  void markPolicyTriggered_returnsTrueFirstTime() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-policy-" + UUID.randomUUID().toString().substring(0, 8);
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    Boolean result = run(() -> repository.markPolicyTriggered(parentCaseId, groupId));
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void markPolicyTriggered_returnsFalseSecondTime() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-policy-idempotent-" + UUID.randomUUID().toString().substring(0, 8);
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    run(() -> repository.markPolicyTriggered(parentCaseId, groupId));
+    Boolean secondCall = run(() -> repository.markPolicyTriggered(parentCaseId, groupId));
+
+    assertThat(secondCall).isFalse();
+  }
+
+  @Test
+  void markPolicyTriggered_returnsFalseForNonExistentGroup() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "non-existent-" + UUID.randomUUID().toString().substring(0, 8);
+
+    Boolean result = run(() -> repository.markPolicyTriggered(parentCaseId, groupId));
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void markPolicyTriggered_persistsFlag() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-policy-persist-" + UUID.randomUUID().toString().substring(0, 8);
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    run(() -> repository.markPolicyTriggered(parentCaseId, groupId));
+
+    // Verify by incrementing - should see policyTriggered=true
+    SubCaseGroup result = run(() -> repository.incrementCompleted(parentCaseId, groupId));
+    assertThat(result.isPolicyTriggered()).isTrue();
+  }
+
+  @Test
+  void findByChildCaseId_returnsGroup() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-find-" + UUID.randomUUID().toString().substring(0, 8);
+    UUID childCaseId = UUID.randomUUID();
+
+    run(() -> repository.getOrCreate(parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    run(() -> repository.registerChild(parentCaseId, groupId, childCaseId));
+
+    Optional<SubCaseGroup> result = run(() -> repository.findByChildCaseId(childCaseId));
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getParentCaseId()).isEqualTo(parentCaseId);
+    assertThat(result.get().getGroupId()).isEqualTo(groupId);
+    assertThat(result.get().getChildCaseIds()).contains(childCaseId);
+  }
+
+  @Test
+  void findByChildCaseId_returnsEmptyForUnknownChild() {
+    UUID unknownChildCaseId = UUID.randomUUID();
+
+    Optional<SubCaseGroup> result = run(() -> repository.findByChildCaseId(unknownChildCaseId));
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findByChildCaseId_returnsFirstGroupWhenChildInMultipleGroups() {
+    // Edge case: if a child is registered in multiple groups (should not happen, but testing)
+    UUID parentCaseId1 = UUID.randomUUID();
+    UUID parentCaseId2 = UUID.randomUUID();
+    String groupId1 = "group-multi-1-" + UUID.randomUUID().toString().substring(0, 8);
+    String groupId2 = "group-multi-2-" + UUID.randomUUID().toString().substring(0, 8);
+    UUID sharedChildCaseId = UUID.randomUUID();
+
+    run(() -> repository.getOrCreate(parentCaseId1, groupId1, 3, 2, OnThresholdReached.KEEP));
+    run(() -> repository.getOrCreate(parentCaseId2, groupId2, 3, 2, OnThresholdReached.KEEP));
+    run(() -> repository.registerChild(parentCaseId1, groupId1, sharedChildCaseId));
+    run(() -> repository.registerChild(parentCaseId2, groupId2, sharedChildCaseId));
+
+    Optional<SubCaseGroup> result = run(() -> repository.findByChildCaseId(sharedChildCaseId));
+
+    // Should return one of the groups (implementation returns first match)
+    assertThat(result).isPresent();
+    assertThat(result.get().getChildCaseIds()).contains(sharedChildCaseId);
+  }
+
+  @Test
+  void roundTrip_createRegisterIncrementFind() {
+    UUID parentCaseId = UUID.randomUUID();
+    String groupId = "group-roundtrip-" + UUID.randomUUID().toString().substring(0, 8);
+    UUID child1 = UUID.randomUUID();
+    UUID child2 = UUID.randomUUID();
+
+    // Create
+    SubCaseGroup created =
+        run(() -> repository.getOrCreate(parentCaseId, groupId, 5, 3, OnThresholdReached.CANCEL));
+    assertThat(created.getInstanceCount()).isEqualTo(5);
+    assertThat(created.getRequiredCount()).isEqualTo(3);
+
+    // Register children
+    run(() -> repository.registerChild(parentCaseId, groupId, child1));
+    run(() -> repository.registerChild(parentCaseId, groupId, child2));
+
+    // Increment counters
+    run(() -> repository.incrementCompleted(parentCaseId, groupId));
+    run(() -> repository.incrementRejected(parentCaseId, groupId));
+
+    // Mark policy
+    Boolean policyResult = run(() -> repository.markPolicyTriggered(parentCaseId, groupId));
+    assertThat(policyResult).isTrue();
+
+    // Find by child
+    Optional<SubCaseGroup> found = run(() -> repository.findByChildCaseId(child1));
+    assertThat(found).isPresent();
+    assertThat(found.get().getParentCaseId()).isEqualTo(parentCaseId);
+    assertThat(found.get().getGroupId()).isEqualTo(groupId);
+    assertThat(found.get().getChildCaseIds()).containsExactlyInAnyOrder(child1, child2);
+    assertThat(found.get().getCompletedCount()).isEqualTo(1);
+    assertThat(found.get().getRejectedCount()).isEqualTo(1);
+    assertThat(found.get().isPolicyTriggered()).isTrue();
+    assertThat(found.get().getOnThresholdReached()).isEqualTo(OnThresholdReached.CANCEL);
+  }
+
+  private <T> T run(Supplier<Uni<T>> supplier) {
+    try {
+      return VertxContextSupport.subscribeAndAwait(supplier);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/PersistenceIntegrationTest.java
+++ b/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/PersistenceIntegrationTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.OnThresholdReached;
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.casehub.engine.internal.model.CaseMetaModel;
+import io.casehub.engine.internal.model.SubCaseGroup;
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.casehub.engine.spi.CaseMetaModelRepository;
+import io.casehub.engine.spi.EventLogRepository;
+import io.casehub.engine.spi.SubCaseGroupRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.vertx.VertxContextSupport;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class PersistenceIntegrationTest {
+
+  @Inject CaseInstanceRepository instanceRepository;
+  @Inject CaseMetaModelRepository metaModelRepository;
+  @Inject EventLogRepository eventLogRepository;
+  @Inject SubCaseGroupRepository subCaseGroupRepository;
+
+  private CaseMetaModel savedMeta;
+  private UUID parentCaseId;
+
+  @BeforeEach
+  void setUp() {
+    String unique = UUID.randomUUID().toString().substring(0, 8);
+    CaseMetaModel meta = new CaseMetaModel();
+    meta.setName("integration-test-" + unique);
+    meta.setNamespace("test-ns");
+    meta.setVersion("1.0");
+    savedMeta = run(() -> metaModelRepository.save(meta));
+    parentCaseId = UUID.randomUUID();
+  }
+
+  private <T> T run(Supplier<Uni<T>> supplier) {
+    try {
+      return VertxContextSupport.subscribeAndAwait(supplier);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // ========== CaseInstance + EventLog Integration ==========
+
+  @Test
+  void updateStateAndAppendEvent_atomicallyUpdatesInstanceAndCreatesEvent() {
+    CaseInstance instance = newInstance(CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(instance));
+
+    instance.setState(CaseStatus.COMPLETED);
+    EventLog eventLog = newEventLog(instance.getUuid(), CaseHubEventType.CASE_COMPLETED);
+
+    run(() -> instanceRepository.updateStateAndAppendEvent(instance, eventLog));
+
+    // Verify instance state updated
+    CaseInstance reloaded = run(() -> instanceRepository.findByUuid(instance.getUuid()));
+    assertThat(reloaded.getState()).isEqualTo(CaseStatus.COMPLETED);
+
+    // Verify event created
+    assertThat(eventLog.id).isNotNull();
+    assertThat(eventLog.getSeq()).isNotNull();
+
+    EventLog foundEvent = run(() -> eventLogRepository.findById(eventLog.id));
+    assertThat(foundEvent).isNotNull();
+    assertThat(foundEvent.getEventType()).isEqualTo(CaseHubEventType.CASE_COMPLETED);
+    assertThat(foundEvent.getCaseId()).isEqualTo(instance.getUuid());
+  }
+
+  @Test
+  void updateStateAndAppendEvent_multipleEvents_sequencesAreOrdered() {
+    CaseInstance instance = newInstance(CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(instance));
+
+    // Append 3 events
+    EventLog event1 = newEventLog(instance.getUuid(), CaseHubEventType.CASE_STARTED);
+    instance.setState(CaseStatus.RUNNING);
+    run(() -> instanceRepository.updateStateAndAppendEvent(instance, event1));
+
+    EventLog event2 = newEventLog(instance.getUuid(), CaseHubEventType.CASE_STATUS_CHANGED);
+    instance.setState(CaseStatus.SUSPENDED);
+    run(() -> instanceRepository.updateStateAndAppendEvent(instance, event2));
+
+    EventLog event3 = newEventLog(instance.getUuid(), CaseHubEventType.CASE_COMPLETED);
+    instance.setState(CaseStatus.COMPLETED);
+    run(() -> instanceRepository.updateStateAndAppendEvent(instance, event3));
+
+    // Verify sequences are strictly increasing
+    assertThat(event1.getSeq()).isNotNull();
+    assertThat(event2.getSeq()).isNotNull();
+    assertThat(event3.getSeq()).isNotNull();
+    assertThat(event1.getSeq()).isLessThan(event2.getSeq());
+    assertThat(event2.getSeq()).isLessThan(event3.getSeq());
+
+    // Verify all events persisted
+    List<EventLog> events =
+        run(() -> eventLogRepository.findByCaseWithFilters(instance.getUuid(), null, null));
+    assertThat(events).hasSize(3);
+    assertThat(events.stream().map(EventLog::getSeq))
+        .containsExactly(event1.getSeq(), event2.getSeq(), event3.getSeq());
+  }
+
+  // ========== CaseInstance + CaseMetaModel Integration ==========
+
+  @Test
+  void caseInstance_loadsMetaModel() {
+    CaseInstance instance = newInstance(CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(instance));
+
+    CaseInstance found = run(() -> instanceRepository.findByUuid(instance.getUuid()));
+
+    assertThat(found.getCaseMetaModel()).isNotNull();
+    assertThat(found.getCaseMetaModel().getId()).isEqualTo(savedMeta.getId());
+    assertThat(found.getCaseMetaModel().getName()).isEqualTo(savedMeta.getName());
+    assertThat(found.getCaseMetaModel().getNamespace()).isEqualTo(savedMeta.getNamespace());
+  }
+
+  // ========== SubCaseGroup + CaseInstance Integration ==========
+
+  @Test
+  void subCaseGroup_registerChild_childCaseExists() {
+    CaseInstance childInstance = newInstance(CaseStatus.RUNNING);
+    childInstance.setParentCaseId(parentCaseId);
+    run(() -> instanceRepository.save(childInstance));
+
+    String groupId = "group-1";
+    run(
+        () ->
+            subCaseGroupRepository.getOrCreate(
+                parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+
+    SubCaseGroup group =
+        run(
+            () ->
+                subCaseGroupRepository.registerChild(
+                    parentCaseId, groupId, childInstance.getUuid()));
+
+    assertThat(group.getChildCaseIds()).containsExactly(childInstance.getUuid());
+
+    // Verify child can be found by its UUID
+    CaseInstance foundChild = run(() -> instanceRepository.findByUuid(childInstance.getUuid()));
+    assertThat(foundChild).isNotNull();
+    assertThat(foundChild.getParentCaseId()).isEqualTo(parentCaseId);
+  }
+
+  @Test
+  void subCaseGroup_findByChildCaseId_returnsCorrectGroup() {
+    UUID childCaseId = UUID.randomUUID();
+    String groupId = "group-1";
+
+    SubCaseGroup group =
+        run(
+            () ->
+                subCaseGroupRepository.getOrCreate(
+                    parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+    run(() -> subCaseGroupRepository.registerChild(parentCaseId, groupId, childCaseId));
+
+    var foundGroup = run(() -> subCaseGroupRepository.findByChildCaseId(childCaseId));
+
+    assertThat(foundGroup).isPresent();
+    assertThat(foundGroup.get().getGroupId()).isEqualTo(groupId);
+    assertThat(foundGroup.get().getParentCaseId()).isEqualTo(parentCaseId);
+    assertThat(foundGroup.get().getChildCaseIds()).containsExactly(childCaseId);
+  }
+
+  @Test
+  void subCaseGroup_multipleChildren_allRegistered() {
+    String groupId = "group-1";
+    run(
+        () ->
+            subCaseGroupRepository.getOrCreate(
+                parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+
+    UUID child1 = UUID.randomUUID();
+    UUID child2 = UUID.randomUUID();
+    UUID child3 = UUID.randomUUID();
+
+    run(() -> subCaseGroupRepository.registerChild(parentCaseId, groupId, child1));
+    run(() -> subCaseGroupRepository.registerChild(parentCaseId, groupId, child2));
+    SubCaseGroup group =
+        run(() -> subCaseGroupRepository.registerChild(parentCaseId, groupId, child3));
+
+    assertThat(group.getChildCaseIds()).containsExactlyInAnyOrder(child1, child2, child3);
+  }
+
+  @Test
+  void subCaseGroup_incrementCompleted_reflectsInGroup() {
+    String groupId = "group-1";
+    run(
+        () ->
+            subCaseGroupRepository.getOrCreate(
+                parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+
+    SubCaseGroup group =
+        run(() -> subCaseGroupRepository.incrementCompleted(parentCaseId, groupId));
+    assertThat(group.getCompletedCount()).isEqualTo(1);
+
+    group = run(() -> subCaseGroupRepository.incrementCompleted(parentCaseId, groupId));
+    assertThat(group.getCompletedCount()).isEqualTo(2);
+  }
+
+  @Test
+  void subCaseGroup_incrementRejected_reflectsInGroup() {
+    String groupId = "group-1";
+    run(
+        () ->
+            subCaseGroupRepository.getOrCreate(
+                parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+
+    SubCaseGroup group = run(() -> subCaseGroupRepository.incrementRejected(parentCaseId, groupId));
+    assertThat(group.getRejectedCount()).isEqualTo(1);
+  }
+
+  @Test
+  void subCaseGroup_markPolicyTriggered_canOnlyTriggerOnce() {
+    String groupId = "group-1";
+    run(
+        () ->
+            subCaseGroupRepository.getOrCreate(
+                parentCaseId, groupId, 3, 2, OnThresholdReached.KEEP));
+
+    boolean firstMark =
+        run(() -> subCaseGroupRepository.markPolicyTriggered(parentCaseId, groupId));
+    assertThat(firstMark).isTrue();
+
+    boolean secondMark =
+        run(() -> subCaseGroupRepository.markPolicyTriggered(parentCaseId, groupId));
+    assertThat(secondMark).isFalse();
+  }
+
+  // ========== Cross-Repository Consistency ==========
+
+  @Test
+  void fullCaseLifecycle_parentAndChildCases_withEventsAndGroups() {
+    // Create parent case
+    CaseInstance parentInstance = newInstance(CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(parentInstance));
+
+    // Append event to parent
+    EventLog parentEvent = newEventLog(parentInstance.getUuid(), CaseHubEventType.CASE_STARTED);
+    run(() -> instanceRepository.updateStateAndAppendEvent(parentInstance, parentEvent));
+
+    // Create SubCaseGroup
+    String groupId = "child-group";
+    run(
+        () ->
+            subCaseGroupRepository.getOrCreate(
+                parentInstance.getUuid(), groupId, 2, 2, OnThresholdReached.CANCEL));
+
+    // Create child cases
+    CaseInstance child1 = newInstance(CaseStatus.RUNNING);
+    child1.setParentCaseId(parentInstance.getUuid());
+    run(() -> instanceRepository.save(child1));
+    run(
+        () ->
+            subCaseGroupRepository.registerChild(
+                parentInstance.getUuid(), groupId, child1.getUuid()));
+
+    CaseInstance child2 = newInstance(CaseStatus.RUNNING);
+    child2.setParentCaseId(parentInstance.getUuid());
+    run(() -> instanceRepository.save(child2));
+    run(
+        () ->
+            subCaseGroupRepository.registerChild(
+                parentInstance.getUuid(), groupId, child2.getUuid()));
+
+    // Complete child1
+    child1.setState(CaseStatus.COMPLETED);
+    EventLog child1Event = newEventLog(child1.getUuid(), CaseHubEventType.CASE_COMPLETED);
+    run(() -> instanceRepository.updateStateAndAppendEvent(child1, child1Event));
+    run(() -> subCaseGroupRepository.incrementCompleted(parentInstance.getUuid(), groupId));
+
+    // Complete child2
+    child2.setState(CaseStatus.COMPLETED);
+    EventLog child2Event = newEventLog(child2.getUuid(), CaseHubEventType.CASE_COMPLETED);
+    run(() -> instanceRepository.updateStateAndAppendEvent(child2, child2Event));
+    SubCaseGroup group =
+        run(() -> subCaseGroupRepository.incrementCompleted(parentInstance.getUuid(), groupId));
+
+    // Verify final state
+    assertThat(group.getCompletedCount()).isEqualTo(2);
+    assertThat(group.getChildCaseIds())
+        .containsExactlyInAnyOrder(child1.getUuid(), child2.getUuid());
+
+    CaseInstance foundParent = run(() -> instanceRepository.findByUuid(parentInstance.getUuid()));
+    assertThat(foundParent.getState()).isEqualTo(CaseStatus.RUNNING);
+
+    CaseInstance foundChild1 = run(() -> instanceRepository.findByUuid(child1.getUuid()));
+    assertThat(foundChild1.getState()).isEqualTo(CaseStatus.COMPLETED);
+    assertThat(foundChild1.getParentCaseId()).isEqualTo(parentInstance.getUuid());
+
+    List<EventLog> allEvents =
+        run(() -> eventLogRepository.findByCaseWithFilters(child1.getUuid(), null, null));
+    assertThat(allEvents).hasSize(1);
+    assertThat(allEvents.get(0).getEventType()).isEqualTo(CaseHubEventType.CASE_COMPLETED);
+  }
+
+  // ========== Event Log Stream Ordering ==========
+
+  @Test
+  void eventLog_multipleCases_sequencesAreGloballyUnique() {
+    CaseInstance instance1 = newInstance(CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(instance1));
+
+    CaseInstance instance2 = newInstance(CaseStatus.RUNNING);
+    run(() -> instanceRepository.save(instance2));
+
+    EventLog event1 = newEventLog(instance1.getUuid(), CaseHubEventType.CASE_STARTED);
+    instance1.setState(CaseStatus.RUNNING);
+    run(() -> instanceRepository.updateStateAndAppendEvent(instance1, event1));
+
+    EventLog event2 = newEventLog(instance2.getUuid(), CaseHubEventType.CASE_STARTED);
+    instance2.setState(CaseStatus.RUNNING);
+    run(() -> instanceRepository.updateStateAndAppendEvent(instance2, event2));
+
+    EventLog event3 = newEventLog(instance1.getUuid(), CaseHubEventType.CASE_COMPLETED);
+    instance1.setState(CaseStatus.COMPLETED);
+    run(() -> instanceRepository.updateStateAndAppendEvent(instance1, event3));
+
+    // All sequences should be unique across cases
+    assertThat(event1.getSeq()).isNotEqualTo(event2.getSeq());
+    assertThat(event1.getSeq()).isNotEqualTo(event3.getSeq());
+    assertThat(event2.getSeq()).isNotEqualTo(event3.getSeq());
+
+    // Sequences should be strictly increasing globally
+    List<Long> allSeqs = List.of(event1.getSeq(), event2.getSeq(), event3.getSeq());
+    assertThat(allSeqs).doesNotHaveDuplicates();
+  }
+
+  // ========== Helper Methods ==========
+
+  private CaseInstance newInstance(CaseStatus status) {
+    CaseInstance instance = new CaseInstance();
+    instance.setUuid(UUID.randomUUID());
+    instance.setState(status);
+    instance.setCaseMetaModel(savedMeta);
+    return instance;
+  }
+
+  private EventLog newEventLog(UUID caseId, CaseHubEventType eventType) {
+    EventLog log = new EventLog();
+    log.setCaseId(caseId);
+    log.setEventType(eventType);
+    log.setStreamType(EventStreamType.CASE);
+    log.setTimestamp(Instant.now().truncatedTo(ChronoUnit.MICROS));
+    return log;
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java
@@ -140,6 +140,7 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
                     EnumSet.of(
                         CaseHubEventType.CASE_STARTED,
                         CaseHubEventType.WORKER_EXECUTION_COMPLETED,
+                        CaseHubEventType.SUBCASE_COMPLETED,
                         CaseHubEventType.SIGNAL_RECEIVED,
                         CaseHubEventType.MILESTONE_ACTIVATED,
                         CaseHubEventType.MILESTONE_COMPLETED,
@@ -166,7 +167,8 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
                   if (patch != null) {
                     caseContext.applyDiff(patch);
                   }
-                } else if (eventLog.getEventType() == CaseHubEventType.WORKER_EXECUTION_COMPLETED) {
+                } else if (eventLog.getEventType() == CaseHubEventType.WORKER_EXECUTION_COMPLETED
+                    || eventLog.getEventType() == CaseHubEventType.SUBCASE_COMPLETED) {
                   caseContext.setAll(payloadAsMap(eventLog.getPayload()));
                 } else if (eventLog.getEventType() == CaseHubEventType.MILESTONE_ACTIVATED) {
                   applyMilestoneActivatedEvent(caseContext, eventLog);

--- a/runtime/src/test/java/io/casehub/engine/SubCaseOutputMappingRecoveryTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SubCaseOutputMappingRecoveryTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import io.casehub.engine.internal.history.EventLog;
+import io.casehub.engine.internal.model.CaseInstance;
+import io.casehub.engine.internal.model.CaseMetaModel;
+import io.casehub.engine.spi.CaseInstanceRepository;
+import io.casehub.engine.spi.CaseMetaModelRepository;
+import io.casehub.engine.spi.EventLogRepository;
+import io.casehub.engine.spi.cache.CaseInstanceCache;
+import io.casehub.engine.spi.recovery.WorkerExecutionRecoveryService;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.vertx.VertxContextSupport;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for SubCase outputMapping recovery after JVM restart.
+ *
+ * <p>CRITICAL BUG: SubCase outputMapping data is lost after restart because:
+ *
+ * <ul>
+ *   <li>SUBCASE_COMPLETED events are written WITHOUT payload containing applied data
+ *   <li>DefaultWorkerExecutionRecoveryService.rebuildStateContext() does NOT process
+ *       SUBCASE_COMPLETED events
+ * </ul>
+ *
+ * <p>This test demonstrates the bug by simulating the exact sequence that happens in production.
+ *
+ * <p>Related issues: #13, #10, #12
+ */
+@QuarkusTest
+public class SubCaseOutputMappingRecoveryTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Inject CaseInstanceRepository instanceRepository;
+  @Inject CaseMetaModelRepository metaModelRepository;
+  @Inject EventLogRepository eventLogRepository;
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject WorkerExecutionRecoveryService recoveryService;
+
+  private CaseMetaModel savedMeta;
+
+  @BeforeEach
+  void setUp() {
+    String unique = UUID.randomUUID().toString().substring(0, 8);
+    CaseMetaModel meta = new CaseMetaModel();
+    meta.setName("recovery-test-" + unique);
+    meta.setNamespace("test-ns");
+    meta.setVersion("1.0");
+    savedMeta = run(() -> metaModelRepository.save(meta));
+  }
+
+  /**
+   * Demonstrates the bug: SubCase outputMapping data is lost after restart.
+   *
+   * <p>Steps:
+   *
+   * <ol>
+   *   <li>Create parent case with initial context: { orderId: "ORDER-1" }
+   *   <li>Create child case with result data
+   *   <li>Write SUBCASE_STARTED EventLog to parent
+   *   <li>Apply outputMapping to parent context IN MEMORY (as SubCaseCompletionListener does)
+   *   <li>Write SUBCASE_COMPLETED EventLog WITHOUT payload (current buggy implementation)
+   *   <li>Clear cache (simulates JVM restart)
+   *   <li>Load parent via recoveryService
+   *   <li>BUG: outputMapping data is LOST
+   * </ol>
+   */
+  @Test
+  void subCaseOutputMapping_lostAfterRestart() {
+    // 1. Create parent case
+    final UUID parentId = createParentCase("ORDER-1");
+
+    // 2. Create child case
+    final UUID childId = createChildCase(parentId, "approved", Map.of("key", "value", "score", 95));
+
+    // 3. Write SUBCASE_STARTED event
+    String outputMapping = "{ approval: .result, data: .processedData }";
+    writeSubCaseStartedEvent(parentId, childId, outputMapping);
+
+    // 4. Apply outputMapping to parent IN MEMORY (simulating SubCaseCompletionListener)
+    CaseInstance child = caseInstanceCache.get(childId);
+    CaseInstance parent = caseInstanceCache.get(parentId);
+    Map<String, Object> mappedData = child.getCaseContext().evalObjectTemplate(outputMapping);
+    mappedData.forEach((k, v) -> parent.getCaseContext().set(k, v));
+
+    // Verify data was applied in memory
+    assertThat(parent.getCaseContext().get("approval")).isEqualTo("approved");
+    assertThat(parent.getCaseContext().get("data")).isNotNull();
+
+    // 5. Write SUBCASE_COMPLETED WITHOUT payload (BUG!)
+    writeSubCaseCompletedEvent(parentId, childId, null);
+
+    // 6. Clear cache (simulates JVM restart)
+    caseInstanceCache.clear();
+
+    // 7. Restore parent via recovery service
+    CaseInstance restored = run(() -> recoveryService.loadOrRestoreCaseInstance(parentId));
+
+    // 8. BUG: outputMapping data is LOST!
+    assertThat(restored.getCaseContext().get("orderId")).isEqualTo("ORDER-1");
+
+    assertThat(restored.getCaseContext().get("approval"))
+        .as("approval should be 'approved' from SubCase outputMapping")
+        .isEqualTo("approved"); // ← FAILS when bug exists: data lost!
+
+    assertThat(restored.getCaseContext().get("data"))
+        .as("data should be present from SubCase outputMapping")
+        .isNotNull(); // ← FAILS when bug exists: data lost!
+  }
+
+  /**
+   * Demonstrates that regular worker output IS preserved (for comparison).
+   *
+   * <p>WORKER_EXECUTION_COMPLETED events correctly save output in payload.
+   */
+  @Test
+  void regularWorkerOutput_preservedAfterRestart_forComparison() {
+    final UUID caseId = createParentCase("ORDER-2");
+
+    // Write WORKER_EXECUTION_COMPLETED with payload (CORRECT implementation)
+    EventLog workerEvent = new EventLog();
+    workerEvent.setCaseId(caseId);
+    workerEvent.setWorkerId("test-worker");
+    workerEvent.setEventType(CaseHubEventType.WORKER_EXECUTION_COMPLETED);
+    workerEvent.setStreamType(EventStreamType.CASE);
+    workerEvent.setTimestamp(Instant.now());
+    // ✓ CORRECT: payload contains output data
+    workerEvent.setPayload(
+        OBJECT_MAPPER.valueToTree(Map.of("processed", true, "result", "success")));
+    run(() -> eventLogRepository.append(workerEvent));
+
+    // Clear cache and restore
+    caseInstanceCache.clear();
+    CaseInstance restored = run(() -> recoveryService.loadOrRestoreCaseInstance(caseId));
+
+    // ✓ WORKS: worker output is preserved!
+    assertThat(restored.getCaseContext().get("orderId")).isEqualTo("ORDER-2");
+    assertThat(restored.getCaseContext().get("processed")).isEqualTo(true);
+    assertThat(restored.getCaseContext().get("result")).isEqualTo("success");
+  }
+
+  // ========== Helper Methods ==========
+
+  private <T> T run(Supplier<Uni<T>> supplier) {
+    try {
+      return VertxContextSupport.subscribeAndAwait(supplier);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private UUID createParentCase(String orderId) {
+    CaseInstance parent = newInstance(CaseStatus.RUNNING);
+    parent.getCaseContext().set("orderId", orderId);
+    CaseInstance savedParent = run(() -> instanceRepository.save(parent));
+
+    // Write CASE_STARTED event (needed for recovery)
+    EventLog caseStarted = new EventLog();
+    caseStarted.setCaseId(savedParent.getUuid());
+    caseStarted.setEventType(CaseHubEventType.CASE_STARTED);
+    caseStarted.setStreamType(EventStreamType.CASE);
+    caseStarted.setTimestamp(Instant.now());
+    caseStarted.setPayload(OBJECT_MAPPER.valueToTree(Map.of("orderId", orderId)));
+    run(() -> eventLogRepository.append(caseStarted));
+
+    caseInstanceCache.put(savedParent);
+    return savedParent.getUuid();
+  }
+
+  private UUID createChildCase(UUID parentId, String result, Map<String, Object> processedData) {
+    UUID childId = UUID.randomUUID();
+    CaseInstance child = newInstance(CaseStatus.COMPLETED);
+    child.setUuid(childId);
+    child.setParentCaseId(parentId);
+    child.getCaseContext().set("result", result);
+    child.getCaseContext().set("processedData", processedData);
+    run(() -> instanceRepository.save(child));
+    caseInstanceCache.put(child);
+    return childId;
+  }
+
+  private void writeSubCaseStartedEvent(UUID parentId, UUID childId, String outputMapping) {
+    EventLog event = new EventLog();
+    event.setCaseId(parentId);
+    event.setWorkerId(childId.toString());
+    event.setEventType(CaseHubEventType.SUBCASE_STARTED);
+    event.setStreamType(EventStreamType.CASE);
+    event.setTimestamp(Instant.now());
+    ObjectNode metadata = OBJECT_MAPPER.createObjectNode();
+    metadata.put("childCaseId", childId.toString());
+    metadata.put("outputMapping", outputMapping);
+    metadata.put("waitForCompletion", true);
+    event.setMetadata(metadata);
+    run(() -> eventLogRepository.append(event));
+  }
+
+  private void writeSubCaseCompletedEvent(
+      UUID parentId, UUID childId, Map<String, Object> appliedData) {
+    EventLog event = new EventLog();
+    event.setCaseId(parentId);
+    event.setWorkerId(childId.toString());
+    event.setEventType(CaseHubEventType.SUBCASE_COMPLETED);
+    event.setStreamType(EventStreamType.CASE);
+    event.setTimestamp(Instant.now());
+    ObjectNode metadata = OBJECT_MAPPER.createObjectNode();
+    metadata.put("childCaseId", childId.toString());
+    event.setMetadata(metadata);
+    // BUG: NO payload with applied data!
+    // This is what current implementation does (incorrectly)
+    if (appliedData != null) {
+      event.setPayload(OBJECT_MAPPER.valueToTree(appliedData));
+    }
+    run(() -> eventLogRepository.append(event));
+  }
+
+  private CaseInstance newInstance(CaseStatus status) {
+    CaseInstance instance = new CaseInstance();
+    instance.setUuid(UUID.randomUUID());
+    instance.setState(status);
+    instance.setCaseMetaModel(savedMeta);
+    instance.setCaseContext(new io.casehub.engine.internal.context.CaseContextImpl());
+    return instance;
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/SubCaseOutputMappingRecoveryTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SubCaseOutputMappingRecoveryTest.java
@@ -80,7 +80,7 @@ public class SubCaseOutputMappingRecoveryTest {
   }
 
   /**
-   * Demonstrates the bug: SubCase outputMapping data is lost after restart.
+   * Verifies that SubCase outputMapping data is preserved after restart.
    *
    * <p>Steps:
    *
@@ -89,14 +89,14 @@ public class SubCaseOutputMappingRecoveryTest {
    *   <li>Create child case with result data
    *   <li>Write SUBCASE_STARTED EventLog to parent
    *   <li>Apply outputMapping to parent context IN MEMORY (as SubCaseCompletionListener does)
-   *   <li>Write SUBCASE_COMPLETED EventLog WITHOUT payload (current buggy implementation)
+   *   <li>Write SUBCASE_COMPLETED EventLog WITH payload containing applied data
    *   <li>Clear cache (simulates JVM restart)
    *   <li>Load parent via recoveryService
-   *   <li>BUG: outputMapping data is LOST
+   *   <li>Verify: outputMapping data is correctly restored from SUBCASE_COMPLETED payload
    * </ol>
    */
   @Test
-  void subCaseOutputMapping_lostAfterRestart() {
+  void subCaseOutputMapping_preservedAfterRestart() {
     // 1. Create parent case
     final UUID parentId = createParentCase("ORDER-1");
 
@@ -117,8 +117,8 @@ public class SubCaseOutputMappingRecoveryTest {
     assertThat(parent.getCaseContext().get("approval")).isEqualTo("approved");
     assertThat(parent.getCaseContext().get("data")).isNotNull();
 
-    // 5. Write SUBCASE_COMPLETED WITHOUT payload (BUG!)
-    writeSubCaseCompletedEvent(parentId, childId, null);
+    // 5. Write SUBCASE_COMPLETED WITH payload (FIXED - now includes applied data)
+    writeSubCaseCompletedEvent(parentId, childId, mappedData);
 
     // 6. Clear cache (simulates JVM restart)
     caseInstanceCache.clear();
@@ -126,16 +126,16 @@ public class SubCaseOutputMappingRecoveryTest {
     // 7. Restore parent via recovery service
     CaseInstance restored = run(() -> recoveryService.loadOrRestoreCaseInstance(parentId));
 
-    // 8. BUG: outputMapping data is LOST!
+    // 8. Verify: outputMapping data is correctly restored!
     assertThat(restored.getCaseContext().get("orderId")).isEqualTo("ORDER-1");
 
     assertThat(restored.getCaseContext().get("approval"))
         .as("approval should be 'approved' from SubCase outputMapping")
-        .isEqualTo("approved"); // ← FAILS when bug exists: data lost!
+        .isEqualTo("approved");
 
     assertThat(restored.getCaseContext().get("data"))
         .as("data should be present from SubCase outputMapping")
-        .isNotNull(); // ← FAILS when bug exists: data lost!
+        .isNotNull();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #266 - Critical data loss bug where SubCase outputMapping data was permanently lost after JVM restart.

## Problem

SubCase outputMapping data was lost after JVM restart because:
1. `SubCaseCompletionListener` wrote `SUBCASE_COMPLETED` events WITHOUT payload containing applied data
2. `DefaultWorkerExecutionRecoveryService` did NOT process `SUBCASE_COMPLETED` events during state recovery

## Solution

### 1. Modified SubCaseCompletionListener (`blackboard/src/main/java/io/casehub/blackboard/subcase/SubCaseCompletionListener.java`)

- `applyOutputMappingToParent()` now returns `Map<String, Object>` with applied data
- `writeCompletedLog()` accepts `appliedData` parameter and saves it in payload
- Updated all call sites in `handleGroupedCompletion()` and `handleUngroupedCompletion()`

### 2. Modified DefaultWorkerExecutionRecoveryService (`runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java`)

- Added `SUBCASE_COMPLETED` to `rebuildStateContext()` event types list
- Process `SUBCASE_COMPLETED` same as `WORKER_EXECUTION_COMPLETED`: read payload and apply via `setAll()`

## Testing

- ✅ Added `SubCaseOutputMappingRecoveryTest` demonstrating the bug and verifying the fix
- ✅ Test `subCaseOutputMapping_preservedAfterRestart()` now PASSES
- ✅ Comparison test `regularWorkerOutput_preservedAfterRestart_forComparison()` confirms regular workers work correctly
- ✅ All blackboard tests pass - no regressions

## Result

SubCases now behave identically to regular workers during recovery - outputMapping data is preserved after JVM restart.

## Related

- Closes casehubio/engine#266
