### PR TITLE
feat: add humanTask as first-class YAML binding type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,28 @@ All implementation work must be linked to a GitHub issue:
 | specs      | project     | lands in `docs/specs/` — promoted at epic close |
 | blog       | workspace   | staged here; published to mdproctor.github.io via publish-blog |
 | plans      | workspace   | stay in workspace permanently |
-| design     | workspace   | epic journal stays in workspace |
+| design journal | workspace | JOURNAL.md (epic artifact) stays in workspace permanently |
+| DESIGN.md  | project     | canonical design doc — `docs/DESIGN.md` in the project repo |
 | snapshots  | workspace   | stay in workspace permanently |
 | handover   | workspace   | |
+
+---
+
+## Document Locations
+
+Key documents and where to find them. Skills must use these paths — never guess.
+
+| Document | Repo | Path |
+|----------|------|------|
+| DESIGN.md | project | `docs/DESIGN.md` |
+| ADR index | project | `docs/adr/INDEX.md` |
+| Protocol index | parent | `docs/protocols/casehub/FOUNDATION-INDEX.md` |
+| Platform architecture | parent (remote) | `https://raw.githubusercontent.com/casehubio/parent/main/docs/PLATFORM.md` |
+| This repo's deep-dive | parent (remote) | `https://raw.githubusercontent.com/casehubio/parent/main/docs/repos/casehub-engine.md` |
+| HANDOFF.md | workspace | `HANDOFF.md` (root) |
+| Blog entries | workspace | `blog/` |
+| Plans | workspace | `plans/` |
+| Epic journal | workspace | `design/JOURNAL.md` |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,19 +41,19 @@ All implementation work must be linked to a GitHub issue:
 
 ## Document Locations
 
-Key documents and where to find them. Skills must use these paths — never guess.
+Key documents and where to find them. All paths are relative — no absolute paths.
+Convention: `proj/` in workspace reaches the project repo; `wksp/` in the project repo reaches the workspace.
 
-| Document | Repo | Path |
-|----------|------|------|
-| DESIGN.md | project | `docs/DESIGN.md` |
-| ADR index | project | `docs/adr/INDEX.md` |
-| Protocol index | parent | `docs/protocols/casehub/FOUNDATION-INDEX.md` |
-| Platform architecture | parent (remote) | `https://raw.githubusercontent.com/casehubio/parent/main/docs/PLATFORM.md` |
-| This repo's deep-dive | parent (remote) | `https://raw.githubusercontent.com/casehubio/parent/main/docs/repos/casehub-engine.md` |
-| HANDOFF.md | workspace | `HANDOFF.md` (root) |
-| Blog entries | workspace | `blog/` |
-| Plans | workspace | `plans/` |
-| Epic journal | workspace | `design/JOURNAL.md` |
+| Document | Path from project root | Path from workspace root |
+|----------|----------------------|------------------------|
+| DESIGN.md | `docs/DESIGN.md` | `proj/docs/DESIGN.md` |
+| ADR index | `docs/adr/INDEX.md` | `proj/docs/adr/INDEX.md` |
+| HANDOFF.md | `wksp/HANDOFF.md` | `HANDOFF.md` |
+| Blog entries | `wksp/blog/` | `blog/` |
+| Plans | `wksp/plans/` | `plans/` |
+| Epic journal | `wksp/design/JOURNAL.md` | `design/JOURNAL.md` |
+| Platform architecture | remote: `https://raw.githubusercontent.com/casehubio/parent/main/docs/PLATFORM.md` | — |
+| Protocol index | remote: `https://raw.githubusercontent.com/casehubio/parent/main/docs/protocols/casehub/FOUNDATION-INDEX.md` | — |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,10 @@ is unavailable.
 
 ## casehub-work-adapter Module
 
