### PR TITLE
fix: work-adapter API compatibility and reactive PlanItemStore flush

### DIFF
--- a/common/src/test/java/io/casehub/engine/spi/ReactivePlanItemStoreContractTest.java
+++ b/common/src/test/java/io/casehub/engine/spi/ReactivePlanItemStoreContractTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.engine.internal.model.PlanItemRecord;
+import io.casehub.engine.internal.model.PlanItemStatus;
+import io.smallrye.mutiny.Uni;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/** Abstract contract test — extend with a concrete impl to verify the ReactivePlanItemStore SPI. */
+public abstract class ReactivePlanItemStoreContractTest {
+
+  protected abstract ReactivePlanItemStore store();
+
+  /** Execute a Uni on whatever execution context the concrete impl requires. */
+  protected abstract <T> T run(Uni<T> uni);
+
+  @Test
+  void save_and_findByCaseId() {
+    UUID caseId = UUID.randomUUID();
+    String planItemId = UUID.randomUUID().toString();
+    run(store().save(caseId, planItemId, "my-binding", PlanItemStatus.PENDING, Instant.now()));
+    List<PlanItemRecord> results = run(store().findByCaseId(caseId));
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).planItemId()).isEqualTo(planItemId);
+    assertThat(results.get(0).status()).isEqualTo(PlanItemStatus.PENDING);
+  }
+
+  @Test
+  void updateStatus_changes_stored_status() {
+    UUID caseId = UUID.randomUUID();
+    String planItemId = UUID.randomUUID().toString();
+    run(store().save(caseId, planItemId, "my-binding", PlanItemStatus.PENDING, Instant.now()));
+    run(store().updateStatus(planItemId, PlanItemStatus.RUNNING));
+    List<PlanItemRecord> results = run(store().findByCaseId(caseId));
+    assertThat(results.get(0).status()).isEqualTo(PlanItemStatus.RUNNING);
+  }
+}

--- a/persistence-hibernate/pom.xml
+++ b/persistence-hibernate/pom.xml
@@ -46,6 +46,13 @@
 
         <!-- Test -->
         <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-engine-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>

--- a/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaReactivePlanItemStore.java
+++ b/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaReactivePlanItemStore.java
@@ -19,6 +19,7 @@ import io.casehub.engine.internal.model.PlanItemRecord;
 import io.casehub.engine.internal.model.PlanItemStatus;
 import io.casehub.engine.spi.ReactivePlanItemStore;
 import io.quarkus.hibernate.reactive.panache.Panache;
+import io.quarkus.panache.common.Parameters;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.Instant;
@@ -57,12 +58,16 @@ public class JpaReactivePlanItemStore extends AbstractJpaRepository
         () ->
             Panache.withTransaction(
                 () ->
-                    PlanItemEntity.<PlanItemEntity>find("planItemId", planItemId)
-                        .firstResult()
-                        .invoke(
-                            e -> {
-                              if (e != null) e.status = status;
-                            })
+                    // Flush pending inserts so the JPQL UPDATE can see entities persisted
+                    // earlier in this transaction but not yet written to the DB row store.
+                    PlanItemEntity.getSession()
+                        .chain(session -> session.flush())
+                        .chain(
+                            () ->
+                                PlanItemEntity.update(
+                                    "status = :status WHERE planItemId = :planItemId",
+                                    Parameters.with("status", status)
+                                        .and("planItemId", planItemId)))
                         .replaceWithVoid()));
   }
 

--- a/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaReactivePlanItemStoreTest.java
+++ b/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaReactivePlanItemStoreTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.persistence.jpa;
+
+import io.casehub.engine.spi.ReactivePlanItemStore;
+import io.casehub.engine.spi.ReactivePlanItemStoreContractTest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.vertx.VertxContextSupport;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+class JpaReactivePlanItemStoreTest extends ReactivePlanItemStoreContractTest {
+
+  @Inject JpaReactivePlanItemStore store;
+
+  @Override
+  protected ReactivePlanItemStore store() {
+    return store;
+  }
+
+  @Override
+  protected <T> T run(Uni<T> uni) {
+    try {
+      return VertxContextSupport.subscribeAndAwait(() -> uni);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -257,6 +257,7 @@ public class CaseContextChangedEventHandler {
             null,
             null,
             null,
+            null,
             null);
 
     AssignmentDecision decision =

--- a/runtime/src/main/java/io/casehub/engine/internal/orchestration/WorkOrchestrator.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/orchestration/WorkOrchestrator.java
@@ -129,7 +129,7 @@ public class WorkOrchestrator {
 
     // 3. Build SelectionContext and call WorkBroker
     SelectionContext context =
-        new SelectionContext(null, null, capability.getName(), null, null, null, null);
+        new SelectionContext(null, null, capability.getName(), null, null, null, null, null);
     AssignmentDecision decision =
         workBroker.apply(context, AssignmentTrigger.CREATED, candidates, selectionStrategy);
 

--- a/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
@@ -180,7 +180,12 @@ public class HumanTaskScheduleHandler {
             null, // confidenceScore
             callerRef,
             null, // claimDeadlineBusinessHours
-            null); // expiresAtBusinessHours
+            null, // expiresAtBusinessHours
+            null, // templateId
+            null, // permittedOutcomes
+            null, // inputDataSchema
+            null, // outputDataSchema
+            null); // excludedUsers
 
     workItemService.create(request);
     LOG.infof(


### PR DESCRIPTION
## Summary

- **engine#278**: Add missing `excludedUsers` arg to `SelectionContext` and `WorkItemCreateRequest` constructor — was causing `ArrayIndexOutOfBoundsException` at runtime after upstream added new fields
- **engine#279**: Switch `JpaReactivePlanItemStore.updateStatus` from dirty-read JPQL to explicit `session.flush()` + JPQL UPDATE — JPQL bypasses first-level cache; flush ensures entity written by `save()` in same tx is visible
- **engine#280**: Add `ReactivePlanItemStore` contract test + JPA implementation test to catch flush/cache issues at the contract level

## Test plan

- [ ] `JpaReactivePlanItemStoreTest` passes
- [ ] `ReactivePlanItemStoreContractTest` passes for JPA impl
- [ ] Existing work-adapter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)