### PR TITLE
feat: implement $secret and $config JQ scope variables for use.secrets/configMaps

### DIFF
--- a/api/src/main/java/io/casehub/api/model/CaseDefinition.java
+++ b/api/src/main/java/io/casehub/api/model/CaseDefinition.java
@@ -28,6 +28,7 @@ public class CaseDefinition {
   private final String version;
   private String title;
   private String summary;
+  private Use use;
   private final List<Capability> capabilities;
   private final List<Worker> workers;
   private final List<Binding> bindings;
@@ -80,6 +81,14 @@ public class CaseDefinition {
 
   public void setSummary(String summary) {
     this.summary = summary;
+  }
+
+  public Use getUse() {
+    return use;
+  }
+
+  public void setUse(Use use) {
+    this.use = use;
   }
 
   public List<Capability> getCapabilities() {

--- a/api/src/main/java/io/casehub/api/model/Use.java
+++ b/api/src/main/java/io/casehub/api/model/Use.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * External dependencies declaration (secrets and config maps).
+ *
+ * <p>Inspired by CNCF Serverless Workflow 'use' section.
+ */
+public class Use {
+
+  private Set<String> secrets;
+  private Set<String> configMaps;
+
+  public Use() {
+    this.secrets = new HashSet<>();
+    this.configMaps = new HashSet<>();
+  }
+
+  public Set<String> getSecrets() {
+    return secrets;
+  }
+
+  public void setSecrets(Set<String> secrets) {
+    this.secrets = secrets;
+  }
+
+  public Set<String> getConfigMaps() {
+    return configMaps;
+  }
+
+  public void setConfigMaps(Set<String> configMaps) {
+    this.configMaps = configMaps;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Use use = (Use) o;
+    return Objects.equals(secrets, use.secrets) && Objects.equals(configMaps, use.configMaps);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(secrets, configMaps);
+  }
+
+  @Override
+  public String toString() {
+    return "Use{" + "secrets=" + secrets + ", configMaps=" + configMaps + '}';
+  }
+}

--- a/common/src/main/java/io/casehub/engine/internal/config/ConfigManager.java
+++ b/common/src/main/java/io/casehub/engine/internal/config/ConfigManager.java
@@ -16,13 +16,15 @@
 package io.casehub.engine.internal.config;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 /**
  * Provides access to configuration properties.
  *
  * <p>Adapted from Serverless Workflow ConfigManager with Quarkus integration. Used programmatically
- * from Java code, NOT directly accessible from JQ expressions.
+ * from Java code, AND accessible from JQ expressions via {@code $config.{configMapName}.{property}}
+ * syntax.
  *
  * <p>Default implementation wraps MicroProfile Config API (application.properties, system
  * properties, environment variables, ConfigSources).
@@ -53,4 +55,28 @@ public interface ConfigManager {
    * @return iterable of property names
    */
   Iterable<String> names();
+
+  /**
+   * Resolve a config map by name.
+   *
+   * <p>Builds a nested map from all properties with {@code configMapName.} prefix.
+   *
+   * <p>Example:
+   *
+   * <pre>
+   * # application.properties
+   * app-config.timeout=5000
+   * app-config.retries=3
+   * app-config.database.host=localhost
+   *
+   * # JQ expression in YAML
+   * timeout: "${$config.\"app-config\".timeout}"  → resolves to "5000"
+   * </pre>
+   *
+   * @param configMapName config map identifier (e.g., "app-config", "feature-flags")
+   * @return map of config properties with nested structure (e.g., {timeout: "5000", database:
+   *     {host: "localhost"}})
+   * @throws ConfigMapNotFoundException if no properties with the prefix exist
+   */
+  Map<String, Object> configMap(String configMapName);
 }

--- a/common/src/main/java/io/casehub/engine/internal/config/ConfigMapNotFoundException.java
+++ b/common/src/main/java/io/casehub/engine/internal/config/ConfigMapNotFoundException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.config;
+
+/**
+ * Thrown when a requested config map does not exist.
+ *
+ * <p>Fail-fast behavior: case definitions are rejected at load time if declared config maps are
+ * missing. JQ expressions fail immediately if config map is not found.
+ */
+public class ConfigMapNotFoundException extends RuntimeException {
+
+  private final String configMapName;
+
+  public ConfigMapNotFoundException(String configMapName) {
+    super("ConfigMap not found: " + configMapName);
+    this.configMapName = configMapName;
+  }
+
+  public String getConfigMapName() {
+    return configMapName;
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/config/impl/QuarkusConfigManager.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/config/impl/QuarkusConfigManager.java
@@ -16,10 +16,13 @@
 package io.casehub.engine.internal.config.impl;
 
 import io.casehub.engine.internal.config.ConfigManager;
+import io.casehub.engine.internal.config.ConfigMapNotFoundException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.eclipse.microprofile.config.Config;
 
@@ -53,5 +56,41 @@ public class QuarkusConfigManager implements ConfigManager {
   @Override
   public Iterable<String> names() {
     return config.getPropertyNames();
+  }
+
+  @Override
+  public Map<String, Object> configMap(String configMapName) {
+    String prefix = configMapName + ".";
+    Map<String, Object> result = new HashMap<>();
+
+    for (String propName : names()) {
+      if (propName.startsWith(prefix)) {
+        String key = propName.substring(prefix.length());
+        config(propName, String.class).ifPresent(value -> putNested(result, key, value));
+      }
+    }
+
+    if (result.isEmpty()) {
+      throw new ConfigMapNotFoundException(configMapName);
+    }
+
+    return result;
+  }
+
+  /**
+   * Converts "database.host" -> nested map {database: {host: value}}.
+   *
+   * <p>Algorithm adapted from ConfigSecretManager.putNested().
+   */
+  private void putNested(Map<String, Object> map, String key, Object value) {
+    String[] parts = key.split("\\.", 2);
+    if (parts.length == 1) {
+      map.put(key, value);
+    } else {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> nested =
+          (Map<String, Object>) map.computeIfAbsent(parts[0], k -> new HashMap<>());
+      putNested(nested, parts[1], value);
+    }
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/DefaultCaseDefinitionRegistry.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/DefaultCaseDefinitionRegistry.java
@@ -22,6 +22,8 @@ import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.PredicateBasedCompletion;
+import io.casehub.engine.internal.config.ConfigManager;
+import io.casehub.engine.internal.config.SecretManager;
 import io.casehub.engine.internal.model.CaseMetaModel;
 import io.casehub.engine.internal.utils.ReactiveUtils;
 import io.casehub.engine.spi.CaseDefinitionRegistry;
@@ -63,10 +65,14 @@ public class DefaultCaseDefinitionRegistry implements CaseDefinitionRegistry {
 
   @Inject ExpressionEngineRegistry expressionEngineRegistry;
 
+  @Inject SecretManager secretManager;
+
+  @Inject ConfigManager configManager;
+
   void onStart(@Observes @Priority(10) StartupEvent ev) {
     ReactiveUtils.runOnSafeVertxContext(vertx, this::registerKnownDefinitions)
         .await()
-        .atMost(Duration.ofSeconds(30));
+        .atMost(Duration.ofSeconds(30)); // TODO this timeout must be configurable
   }
 
   Uni<Void> registerKnownDefinitions() {
@@ -146,6 +152,9 @@ public class DefaultCaseDefinitionRegistry implements CaseDefinitionRegistry {
   }
 
   private void validateExpressions(CaseDefinition definition) {
+    // Validate use.secrets and use.configMaps (fail-fast)
+    validateDependencies(definition);
+
     if (definition.getBindings() != null) {
       for (Binding rule : definition.getBindings()) {
         if (rule.getOn() instanceof ContextChangeTrigger cct) {
@@ -171,6 +180,49 @@ public class DefaultCaseDefinitionRegistry implements CaseDefinitionRegistry {
     }
     if (definition.getCompletion() instanceof PredicateBasedCompletion pbc) {
       expressionEngineRegistry.validate(pbc.getDoneWhen());
+    }
+  }
+
+  /**
+   * Validate use.secrets and use.configMaps declarations.
+   *
+   * <p>Fail-fast: throws IllegalArgumentException if any declared secret/configMap does not exist.
+   *
+   * @param definition case definition to validate
+   * @throws IllegalArgumentException if validation fails
+   */
+  private void validateDependencies(CaseDefinition definition) {
+    if (definition.getUse() == null) {
+      return;
+    }
+
+    // Validate secrets
+    if (definition.getUse().getSecrets() != null) {
+      for (String secretName : definition.getUse().getSecrets()) {
+        try {
+          secretManager.secret(secretName);
+        } catch (Exception e) {
+          throw new IllegalArgumentException(
+              "Secret '" + secretName + "' declared in use.secrets not found: " + e.getMessage(),
+              e);
+        }
+      }
+    }
+
+    // Validate config maps
+    if (definition.getUse().getConfigMaps() != null) {
+      for (String configMapName : definition.getUse().getConfigMaps()) {
+        try {
+          configManager.configMap(configMapName);
+        } catch (Exception e) {
+          throw new IllegalArgumentException(
+              "ConfigMap '"
+                  + configMapName
+                  + "' declared in use.configMaps not found: "
+                  + e.getMessage(),
+              e);
+        }
+      }
     }
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/jq/JQEvaluator.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/jq/JQEvaluator.java
@@ -16,27 +16,98 @@
 package io.casehub.engine.internal.jq;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.engine.internal.config.ConfigManager;
+import io.casehub.engine.internal.config.SecretManager;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import net.thisptr.jackson.jq.BuiltinFunctionLoader;
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.Versions;
 
+/**
+ * JQ expression evaluator with support for $secret and $config scope variables.
+ *
+ * <p>Scope variables:
+ *
+ * <ul>
+ *   <li>$secret.{name}.{property} - resolves secrets via SecretManager
+ *   <li>$config.{name}.{property} - resolves config maps via ConfigManager
+ * </ul>
+ *
+ * <p>Inspired by CNCF Serverless Workflow JQ scope injection pattern.
+ */
 @ApplicationScoped
 public class JQEvaluator {
 
-  private static final Scope ROOT_SCOPE;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  static {
-    ROOT_SCOPE = Scope.newEmptyScope();
-    BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_6, ROOT_SCOPE);
+  @Inject SecretManager secretManager;
+
+  @Inject ConfigManager configManager;
+
+  private Scope rootScope;
+
+  @PostConstruct
+  void init() {
+    rootScope = Scope.newEmptyScope();
+    BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_6, rootScope);
   }
 
+  /**
+   * Evaluate JQ expression without secrets/configs.
+   *
+   * @param jqExpr JQ expression
+   * @param asNode input JSON node
+   * @return validation result
+   */
   public ValidationResult eval(String jqExpr, JsonNode asNode) {
+    return eval(jqExpr, asNode, Set.of(), Set.of());
+  }
+
+  /**
+   * Evaluate JQ expression with $secret and $config scope variables.
+   *
+   * @param jqExpr JQ expression
+   * @param asNode input JSON node
+   * @param secretNames secret names to load (from use.secrets)
+   * @param configMapNames config map names to load (from use.configMaps)
+   * @return validation result
+   */
+  public ValidationResult eval(
+      String jqExpr, JsonNode asNode, Set<String> secretNames, Set<String> configMapNames) {
     try {
-      Scope childScope = Scope.newChildScope(ROOT_SCOPE);
+      Scope childScope = Scope.newChildScope(rootScope);
+
+      // Inject $secret scope variable
+      if (!secretNames.isEmpty()) {
+        Map<String, Object> secretsMap = new HashMap<>();
+        for (String secretName : secretNames) {
+          Map<String, Object> secret = secretManager.secret(secretName);
+          secretsMap.put(secretName, secret);
+        }
+        JsonNode secretNode = MAPPER.valueToTree(secretsMap);
+        childScope.setValue("secret", secretNode);
+      }
+
+      // Inject $config scope variable
+      if (!configMapNames.isEmpty()) {
+        Map<String, Object> configsMap = new HashMap<>();
+        for (String configMapName : configMapNames) {
+          Map<String, Object> configMap = configManager.configMap(configMapName);
+          configsMap.put(configMapName, configMap);
+        }
+        JsonNode configNode = MAPPER.valueToTree(configsMap);
+        childScope.setValue("config", configNode);
+      }
+
       JsonQuery query = JsonQuery.compile(jqExpr, Versions.JQ_1_6);
 
       List<JsonNode> out = new ArrayList<>();

--- a/runtime/src/main/java/io/casehub/engine/internal/milestone/MilestoneLifecycleManager.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/milestone/MilestoneLifecycleManager.java
@@ -81,6 +81,13 @@ public class MilestoneLifecycleManager {
         "CONTEXT_CHANGED received for case %s, state=%s",
         caseInstance.getUuid(), caseInstance.getState());
 
+    // Skip if no metamodel attached
+    if (caseMetaModel == null) {
+      LOG.debugf(
+          "Case %s has no CaseMetaModel, skipping milestone evaluation", caseInstance.getUuid());
+      return Uni.createFrom().voidItem();
+    }
+
     // Only evaluate milestones for RUNNING cases
     if (!caseInstance.getState().equals(CaseStatus.RUNNING)) {
       LOG.debugf("Case %s not RUNNING, skipping milestone evaluation", caseInstance.getUuid());

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/UseDependenciesValidationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/UseDependenciesValidationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.Use;
+import io.casehub.engine.spi.CaseDefinitionRegistry;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for use.secrets and use.configMaps validation.
+ *
+ * <p>Verifies fail-fast behavior: case definitions are rejected at load time if declared
+ * secrets/configMaps do not exist.
+ */
+@QuarkusTest
+@TestProfile(UseDependenciesValidationTest.Profile.class)
+class UseDependenciesValidationTest {
+
+  @Inject CaseDefinitionRegistry registry;
+
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "existing-secret.apiKey", "test-key",
+          "existing-config.timeout", "5000");
+    }
+  }
+
+  @Test
+  void shouldRejectDefinitionWithMissingSecret() {
+    CaseDefinition definition = new CaseDefinition("test", "test-case", "1.0");
+
+    Use use = new Use();
+    use.setSecrets(Set.of("nonexistent-secret"));
+    definition.setUse(use);
+
+    // Should fail with clear error message
+    UniAssertSubscriber<Object> subscriber =
+        registry
+            .registerCaseDefinition(definition)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    subscriber.awaitFailure();
+    assertThat(subscriber.getFailure())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Secret 'nonexistent-secret' declared in use.secrets not found");
+  }
+
+  @Test
+  void shouldRejectDefinitionWithMissingConfigMap() {
+    CaseDefinition definition = new CaseDefinition("test", "test-case", "1.0");
+
+    Use use = new Use();
+    use.setConfigMaps(Set.of("nonexistent-config"));
+    definition.setUse(use);
+
+    // Should fail with clear error message
+    UniAssertSubscriber<Object> subscriber =
+        registry
+            .registerCaseDefinition(definition)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    subscriber.awaitFailure();
+    assertThat(subscriber.getFailure())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ConfigMap 'nonexistent-config' declared in use.configMaps not found")
+        .hasMessageContaining("ConfigMap not found: nonexistent-config");
+  }
+
+  @Test
+  void shouldAcceptDefinitionWithValidDependencies() {
+    CaseDefinition definition = new CaseDefinition("test", "test-case", "1.0");
+
+    Use use = new Use();
+    use.setSecrets(Set.of("existing-secret"));
+    use.setConfigMaps(Set.of("existing-config"));
+    definition.setUse(use);
+
+    // Should succeed
+    UniAssertSubscriber<Object> subscriber =
+        registry
+            .registerCaseDefinition(definition)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    subscriber.awaitItem();
+    assertThat(subscriber.getItem()).isNotNull();
+  }
+
+  @Test
+  void shouldAcceptDefinitionWithoutUseSection() {
+    CaseDefinition definition = new CaseDefinition("test", "test-case", "1.0");
+    // No use section - should be fine
+
+    // Should succeed
+    UniAssertSubscriber<Object> subscriber =
+        registry
+            .registerCaseDefinition(definition)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    subscriber.awaitItem();
+    assertThat(subscriber.getItem()).isNotNull();
+  }
+
+  @Test
+  void shouldAcceptDefinitionWithEmptyUseSection() {
+    CaseDefinition definition = new CaseDefinition("test", "test-case", "1.0");
+
+    Use use = new Use();
+    // Empty sets - should be fine
+    definition.setUse(use);
+
+    // Should succeed
+    UniAssertSubscriber<Object> subscriber =
+        registry
+            .registerCaseDefinition(definition)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+
+    subscriber.awaitItem();
+    assertThat(subscriber.getItem()).isNotNull();
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/jq/JqDashSyntaxTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/jq/JqDashSyntaxTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.jq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test demonstrating why config map names with dashes require quotes in JQ.
+ *
+ * <p>JQ treats dashes as subtraction operators, so:
+ *
+ * <ul>
+ *   <li>$config.app-config -> interpreted as "$config.app minus config"
+ *   <li>$config."app-config" -> correct: property named "app-config"
+ * </ul>
+ */
+@QuarkusTest
+@TestProfile(JqDashSyntaxTest.Profile.class)
+class JqDashSyntaxTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Inject JQEvaluator jqEvaluator;
+
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "app-config.timeout", "5000",
+          "appconfig.timeout", "3000");
+    }
+  }
+
+  @Test
+  void withoutQuotes_shouldFail() {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    // Without quotes: JQ interprets dash as subtraction operator
+    // $config.app-config becomes: $config.app minus config (where config is treated as function)
+    ValidationResult result =
+        jqEvaluator.eval(
+            "$config.app-config.timeout", emptyContext, Set.of(), Set.of("app-config"));
+
+    assertThat(result.ok()).isFalse();
+    // JQ thinks "config" is a function, not a variable
+    assertThat(result.error()).contains("Function config/0 does not exist");
+  }
+
+  @Test
+  void withQuotes_shouldWork() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    // With quotes: JQ treats as property name
+    ValidationResult result =
+        jqEvaluator.eval(
+            "$config.\"app-config\".timeout", emptyContext, Set.of(), Set.of("app-config"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asText()).isEqualTo("5000");
+  }
+
+  @Test
+  void noDash_noQuotesNeeded() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    // No dash: works without quotes
+    ValidationResult result =
+        jqEvaluator.eval("$config.appconfig.timeout", emptyContext, Set.of(), Set.of("appconfig"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asText()).isEqualTo("3000");
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/jq/JqFunctionsIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/jq/JqFunctionsIntegrationTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.jq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for $secret and $config JQ scope variables.
+ *
+ * <p>Verifies that:
+ *
+ * <ul>
+ *   <li>$secret.{name}.{property} resolves secrets via SecretManager
+ *   <li>$config.{name}.{property} resolves config maps via ConfigManager
+ *   <li>Nested properties work: $secret.openai.apiKey
+ *   <li>Missing secrets/configs throw exceptions
+ * </ul>
+ */
+@QuarkusTest
+@TestProfile(JqFunctionsIntegrationTest.Profile.class)
+class JqFunctionsIntegrationTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Inject JQEvaluator jqEvaluator;
+
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "openai.apiKey", "sk-test-key-12345",
+          "openai.organizationId", "org-test-67890",
+          "openai.model.name", "gpt-4o-mini",
+          "app-config.timeout", "5000",
+          "app-config.retries", "3",
+          "app-config.logLevel", "INFO",
+          "feature-flags.analyticsEnabled", "true",
+          "feature-flags.debugMode", "false",
+          "model-params.temperature", "0.7",
+          "model-params.maxTokens", "4096");
+    }
+  }
+
+  // ========== $secret Tests ==========
+
+  @Test
+  void secretVariable_shouldResolveTopLevelSecret() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    ValidationResult result =
+        jqEvaluator.eval("$secret.openai", emptyContext, Set.of("openai"), Set.of());
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+
+    JsonNode secretNode = result.output().get(0);
+    assertThat(secretNode.get("apiKey").asText()).isEqualTo("sk-test-key-12345");
+    assertThat(secretNode.get("organizationId").asText()).isEqualTo("org-test-67890");
+  }
+
+  @Test
+  void secretVariable_shouldResolveNestedProperty() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    ValidationResult result =
+        jqEvaluator.eval("$secret.openai.apiKey", emptyContext, Set.of("openai"), Set.of());
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asText()).isEqualTo("sk-test-key-12345");
+  }
+
+  @Test
+  void secretVariable_shouldResolveDeepNestedProperty() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    ValidationResult result =
+        jqEvaluator.eval("$secret.openai.model.name", emptyContext, Set.of("openai"), Set.of());
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asText()).isEqualTo("gpt-4o-mini");
+  }
+
+  @Test
+  void secretVariable_shouldFailWhenSecretNotFound() {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    ValidationResult result =
+        jqEvaluator.eval("$secret.nonexistent", emptyContext, Set.of("nonexistent"), Set.of());
+
+    assertThat(result.ok()).isFalse();
+    assertThat(result.error()).contains("Secret not found: nonexistent");
+  }
+
+  @Test
+  void secretVariable_shouldWorkInComplexExpression() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    // Combine secret with string concatenation
+    ValidationResult result =
+        jqEvaluator.eval(
+            "\"API Key: \" + $secret.openai.apiKey", emptyContext, Set.of("openai"), Set.of());
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asText()).isEqualTo("API Key: sk-test-key-12345");
+  }
+
+  // ========== $config Tests ==========
+
+  @Test
+  void configVariable_shouldResolveTopLevelConfig() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    ValidationResult result =
+        jqEvaluator.eval("$config.\"app-config\"", emptyContext, Set.of(), Set.of("app-config"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+
+    JsonNode configNode = result.output().get(0);
+    assertThat(configNode.get("timeout").asText()).isEqualTo("5000");
+    assertThat(configNode.get("retries").asText()).isEqualTo("3");
+    assertThat(configNode.get("logLevel").asText()).isEqualTo("INFO");
+  }
+
+  @Test
+  void configVariable_shouldResolveNestedProperty() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    ValidationResult result =
+        jqEvaluator.eval(
+            "$config.\"app-config\".timeout", emptyContext, Set.of(), Set.of("app-config"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asText()).isEqualTo("5000");
+  }
+
+  @Test
+  void configVariable_shouldWorkWithFeatureFlags() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    ValidationResult result =
+        jqEvaluator.eval(
+            "$config.\"feature-flags\".analyticsEnabled",
+            emptyContext,
+            Set.of(),
+            Set.of("feature-flags"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asText()).isEqualTo("true");
+  }
+
+  @Test
+  void configVariable_shouldConvertToNumberWithPipe() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    // Use JQ's tonumber filter to convert string to number
+    ValidationResult result =
+        jqEvaluator.eval(
+            "$config.\"app-config\".timeout | tonumber",
+            emptyContext,
+            Set.of(),
+            Set.of("app-config"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asInt()).isEqualTo(5000);
+  }
+
+  @Test
+  void configVariable_shouldFailWhenConfigMapNotFound() {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    ValidationResult result =
+        jqEvaluator.eval("$config.nonexistent", emptyContext, Set.of(), Set.of("nonexistent"));
+
+    assertThat(result.ok()).isFalse();
+    assertThat(result.error()).contains("ConfigMap not found: nonexistent");
+  }
+
+  @Test
+  void configVariable_shouldWorkInBooleanExpression() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    // Use config in conditional
+    ValidationResult result =
+        jqEvaluator.eval(
+            "if $config.\"feature-flags\".analyticsEnabled == \"true\" then \"enabled\" else \"disabled\" end",
+            emptyContext,
+            Set.of(),
+            Set.of("feature-flags"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+    assertThat(result.output().get(0).asText()).isEqualTo("enabled");
+  }
+
+  // ========== Combined Usage Tests ==========
+
+  @Test
+  void shouldCombineSecretAndConfig() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    // Build object combining secret and config
+    ValidationResult result =
+        jqEvaluator.eval(
+            "{ apiKey: $secret.openai.apiKey, timeout: $config.\"app-config\".timeout }",
+            emptyContext,
+            Set.of("openai"),
+            Set.of("app-config"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+
+    JsonNode resultNode = result.output().get(0);
+    assertThat(resultNode.get("apiKey").asText()).isEqualTo("sk-test-key-12345");
+    assertThat(resultNode.get("timeout").asText()).isEqualTo("5000");
+  }
+
+  @Test
+  void shouldUseConfigAndSecretWithContext() throws Exception {
+    // Context with some data
+    ObjectNode context = MAPPER.createObjectNode();
+    context.put("userId", "user-123");
+    context.put("action", "analyze");
+
+    // Combine context, secret, and config
+    ValidationResult result =
+        jqEvaluator.eval(
+            "{ user: .userId, action: .action, apiKey: $secret.openai.apiKey, retries: ($config.\"app-config\".retries | tonumber) }",
+            context,
+            Set.of("openai"),
+            Set.of("app-config"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.output()).hasSize(1);
+
+    JsonNode resultNode = result.output().get(0);
+    assertThat(resultNode.get("user").asText()).isEqualTo("user-123");
+    assertThat(resultNode.get("action").asText()).isEqualTo("analyze");
+    assertThat(resultNode.get("apiKey").asText()).isEqualTo("sk-test-key-12345");
+    assertThat(resultNode.get("retries").asInt()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldWorkInFilterExpression() throws Exception {
+    JsonNode emptyContext = MAPPER.createObjectNode();
+
+    // Check if analytics is enabled
+    ValidationResult result =
+        jqEvaluator.eval(
+            "$config.\"feature-flags\".analyticsEnabled == \"true\"",
+            emptyContext,
+            Set.of(),
+            Set.of("feature-flags"));
+
+    assertThat(result.ok()).isTrue();
+    assertThat(result.isTrue()).isTrue();
+  }
+}

--- a/runtime/src/test/resources/casehub/use-configmaps-example.yaml
+++ b/runtime/src/test/resources/casehub/use-configmaps-example.yaml
@@ -35,10 +35,10 @@ spec:
               processed:
                 timestamp: ${ now }
                 data: ${ .context.data }
-                featureEnabled: ${ $config.featureFlags.dataProcessing }
+                featureEnabled: ${ $config.\"feature-flags\".dataProcessing }
               metadata:
-                timeout: ${ $config.appConfig.timeout | tonumber }
-                retries: ${ $config.appConfig.retries | tonumber }
+                timeout: ${ $config.\"app-config\".timeout | tonumber }
+                retries: ${ $config.\"app-config\".retries | tonumber }
 
     - name: database-writer
       description: Writes results to database
@@ -49,8 +49,8 @@ spec:
             set:
               stored: true
               connection:
-                host: ${ $config.appConfig.database.host }
-                port: ${ $config.appConfig.database.port | tonumber }
+                host: ${ $config.\"app-config\".database.host }
+                port: ${ $config.\"app-config\".database.port | tonumber }
                 # Credentials from secrets, not configs
                 username: ${ $secret.database.credentials.username }
                 password: ${ $secret.database.credentials.password }
@@ -60,13 +60,13 @@ spec:
       capability: process-data
       on:
         contextChange:
-          filter: '(.status == "pending") and ($config.featureFlags.dataProcessing == "true")'
+          filter: '(.status == "pending") and ($config.\"feature-flags\".dataProcessing == "true")'
 
     - name: store-if-analytics-enabled
       capability: store-result
       on:
         contextChange:
-          filter: '(.processed != null) and ($config.featureFlags.analyticsEnabled == "true")'
+          filter: '(.processed != null) and ($config.\"feature-flags\".analyticsEnabled == "true")'
       when: "${.processed != null}"
 
   milestones:

--- a/runtime/src/test/resources/casehub/use-secrets-example.yaml
+++ b/runtime/src/test/resources/casehub/use-secrets-example.yaml
@@ -33,9 +33,9 @@ spec:
           openai:
             apiKey: "${$secret.openai.apiKey}"
             organizationId: "${$secret.openai.organizationId}"
-            modelName: "${$config.modelParams.primary}"
-            temperature: "${$config.modelParams.temperature | tonumber}"
-            maxTokens: "${$config.modelParams.maxTokens | tonumber}"
+            modelName: "${$config.\"model-params\".primary}"
+            temperature: "${$config.\"model-params\".temperature | tonumber}"
+            maxTokens: "${$config.\"model-params\".maxTokens | tonumber}"
 
     - name: fallback-analyzer
       description: Fallback sentiment analyzer using Anthropic
@@ -57,7 +57,7 @@ spec:
       capability: analyze-sentiment
       on:
         contextChange:
-          filter: '(.status == "pending") and ($config.appConfig.analyticsEnabled == "true")'
+          filter: '(.status == "pending") and ($config.\"app-config\".analyticsEnabled == "true")'
 
   milestones:
     - name: sentimentAnalyzed


### PR DESCRIPTION
Key implementation details:
- Use scope.setValue() to inject $secret and $config as objects
- $secret.{name}.{property} - resolves secrets via SecretManager
- $config.{name}.{property} - resolves config maps via ConfigManager
- Nested map building from dotted properties (e.g., "openai.apiKey")
- JQEvaluator.eval() accepts Set<String> secretNames, Set<String> configMapNames
- Loads only declared secrets/configs (from use.secrets and use.configMaps)

Example syntax:
- $secret.openai.apiKey - accesses OpenAI API key
- $config.\"app-config\".timeout | tonumber - accesses timeout and converts to number
- Quote config map names with dashes: $config.\"app-config\"

Implements validation logic that rejects case definitions at load time if declared secrets or config maps do not exist. This prevents runtime errors and provides immediate feedback during development.

Key changes:

**API Module:**
- Added Use class (io.casehub.api.model.Use) with secrets/configMaps sets
- Added use field with getters/setters to CaseDefinition

**Runtime Module:**
- Added validateDependencies() to DefaultCaseDefinitionRegistry
- Validates all declared secrets exist via SecretManager.secret()
- Validates all declared config maps have at least one property with prefix
- Clear error messages on validation failure
- Injected SecretManager and ConfigManager into registry

Ref #247