+Activated by adding `casehub-engine-work-adapter` to the consumer's classpath (transitively brings `casehub-engine-blackboard`). Required for any runtime that uses `humanTask` YAML bindings — without it, `HumanTaskScheduleEvent` is published but never handled and WorkItems are never created.
+
+**YAML DSL:** `humanTask` is a first-class binding target type in `CaseDefinition.yaml` (alongside `capability` and `subCase`). `CaseDefinitionYamlMapper` converts it to `HumanTaskTarget`. Inline mode requires `title`; template mode requires `templateRef`. Both modes support `outputMapping`, `inputMapping`, `candidateGroups`, `candidateUsers`, and `expiresIn`.
+
 Two-way bridge between casehub-work and CaseHub plan items:
 - **Inbound** (`WorkItemLifecycleAdapter`) — translates terminal `WorkItemLifecycleEvent` CDI events to `PlanItem` transitions, evaluates `outputMapping` against the WorkItem resolution JSON, and fires `CONTEXT_CHANGED` for engine re-evaluation
 - **Outbound** (`HumanTaskScheduleHandler`) — consumes `HUMAN_TASK_SCHEDULE` event bus messages, looks up the `PlanItem` by binding name, then:

--- a/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
+++ b/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
@@ -194,7 +194,13 @@ public final class CaseDefinitionYamlMapper {
       io.casehub.api.model.SubCase subCase = convertSubCase(schemaBinding.getSubCase());
       builder.subCase(subCase);
     } else if (schemaBinding.getHumanTask() != null) {
-      builder.humanTask(convertHumanTask(schemaBinding.getHumanTask()));
+      try {
+        builder.humanTask(convertHumanTask(schemaBinding.getHumanTask()));
+      } catch (IllegalStateException | IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            "Binding '" + schemaBinding.getName() + "' has invalid humanTask: " + e.getMessage(),
+            e);
+      }
     } else {
       throw new IllegalArgumentException(
           "Binding '" + schemaBinding.getName() + "' must have capability, subCase, or humanTask");

--- a/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
+++ b/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
@@ -26,11 +26,14 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalBasedCompletion;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.HumanTaskTarget;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -175,7 +178,7 @@ public final class CaseDefinitionYamlMapper {
 
     Binding.Builder builder = Binding.builder().name(schemaBinding.getName()).on(trigger);
 
-    // Either capability OR subCase (mutually exclusive)
+    // Either capability OR subCase OR humanTask (mutually exclusive)
     if (schemaBinding.getCapability() != null) {
       Capability cap = capabilityMap.get(schemaBinding.getCapability());
       if (cap == null) {
@@ -190,9 +193,11 @@ public final class CaseDefinitionYamlMapper {
     } else if (schemaBinding.getSubCase() != null) {
       io.casehub.api.model.SubCase subCase = convertSubCase(schemaBinding.getSubCase());
       builder.subCase(subCase);
+    } else if (schemaBinding.getHumanTask() != null) {
+      builder.humanTask(convertHumanTask(schemaBinding.getHumanTask()));
     } else {
       throw new IllegalArgumentException(
-          "Binding '" + schemaBinding.getName() + "' must have either capability or subCase");
+          "Binding '" + schemaBinding.getName() + "' must have capability, subCase, or humanTask");
     }
 
     // Optional fields
@@ -270,5 +275,29 @@ public final class CaseDefinitionYamlMapper {
     }
 
     return null;
+  }
+
+  private static HumanTaskTarget convertHumanTask(io.casehub.model.HumanTask schema) {
+    HumanTaskTarget.Builder builder =
+        schema.getTemplateRef() != null
+            ? HumanTaskTarget.template(schema.getTemplateRef())
+            : HumanTaskTarget.inline().title(schema.getTitle());
+
+    if (schema.getInputMapping() != null) {
+      builder.inputMapping(schema.getInputMapping());
+    }
+    if (schema.getOutputMapping() != null) {
+      builder.outputMapping(schema.getOutputMapping());
+    }
+    if (schema.getCandidateGroups() != null && !schema.getCandidateGroups().isEmpty()) {
+      builder.candidateGroups(new LinkedHashSet<>(schema.getCandidateGroups()));
+    }
+    if (schema.getCandidateUsers() != null && !schema.getCandidateUsers().isEmpty()) {
+      builder.candidateUsers(new LinkedHashSet<>(schema.getCandidateUsers()));
+    }
+    if (schema.getExpiresIn() != null) {
+      builder.expiresIn(Duration.parse(schema.getExpiresIn()));
+    }
+    return builder.build();
   }
 }

--- a/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
+++ b/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
@@ -23,6 +23,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Goal;
+import io.casehub.api.model.HumanTaskTarget;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.ai.Agent;
@@ -31,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 class CaseDefinitionYamlMapperTest {
@@ -247,5 +249,133 @@ class CaseDefinitionYamlMapperTest {
     // Verify that the agent was converted to API model (Agent is the value in the function holder)
     Object value = worker.getFunction().getValue();
     assertThat(value).isInstanceOf(Agent.class);
+  }
+
+  @Test
+  void humanTaskBinding_inline_parsedCorrectly() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Human Task Case
+        version: 1.0.0
+        spec:
+          bindings:
+            - name: approval
+              on: { contextChange: {} }
+              humanTask:
+                title: "PR approval required"
+                outputMapping: "{ approval: { status: .decision } }"
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(def.getBindings()).hasSize(1);
+    Binding binding = def.getBindings().get(0);
+    assertThat(binding.getName()).isEqualTo("approval");
+    assertThat(binding.target()).isInstanceOf(HumanTaskTarget.class);
+
+    HumanTaskTarget ht = (HumanTaskTarget) binding.target();
+    assertThat(ht.isTemplateMode()).isFalse();
+    assertThat(ht.title()).isEqualTo("PR approval required");
+    assertThat(ht.outputMapping()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.outputMapping()).expression())
+        .isEqualTo("{ approval: { status: .decision } }");
+    assertThat(ht.inputMapping()).isNull();
+    assertThat(ht.candidateGroups()).isNull();
+    assertThat(ht.expiresIn()).isNull();
+  }
+
+  @Test
+  void humanTaskBinding_template_parsedCorrectly() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Template Task Case
+        version: 1.0.0
+        spec:
+          bindings:
+            - name: review
+              on: { contextChange: {} }
+              humanTask:
+                templateRef: "senior-review"
+                outputMapping: "{ review: .outcome }"
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+    assertThat(ht.isTemplateMode()).isTrue();
+    assertThat(ht.templateRef()).isEqualTo("senior-review");
+    assertThat(ht.title()).isNull();
+    assertThat(ht.outputMapping()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.outputMapping()).expression())
+        .isEqualTo("{ review: .outcome }");
+  }
+
+  @Test
+  void humanTaskBinding_withAllOptionalFields_parsedCorrectly() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Full Human Task Case
+        version: 1.0.0
+        spec:
+          bindings:
+            - name: full-approval
+              on: { contextChange: {} }
+              humanTask:
+                title: "Full approval task"
+                inputMapping: "{ pr: .pr }"
+                outputMapping: "{ approval: .decision }"
+                candidateGroups:
+                  - architects
+                  - seniors
+                candidateUsers:
+                  - alice
+                expiresIn: "PT24H"
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+    assertThat(ht.candidateGroups()).containsExactlyInAnyOrder("architects", "seniors");
+    assertThat(ht.candidateUsers()).containsExactlyInAnyOrder("alice");
+    assertThat(ht.expiresIn()).isEqualTo(Duration.parse("PT24H"));
+    assertThat(ht.inputMapping()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.inputMapping()).expression()).isEqualTo("{ pr: .pr }");
+    assertThat(((JQExpressionEvaluator) ht.outputMapping()).expression())
+        .isEqualTo("{ approval: .decision }");
+  }
+
+  @Test
+  void humanTaskBinding_emptyCandidateLists_treatedAsNotSet() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Empty Lists Case
+        version: 1.0.0
+        spec:
+          bindings:
+            - name: approval
+              on: { contextChange: {} }
+              humanTask:
+                title: "Approval"
+                candidateGroups: []
+                candidateUsers: []
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+    assertThat(ht.candidateGroups()).isNull();
+    assertThat(ht.candidateUsers()).isNull();
   }
 }

