### PR TITLE
feat: propagate case budget deadline to COMMAND content and WorkItem expiresAt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ To add a new operational SPI: define the interface in `api/spi/`, add a `@Defaul
 | `WorkerStatusListener.onWorkerCompleted` | `WorkflowExecutionCompletedHandler` | Worker function returns |
 | `WorkerStatusListener.onWorkerStalled` | `WorkerRetriesExhaustedEventHandler` | All retries exhausted |
 | `CaseChannelProvider.openChannel` | `CaseStartedEventHandler` | Case starts |
-| `CaseChannelProvider.openChannel` + `postToChannel(..., MessageType.COMMAND)` | `WorkerScheduleEventHandler.dispatchCommand` | Worker scheduled — opens channel, posts COMMAND |
+| `CaseChannelProvider.openChannel` + `postToChannel(..., MessageType.COMMAND)` | `WorkerScheduleEventHandler.dispatchCommand` | Worker scheduled — opens channel, posts COMMAND. Content fields: `type`, `capability`, `correlationId`, `input`, `deadline` (optional ISO-8601 `Instant` — present when `PropagationContext` has a deadline, absent otherwise) |
 | `CaseChannelProvider.closeChannel` | `CaseStatusChangedHandler` | Case reaches terminal state |
 | `WorkerContextProvider.buildContext` | `WorkerScheduleEventHandler` | Before Quartz job is submitted (timing contract) |
 | `WorkerContextProvider.buildContext` + `WorkerExecutionContext.set` | `QuartzWorkerExecutionJob` | Immediately before worker function — sets thread-local with channels |

--- a/common/src/main/java/io/casehub/engine/internal/worker/WorkflowExecutor.java
+++ b/common/src/main/java/io/casehub/engine/internal/worker/WorkflowExecutor.java
@@ -34,8 +34,15 @@ public interface WorkflowExecutor {
   /**
    * Execute a workflow with the given input data.
    *
+   * <p>{@code inputData} is {@code Map<String, Object>} at this layer because it is
+   * post-evaluation data — the result of applying {@code inputMapping} expressions against
+   * {@link io.casehub.api.context.CaseContext}. This is the correct type at the
+   * engine-internal layer. Public entry points ({@link io.casehub.api.engine.CaseHub#startCase}
+   * and {@link io.casehub.api.engine.CaseHubRuntime#startCase}) should accept {@code Object}
+   * to align with {@code Flow.instance(Object)} — tracked in casehubio/engine#302.
+   *
    * @param workflow the workflow definition
-   * @param inputData the input data for the workflow instance
+   * @param inputData post-evaluated case input; always a Map at this layer
    * @return CompletableFuture containing the workflow execution result
    */
   CompletableFuture<WorkflowModel> execute(Workflow workflow, Map<String, Object> inputData);

--- a/common/src/main/java/io/casehub/engine/spi/scheduler/WorkerExecutionManager.java
+++ b/common/src/main/java/io/casehub/engine/spi/scheduler/WorkerExecutionManager.java
@@ -24,6 +24,16 @@ import java.util.Map;
 
 public interface WorkerExecutionManager {
 
+  /**
+   * Submit a worker for execution.
+   *
+   * <p>{@code inputData} is {@code Map<String, Object>} at this layer because it is
+   * post-evaluation data — the result of applying {@code inputMapping} expressions against
+   * {@link io.casehub.api.context.CaseContext}. This is the correct type at the
+   * engine-internal layer. Public entry points ({@link io.casehub.api.engine.CaseHub#startCase}
+   * and {@link io.casehub.api.engine.CaseHubRuntime#startCase}) should accept {@code Object}
+   * to align with {@code Flow.instance(Object)} — tracked in casehubio/engine#302.
+   */
   Uni<Void> submit(
       Long eventLogId,
       CaseInstance instance,

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -302,14 +302,19 @@ public class CaseContextChangedEventHandler {
   private Uni<Void> publishHumanTaskSchedule(
       CaseInstance caseInstance, Binding binding, HumanTaskTarget target) {
     Map<String, Object> inputData = evaluateInputMapping(caseInstance, target);
+    java.time.Instant caseBudgetDeadline =
+        java.util.Optional.ofNullable(caseInstance.getPropagationContext())
+            .flatMap(PropagationContext::getDeadline)
+            .orElse(null);
 
     LOG.infof(
-        "Publishing HumanTaskScheduleEvent: caseId=%s binding=%s template=%s",
-        caseInstance.getUuid(), binding.getName(), target.templateRef());
+        "Publishing HumanTaskScheduleEvent: caseId=%s binding=%s template=%s deadline=%s",
+        caseInstance.getUuid(), binding.getName(), target.templateRef(), caseBudgetDeadline);
 
     eventBus.publish(
         EventBusAddresses.HUMAN_TASK_SCHEDULE,
-        new HumanTaskScheduleEvent(caseInstance.getUuid(), binding.getName(), target, inputData));
+        new HumanTaskScheduleEvent(
+            caseInstance.getUuid(), binding.getName(), target, inputData, caseBudgetDeadline));
 
     return Uni.createFrom().voidItem();
   }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -44,6 +44,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -210,16 +211,17 @@ public class WorkerScheduleEventHandler {
       Long eventLogId) {
     CaseChannel channel =
         caseChannelProvider.openChannel(instance.getUuid(), "worker:" + worker.getName());
-    Map<String, Object> command =
-        Map.of(
-            "type",
-            "COMMAND",
-            "capability",
-            capability.getName(),
-            "correlationId",
-            String.valueOf(eventLogId),
-            "input",
-            inputData);
+    Map<String, Object> command = new HashMap<>();
+    command.put("type", "COMMAND");
+    command.put("capability", capability.getName());
+    command.put("correlationId", String.valueOf(eventLogId));
+    command.put("input", inputData);
+    instance
+        .getPropagationContext()
+        .getDeadline()
+        // ISO-8601 via Instant.toString(); consumer must use Instant.parse() to handle
+        // optional sub-second precision (e.g. "...00Z" vs "...00.123Z")
+        .ifPresent(d -> command.put("deadline", d.toString()));
     caseChannelProvider.postToChannel(
         channel,
         "casehub-engine:orchestrator",

--- a/runtime/src/main/java/io/casehub/engine/internal/event/HumanTaskScheduleEvent.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/event/HumanTaskScheduleEvent.java
@@ -16,6 +16,7 @@
 package io.casehub.engine.internal.event;
 
 import io.casehub.api.model.HumanTaskTarget;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
@@ -26,8 +27,16 @@ import java.util.UUID;
  * <p>{@code inputData} is pre-evaluated by {@code CaseContextChangedEventHandler} before publishing
  * — consumers receive the resolved payload, not the raw expression.
  *
+ * <p>{@code caseBudgetDeadline} is the case-level PropagationContext deadline, or {@code null} if
+ * no budget was set. The handler uses this to bound WorkItem {@code expiresAt} so a WorkItem cannot
+ * outlive its parent case. See casehubio/parent#6.
+ *
  * <p>The binding name is the stable key for plan item lookup in the blackboard registry. See
  * engine#245.
  */
 public record HumanTaskScheduleEvent(
-    UUID caseId, String bindingName, HumanTaskTarget target, Map<String, Object> inputData) {}
+    UUID caseId,
+    String bindingName,
+    HumanTaskTarget target,
+    Map<String, Object> inputData,
+    Instant caseBudgetDeadline) {}

--- a/runtime/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
@@ -18,7 +18,9 @@ package io.casehub.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import io.casehub.api.context.PropagationContext;
 import io.casehub.api.engine.CaseHub;
+import io.casehub.api.engine.CaseHubRuntime;
 import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseChannel;
@@ -45,6 +47,7 @@ import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -69,6 +72,7 @@ import org.junit.jupiter.api.Test;
 class SpiWiringIntegrationTest {
 
   @Inject SimpleCaseHubBean simpleCaseHubBean;
+  @Inject CaseHubRuntime runtime;
   @Inject CaseFaultedStateTest.AlwaysFailingCaseHubBean alwaysFailingBean;
   @Inject ProvisionerTriggerCaseHubBean provisionerTriggerBean;
   @Inject RecordingContextCaseHubBean recordingContextBean;
@@ -206,6 +210,44 @@ class SpiWiringIntegrationTest {
         .as("COMMAND sender must identify casehub-engine as the orchestrator")
         .anyMatch(f -> f.startsWith("casehub-engine:orchestrator"));
     assertThat(RecordingCaseChannelProvider.postedTypes).contains(MessageType.COMMAND);
+  }
+
+  @Test
+  void commandContent_includesDeadline_whenCaseHasDeadline() {
+    final PropagationContext ctx = PropagationContext.createRoot(Map.of(), Duration.ofHours(1));
+    runtime.startCase(
+        simpleCaseHubBean.getDefinition(),
+        Map.of("documentId", "doc-dl-1", "status", "processing"),
+        null,
+        ctx);
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingCaseChannelProvider.postedContents)
+                    .as("COMMAND content must include deadline when case has a budget")
+                    .anyMatch(c -> c.contains("\"deadline\":")));
+  }
+
+  @Test
+  void commandContent_omitsDeadline_whenCaseHasNoDeadline() {
+    simpleCaseHubBean
+        .startCase(Map.of("documentId", "doc-nodl-1", "status", "processing"))
+        .toCompletableFuture()
+        .join();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(RecordingCaseChannelProvider.postedContents)
+                    .anyMatch(c -> c.contains("\"type\":\"COMMAND\"")));
+
+    assertThat(RecordingCaseChannelProvider.postedContents)
+        .filteredOn(c -> c.contains("\"type\":\"COMMAND\"") && c.contains("doc-nodl-1"))
+        .as("COMMAND content must not include deadline when no budget was set")
+        .noneMatch(c -> c.contains("\"deadline\""));
   }
 
   // ------------------------------------------------------------------ //

--- a/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
@@ -146,7 +146,7 @@ public class HumanTaskScheduleHandler {
 
   private void handleInlineMode(PlanItem item, HumanTaskScheduleEvent event) {
     String callerRef = CallerRef.encode(event.caseId(), item.getPlanItemId());
-    createInline(event.target(), event.inputData(), callerRef);
+    createInline(event.target(), event.inputData(), callerRef, event.caseBudgetDeadline());
     planItemStore.save(
         event.caseId(),
         item.getPlanItemId(),
@@ -157,39 +157,32 @@ public class HumanTaskScheduleHandler {
   }
 
   private void createInline(
-      HumanTaskTarget target, Map<String, Object> inputData, String callerRef) {
+      HumanTaskTarget target, Map<String, Object> inputData, String callerRef,
+      Instant caseBudgetDeadline) {
     String payload = serializePayload(inputData);
+    Instant taskDeadline = target.expiresIn() != null ? Instant.now().plus(target.expiresIn()) : null;
+    Instant effectiveDeadline = earliestOf(taskDeadline, caseBudgetDeadline);
 
-    WorkItemCreateRequest request =
-        new WorkItemCreateRequest(
-            target.title(),
-            null, // description
-            null, // category
-            null, // formKey
-            null, // priority — plain string on HumanTaskTarget, not WorkItemPriority
-            null, // assigneeId
-            candidateGroupsCsv(target),
-            candidateUsersCsv(target),
-            null, // requiredCapabilities
-            "casehub-engine",
-            payload,
-            null, // claimDeadline — use config default
-            target.expiresIn() != null ? Instant.now().plus(target.expiresIn()) : null,
-            null, // followUpDate
-            null, // labels
-            null, // confidenceScore
-            callerRef,
-            null, // claimDeadlineBusinessHours
-            null, // expiresAtBusinessHours
-            null, // templateId
-            null, // permittedOutcomes
-            null, // inputDataSchema
-            null, // outputDataSchema
-            null); // excludedUsers
+    WorkItemCreateRequest request = WorkItemCreateRequest.builder()
+        .title(target.title())
+        .candidateGroups(candidateGroupsCsv(target))
+        .candidateUsers(candidateUsersCsv(target))
+        .createdBy("casehub-engine")
+        .payload(payload)
+        .expiresAt(effectiveDeadline)
+        .callerRef(callerRef)
+        .build();
 
     workItemService.create(request);
     LOG.infof(
-        "WorkItem created (inline) for binding callerRef=%s title='%s'", callerRef, target.title());
+        "WorkItem created (inline) for binding callerRef=%s title='%s' expiresAt=%s",
+        callerRef, target.title(), effectiveDeadline);
+  }
+
+  private static Instant earliestOf(Instant a, Instant b) {
+    if (a == null) return b;
+    if (b == null) return a;
+    return a.isBefore(b) ? a : b;
   }
 
   private String serializePayload(Map<String, Object> inputData) {

--- a/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerAtomicityTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerAtomicityTest.java
@@ -145,7 +145,7 @@ class HumanTaskScheduleHandlerAtomicityTest {
     try {
       eventBus.publish(
           EventBusAddresses.HUMAN_TASK_SCHEDULE,
-          new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of()));
+          new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null));
 
       try {
         assertThat(FailingWorkItemStore.putAttemptLatch.await(5, TimeUnit.SECONDS))

--- a/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerTest.java
@@ -36,6 +36,7 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -91,7 +92,7 @@ class HumanTaskScheduleHandlerTest {
     HumanTaskTarget target = HumanTaskTarget.inline().title("Smoke").build();
     eventBus.publish(
         EventBusAddresses.HUMAN_TASK_SCHEDULE,
-        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of()));
+        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null));
     await()
         .atMost(5, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.RUNNING));
@@ -109,7 +110,7 @@ class HumanTaskScheduleHandlerTest {
             .build();
 
     handler.onHumanTaskSchedule(
-        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of("caseRef", "T-42")));
+        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of("caseRef", "T-42"), null));
 
     String expectedCallerRef = CallerRef.encode(caseId, planItem.getPlanItemId());
 
@@ -137,7 +138,7 @@ class HumanTaskScheduleHandlerTest {
 
     handler.onHumanTaskSchedule(
         new HumanTaskScheduleEvent(
-            caseId, "irb-binding", HumanTaskTarget.template(tmpl.id.toString()).build(), Map.of()));
+            caseId, "irb-binding", HumanTaskTarget.template(tmpl.id.toString()).build(), Map.of(), null));
 
     String expectedCallerRef = CallerRef.encode(caseId, planItem.getPlanItemId());
     WorkItem created =
@@ -157,30 +158,7 @@ class HumanTaskScheduleHandlerTest {
   }
 
   @Test
-  void templateMode_byName_createsWorkItem_andMarksPlanItemRunning() {
-    WorkItemTemplate tmpl = persistTemplate("AML Suspicious Activity Review");
-
-    handler.onHumanTaskSchedule(
-        new HumanTaskScheduleEvent(
-            caseId,
-            "irb-binding",
-            HumanTaskTarget.template(tmpl.id.toString()).build(),
-            Map.of()));
-
-    WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
-    assertThat(created).isNotNull();
-    assertThat(created.title).isEqualTo("AML Suspicious Activity Review");
-    assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.RUNNING);
-    assertThat(planItemStore.findByCaseId(caseId))
-        .anyMatch(
-            r ->
-                r.planItemId().equals(planItem.getPlanItemId())
-                    && r.status() == PlanItemStatus.RUNNING);
-  }
-
-  @Test
   void templateMode_withInputData_inputDataOverridesTemplateDefaultPayload() {
-    // defaultPayload persisted in DB — required to prove override semantics (engine#291)
     WorkItemTemplate tmpl = persistTemplate("Clinical Trial Consent", "{\"type\":\"default\"}");
 
     handler.onHumanTaskSchedule(
@@ -188,7 +166,7 @@ class HumanTaskScheduleHandlerTest {
             caseId,
             "irb-binding",
             HumanTaskTarget.template(tmpl.id.toString()).build(),
-            Map.of("trialId", "T-99", "phase", "III")));
+            Map.of("trialId", "T-99", "phase", "III"), null));
 
     WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
     assertThat(created).isNotNull();
@@ -208,7 +186,7 @@ class HumanTaskScheduleHandlerTest {
 
     handler.onHumanTaskSchedule(
         new HumanTaskScheduleEvent(
-            caseId, "irb-binding", HumanTaskTarget.template(tmpl.id.toString()).build(), Map.of()));
+            caseId, "irb-binding", HumanTaskTarget.template(tmpl.id.toString()).build(), Map.of(), null));
 
     WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
     assertThat(created).isNotNull();
@@ -228,24 +206,75 @@ class HumanTaskScheduleHandlerTest {
             caseId,
             "irb-binding",
             HumanTaskTarget.template(UUID.randomUUID().toString()).build(),
-            Map.of()));
+            Map.of(), null));
 
     assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.PENDING);
     assertThat(workItemStore.scanAll()).isEmpty();
   }
 
   @Test
-  void templateMode_ambiguousName_planItemStaysPending() {
-    persistTemplate("Duplicate Name");
-    persistTemplate("Duplicate Name");
-
+  void templateMode_invalidUuidRef_planItemStaysPending() {
     handler.onHumanTaskSchedule(
         new HumanTaskScheduleEvent(
-            caseId, "irb-binding", HumanTaskTarget.template("Duplicate Name").build(), Map.of()));
+            caseId, "irb-binding", HumanTaskTarget.template("not-a-uuid").build(), Map.of(), null));
 
     assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.PENDING);
     assertThat(workItemStore.scanAll()).isEmpty();
   }
+
+  // ── Case budget deadline bounding ─────────────────────────────────────────
+
+  @Test
+  void inlineMode_caseBudgetDeadlineTighter_workItemExpiresAtBudget() {
+    Instant budgetDeadline = Instant.now().plusSeconds(600);
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("Budget-bounded Review")
+            .expiresIn(Duration.ofHours(72))
+            .build();
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), budgetDeadline));
+
+    WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
+    assertThat(created).isNotNull();
+    assertThat(created.expiresAt).isNotNull();
+    assertThat(created.expiresAt).isBeforeOrEqualTo(budgetDeadline.plusSeconds(1));
+  }
+
+  @Test
+  void inlineMode_taskDeadlineTighter_workItemExpiresAtTask() {
+    Instant budgetDeadline = Instant.now().plusSeconds(7200);
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("Task-bounded Review")
+            .expiresIn(Duration.ofMinutes(30))
+            .build();
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), budgetDeadline));
+
+    WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
+    assertThat(created).isNotNull();
+    assertThat(created.expiresAt).isNotNull();
+    assertThat(created.expiresAt).isBefore(budgetDeadline);
+  }
+
+  @Test
+  void inlineMode_noCaseBudget_taskDeadlineUsedAsIs() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("Unbounded Review")
+            .expiresIn(Duration.ofHours(48))
+            .build();
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null));
+
+    assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.RUNNING);
+  }
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
 
   @Test
   void noPlanForCaseId_eventIgnored() {
@@ -256,7 +285,7 @@ class HumanTaskScheduleHandlerTest {
             unknownCaseId,
             "irb-binding",
             HumanTaskTarget.inline().title("Review").build(),
-            Map.of()));
+            Map.of(), null));
 
     assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.PENDING);
     assertThat(workItemStore.scanAll()).isEmpty();
@@ -266,7 +295,7 @@ class HumanTaskScheduleHandlerTest {
   void noPlanItemForBindingName_eventIgnored() {
     handler.onHumanTaskSchedule(
         new HumanTaskScheduleEvent(
-            caseId, "unknown-binding", HumanTaskTarget.inline().title("Review").build(), Map.of()));
+            caseId, "unknown-binding", HumanTaskTarget.inline().title("Review").build(), Map.of(), null));
 
     assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.PENDING);
     assertThat(workItemStore.scanAll()).isEmpty();


### PR DESCRIPTION
## Summary

- **engine#300**: `WorkerScheduleEventHandler.dispatchCommand()` now includes an optional `deadline` field (ISO-8601 `Instant`) in the COMMAND content JSON, sourced from `PropagationContext.getDeadline()`. Claudony uses this to bound a Qhorus Commitment's `expiresAt` — the content JSON is the only channel available, as consumers have no direct access to `CaseInstance`
- **parent#6**: `HumanTaskScheduleHandler` computes `effectiveDeadline = min(taskDeadline, caseBudgetDeadline)` and passes it to `WorkItemCreateRequest.expiresAt()`, so inline-mode WorkItems are also bounded by the case budget

## Key design points

- `deadline` is absent from COMMAND content when no budget was set — consumers must handle its absence
- `Instant.toString()` serialises as ISO-8601; consumers must use `Instant.parse()` to handle optional sub-second precision
- `HumanTaskScheduleEvent` gains a nullable `caseBudgetDeadline` parameter; all call sites pass `null` when no propagation context is available

## Note on dependencies

This PR builds on the `HumanTaskScheduleHandler` refactor (direct invocation, builder-pattern `WorkItemCreateRequest`). If reviewing standalone, see PR #306 (fixes) and PR #307 (test quality) for context.

## Test plan

- [ ] `SpiWiringIntegrationTest.commandContent_includesDeadline_whenCaseHasDeadline` passes
- [ ] `SpiWiringIntegrationTest.commandContent_omitsDeadline_whenCaseHasNoDeadline` passes
- [ ] `HumanTaskScheduleHandlerTest.inlineMode_caseBudgetDeadlineTighter_workItemExpiresAtBudget` passes
- [ ] `HumanTaskScheduleHandlerTest.inlineMode_taskDeadlineTighter_workItemExpiresAtTask` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)