--- a/docs/adr/0001-humantask-yaml-binding-target.md
+++ b/docs/adr/0001-humantask-yaml-binding-target.md
@@ -1,0 +1,88 @@
+# 0001 — humanTask as a first-class YAML binding target for human-in-the-loop gates
+
+Date: 2026-05-20
+Status: Accepted
+
+## Context and Problem Statement
+
+The engine YAML DSL needed a way to express bindings that create a casehub-work WorkItem for
+a human to complete, then resume the case when the WorkItem reaches a terminal state. Three
+approaches were available: reuse the existing `capability` target with a naming convention,
+add a first-class binding target type, or introduce a dedicated WorkerProvisioner.
+
+## Decision Drivers
+
+* **Type safety over convention** — foundational platform code should enforce structure at the
+  schema layer, not rely on undocumented naming patterns that tooling cannot validate
+* **Explicit dispatch path** — the engine should be able to route `humanTask` bindings directly
+  to the correct handler without runtime convention matching
+* **Structured domain model** — human task fields (`title`, `templateRef`, `outputMapping`,
+  `candidateGroups`, `expiresIn`) are distinct from capability fields and deserve their own
+  schema definition with inline validation (e.g. title XOR templateRef)
+
+## Considered Options
+
+* **Option A** — Naming convention on `capability`: use `capability: "human-decision:*"` as a
+  convention; per-harness WorkerProvisioner intercepts the name and creates WorkItems
+* **Option B** — First-class `humanTask` binding target: third `oneOf` branch in the schema;
+  `CaseDefinitionYamlMapper` converts to `HumanTaskTarget`; dispatched via `HumanTaskScheduleEvent`
+* **Option C** — Inline `HumanTaskWorkerProvisioner`: specific provisioner intercepts named
+  capabilities and creates WorkItems, keeping `capability` as the only binding target type
+
+## Decision Outcome
+
+Chosen option: **Option B**, because it enforces the human-task contract at the schema layer
+(title XOR templateRef, typed optional fields) rather than at runtime through a naming
+convention. The `capability` target retains its clear meaning (automated worker), and
+`humanTask` bindings are unambiguous to readers, tooling, and the engine dispatcher.
+
+### Positive Consequences
+
+* Schema validation rejects malformed human task bindings at load time (inline mode without
+  title, both title and templateRef present, etc.)
+* `CaseContextChangedEventHandler` dispatches `humanTask` bindings via a direct type match
+  (`HumanTaskTarget`) — no string matching or convention interpretation at runtime
+* Adding `outputMapping`, `candidateGroups`, `candidateUsers`, `expiresIn` as typed schema
+  fields enables IDE completion and validation for case definition authors
+* `casehub-engine-work-adapter` is activated by classpath presence alone — no harness code
+  required beyond the Maven dependency
+
+### Negative Consequences / Tradeoffs
+
+* Schema and mapper changes are required each time a new binding target type is introduced
+  (vs. convention-based approaches where new types are free)
+* The YAML subset constraint tightens: the schema must be kept in sync with `HumanTaskTarget`
+  as that class evolves
+
+## Pros and Cons of the Options
+
+### Option A — Naming convention on capability
+
+* ✅ Zero schema changes — any capability name works
+* ✅ Per-harness provisioners are already the extension pattern for WorkerProvisioner
+* ❌ Convention is invisible to schema validation — `capability: "human-decision:typo"` passes schema
+* ❌ WorkerProvisioner path does not fire `HumanTaskScheduleEvent` — requires a separate bridge
+* ❌ Each harness must implement a matching WorkerProvisioner; no shared implementation path
+
+### Option B — First-class humanTask binding target (chosen)
+
+* ✅ Schema-enforced: inline/template mode, required fields, mutual exclusion
+* ✅ Direct dispatch path through existing `HumanTaskScheduleEvent` / `HumanTaskScheduleHandler`
+* ✅ Shared implementation in `casehub-engine-work-adapter` — harnesses opt in via dependency only
+* ❌ Requires schema + mapper changes per new binding target type
+* ❌ `HumanTaskTarget` fields must stay in sync with the schema definition
+
+### Option C — HumanTaskWorkerProvisioner
+
+* ✅ Keeps the `capability` target as the only binding type
+* ❌ WorkerProvisioner lifecycle (Quartz job scheduling, worker function execution) is designed
+  for automated workers — adapting it for long-lived human tasks requires significant workarounds
+* ❌ No natural path for `outputMapping` to reach the case context at completion
+* ❌ Per-harness provisioner implementation; no shared code reuse
+
+## Links
+
+* Protocol PP-20260520-b2a932 — `yaml-humantask-binding-type.md` (casehubio/parent)
+* Protocol PP-20260520-5d0b91 — `hitl-runtime-assembly.md` (casehubio/parent)
+* engine#293 — HITL YAML binding + devtown wiring
+* engine#297 — follow-up: improve error handling for malformed humanTask bindings

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,0 +1,5 @@
+# ADR Index
+
+| ID | Title | Status | Date |
+|----|-------|--------|------|
+| 0001 | [humanTask as first-class YAML binding target](0001-humantask-yaml-binding-target.md) | Accepted | 2026-05-20 |

--- a/docs/specs/2026-05-19-hitl-yaml-binding-design.md
+++ b/docs/specs/2026-05-19-hitl-yaml-binding-design.md
@@ -1,0 +1,182 @@
+# Design: HITL YAML Binding and devtown Wiring
+
+**Issue:** engine#293 (epic)  
+**Date:** 2026-05-19  
+**Sub-issues:** engine#294, engine#295, devtown#33
+
+---
+
+## Problem
+
+HITL case resumption is broken in devtown. When a human completes a WorkItem, the case stalls in WAITING state. There are two gaps:
+
+1. The YAML DSL only supports `capability` and `subCase` as binding targets. There is no `humanTask` type. Devtown's `human-approval` binding uses `capability: "human-decision:pr-approval"`, which routes through the Quartz/WorkerProvisioner path — `HumanTaskScheduleEvent` is never fired, so `HumanTaskScheduleHandler` is never invoked.
+2. `casehub-engine-work-adapter` is not on devtown's classpath, so even if the event were fired, `WorkItemLifecycleAdapter` could not observe `WorkItemLifecycleEvent` to resume the case.
+
+---
+
+## Design
+
+### 1. Schema — `$defs/HumanTask` and `Binding.humanTask` (engine#294)
+
+Add `HumanTask` to `CaseDefinition.yaml`:
+
+```yaml
+HumanTask:
+  type: object
+  unevaluatedProperties: false
+  description: >-
+    A binding target that creates a WorkItem in casehub-work and resumes the case
+    when the WorkItem reaches a terminal state.
+  oneOf:
+    - required: [title]
+      not: { required: [templateRef] }
+    - required: [templateRef]
+      not: { required: [title] }
+  properties:
+    title:
+      type: string
+      description: "WorkItem title — inline mode"
+    templateRef:
+      type: string
+      description: "WorkItemTemplate reference (UUID or name) — template mode"
+    inputMapping:
+      type: string
+      description: "JQ expression mapping case context to WorkItem payload"
+    outputMapping:
+      type: string
+      description: "JQ expression mapping WorkItem resolution to case context updates"
+    candidateGroups:
+      type: array
+      items: { type: string }
+      description: "Groups eligible to claim this WorkItem"
+    candidateUsers:
+      type: array
+      items: { type: string }
+      description: "Users eligible to claim this WorkItem"
+    expiresIn:
+      type: string
+      description: "ISO 8601 duration after which the WorkItem expires (e.g. PT24H)"
+```
+
+Extend `Binding` with `humanTask` as a third mutually exclusive target:
+
+```yaml
+Binding:
+  oneOf:
+    - required: [capability]
+      not: { required: [subCase, humanTask] }
+    - required: [subCase]
+      not: { required: [capability, humanTask] }
+    - required: [humanTask]
+      not: { required: [capability, subCase] }
+  properties:
+    ...existing...
+    humanTask: { $ref: "#/$defs/HumanTask" }
+```
+
+`jsonschema2pojo` generates `io.casehub.model.HumanTask` and adds `getHumanTask()` to `io.casehub.model.Binding`.
+
+### 2. YAML Mapper — `CaseDefinitionYamlMapper` (engine#295)
+
+Add a `humanTask` branch in `convertBinding`, after the `subCase` branch:
+
+```java
+} else if (schemaBinding.getHumanTask() != null) {
+    builder.humanTask(convertHumanTask(schemaBinding.getHumanTask()));
+}
+```
+
+`convertHumanTask` maps schema fields to `HumanTaskTarget`:
+- `title` present → `HumanTaskTarget.inline().title(title)...build()`
+- `templateRef` present → `HumanTaskTarget.template(ref)...build()`
+- `inputMapping`, `outputMapping` → `new JQExpressionEvaluator(expr)`
+- `candidateGroups`, `candidateUsers` → `Set.of(...)` (null-safe)
+- `expiresIn` → `Duration.parse(expiresIn)` (null-safe)
+
+The error branch (neither capability nor subCase nor humanTask) is updated to include `humanTask` in the message.
+
+**Tests added to `CaseDefinitionYamlMapperTest`:**
+- Inline mode: YAML with `humanTask: { title: "...", outputMapping: "..." }` → `HumanTaskTarget` with correct fields
+- Template mode: `humanTask: { templateRef: "my-template" }` → `HumanTaskTarget.isTemplateMode() == true`
+- With optional fields: `candidateGroups`, `expiresIn` round-trip correctly
+
+### 3. Devtown wiring (devtown#33)
+
+**`review/src/main/resources/devtown/pr-review.yaml`**
+
+Remove the now-unused `"human-decision:pr-approval"` capability declaration.
+
+Change `human-approval` binding:
+```yaml
+# Before
+- name: human-approval
+  capability: "human-decision:pr-approval"
+
+# After
+- name: human-approval
+  humanTask:
+    title: "PR approval required"
+    outputMapping: "{ humanApproval: { status: .decision } }"
+```
+
+**`app/pom.xml`**
+
+```xml
+<dependency>
+  <groupId>io.casehub</groupId>
+  <artifactId>casehub-engine-work-adapter</artifactId>
+  <version>${project.version}</version>
+</dependency>
+```
+
+This transitively brings `casehub-engine-blackboard` onto the classpath, activating `BlackboardRegistry` and plan model tracking (required by `HumanTaskScheduleHandler`).
+
+**`app/src/test/resources/application.properties`**
+
+Add index-dependency entries (following existing `engine-scheduler-quartz` pattern):
+```properties
+quarkus.index-dependency.engine-work-adapter.group-id=io.casehub
+quarkus.index-dependency.engine-work-adapter.artifact-id=casehub-engine-work-adapter
+
+quarkus.index-dependency.engine-blackboard.group-id=io.casehub
+quarkus.index-dependency.engine-blackboard.artifact-id=casehub-engine-blackboard
+```
+
+---
+
+## Flow After This Change
+
+```
+humanApproval binding fires (context matches when condition)
+  → CaseContextChangedEventHandler: target is HumanTaskTarget
+  → publishes HumanTaskScheduleEvent
+  → HumanTaskScheduleHandler.onHumanTaskSchedule()
+      creates WorkItem, saves PlanItem RUNNING, marks PlanItem RUNNING
+  → Human completes WorkItem via WorkItemService.completeFromSystem()
+  → WorkItemLifecycleEvent fires
+  → WorkItemLifecycleAdapter.onWorkItemLifecycle()
+      marks PlanItem COMPLETED, applies outputMapping to CaseContext
+      publishes CONTEXT_CHANGED
+  → CaseContextChangedEventHandler re-evaluates
+  → merge binding fires (all conditions satisfied)
+```
+
+---
+
+## What's Deferred
+
+- **devtown#30** — End-to-end `@QuarkusTest`: start PR review case, complete WorkItem, verify case resumes and merge binding fires. Unblocked once devtown#33 lands.
+
+---
+
+## Files Touched
+
+| File | Repo | Change |
+|------|------|--------|
+| `schema/src/main/resources/schema/CaseDefinition.yaml` | engine | Add `HumanTask` def + `humanTask` binding branch |
+| `api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java` | engine | Add `humanTask` → `HumanTaskTarget` conversion |
+| `api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java` | engine | Add parse tests for `humanTask` binding |
+| `review/src/main/resources/devtown/pr-review.yaml` | devtown | Replace capability binding with `humanTask` |
+| `app/pom.xml` | devtown | Add `casehub-engine-work-adapter` dep |
+| `app/src/test/resources/application.properties` | devtown | Add `quarkus.index-dependency` entries |

--- a/schema/src/main/resources/schema/CaseDefinition.yaml
+++ b/schema/src/main/resources/schema/CaseDefinition.yaml
@@ -240,6 +240,43 @@ $defs:
       outputSchema:
         { type: string, description: "JQ producing capability output" }
 
+  HumanTask:
+    type: object
+    description: >-
+      A binding target that creates a WorkItem in casehub-work and resumes the case
+      when the WorkItem reaches a terminal state. Inline mode requires title;
+      template mode requires templateRef. The two modes are mutually exclusive.
+    unevaluatedProperties: false
+    oneOf:
+      - required: [ title ]
+        not: { required: [ templateRef ] }
+      - required: [ templateRef ]
+        not: { required: [ title ] }
+    properties:
+      title:
+        type: string
+        description: "WorkItem title — inline mode"
+      templateRef:
+        type: string
+        description: "WorkItemTemplate reference (UUID or name) — template mode"
+      inputMapping:
+        type: string
+        description: "JQ expression: case context → WorkItem payload"
+      outputMapping:
+        type: string
+        description: "JQ expression: WorkItem resolution → case context updates"
+      candidateGroups:
+        type: array
+        items: { type: string }
+        description: "Groups eligible to claim this WorkItem"
+      candidateUsers:
+        type: array
+        items: { type: string }
+        description: "Users eligible to claim this WorkItem"
+      expiresIn:
+        type: string
+        description: "ISO 8601 duration after which the WorkItem expires (e.g. PT24H)"
+
   Binding:
     type: object
     required: [ on ]
@@ -247,16 +284,20 @@ $defs:
     oneOf:
       - required: [ capability ]
         not:
-          required: [ subCase ]
+          required: [ subCase, humanTask ]
       - required: [ subCase ]
         not:
-          required: [ capability ]
+          required: [ capability, humanTask ]
+      - required: [ humanTask ]
+        not:
+          required: [ capability, subCase ]
     properties:
       name: { type: string }
       on: { $ref: "#/$defs/Trigger" }
       when: { type: string, description: "JQ over context and/or event" }
       capability: { type: string }
       subCase: { $ref: "#/$defs/SubCase" }
+      humanTask: { $ref: "#/$defs/HumanTask" }
       conflictResolverStrategy:
         type: string
         enum: [ LAST_WRITER_WINS, FIRST_WRITER_WINS, FAIL ]


### PR DESCRIPTION
## Summary

- Adds `humanTask` as a first-class binding type in the YAML DSL alongside `capability` and `subCase`
- Schema: `HumanTask` definition is mutually exclusive `title` (inline) or `templateRef` (UUID of a `WorkItemTemplate`), with optional `inputMapping`, `outputMapping`, `candidateGroups`, `candidateUsers`, `expiresIn`
- Mapper: `CaseDefinitionYamlMapper.convertHumanTask()` converts YAML → `HumanTaskTarget`; errors are wrapped with binding context for diagnosis
- ADR-0001 records the decision to make humanTask first-class rather than use a naming convention on `capability`

## Why not `capability`?

A `capability` binding with a name like `human-decision:pr-approval` routes to `WorkerProvisioner`, not to `HumanTaskScheduleHandler`. Convention-based routing breaks silently — a typo produces no error, the WorkItem is never created, and the case stalls with nothing to diagnose. A first-class type means the schema rejects invalid configs before the engine starts.

## Test plan

- [ ] `CaseDefinitionYamlMapperTest` covers humanTask schema parsing
- [ ] `use-configmaps-example.yaml` and `use-secrets-example.yaml` examples still parse correctly
- [ ] Existing YAML binding tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)