### PR TITLE
fix: ledger merkle tests + CapabilityHealth integration + postToChannel 6-param

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,9 @@ Eight interfaces in `api/src/main/java/io/casehub/api/spi/` (four blocking + fou
 **Default implementations** in `engine/src/main/java/io/casehub/engine/internal/worker/`:
 - `NoOpWorkerProvisioner`, `NoOpWorkerStatusListener`, `NoOpCaseChannelProvider`, `EmptyWorkerContextProvider`
 - Four `@DefaultBean` reactive mirrors: `NoOpReactiveWorkerProvisioner`, `NoOpReactiveCaseChannelProvider`, `NoOpReactiveWorkerStatusListener`, `EmptyReactiveWorkerContextProvider`
+- `NoOpCapabilityHealth` — returns `Ready` for all probes; deployments without `casehub-eidos-api` get transparent no-op
 
-All eight are `@DefaultBean @ApplicationScoped` (`io.quarkus.arc.DefaultBean`) — they yield automatically to any consumer-provided implementation without requiring `selected-alternatives` configuration. See protocol `PP-20260514-engine-spi-noops-defaultbean`.
+All nine are `@DefaultBean @ApplicationScoped` (`io.quarkus.arc.DefaultBean`) — they yield automatically to any consumer-provided implementation without requiring `selected-alternatives` configuration. See protocol `PP-20260514-engine-spi-noops-defaultbean`.
 
 **`ContextDiffStrategy`** is engine-internal strategy selection, not a consumer-replaceable SPI. Selected via `casehub.engine.diff-strategy` config (`none` | `top-level` | `json-patch`, default `none`). A `@Produces @DefaultBean` producer in `engine/internal/diff/ContextDiffStrategyProducer` instantiates the chosen POJO — consumer `@ApplicationScoped` impl still wins automatically.
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -47,6 +47,11 @@
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-eidos-api</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/api/src/main/java/io/casehub/api/model/Worker.java
+++ b/api/src/main/java/io/casehub/api/model/Worker.java
@@ -19,6 +19,7 @@ import io.casehub.api.context.CaseContext;
 import io.casehub.api.model.ai.Agent;
 import io.casehub.api.model.holder.WorkerFunctionHolder;
 import io.casehub.api.plan.PlanElement;
+import io.casehub.eidos.api.AgentDescriptor;
 import io.serverlessworkflow.api.types.Workflow;
 import java.io.File;
 import java.util.Arrays;
@@ -34,6 +35,7 @@ public class Worker implements PlanElement {
   private final WorkerFunctionHolder<?> functionHolder;
   private ExecutionPolicy executionPolicy;
   private String description;
+  private AgentDescriptor agentDescriptor;
 
   public Worker(
       String name,
@@ -98,6 +100,14 @@ public class Worker implements PlanElement {
     return functionHolder;
   }
 
+  public AgentDescriptor agentDescriptor() {
+    return agentDescriptor;
+  }
+
+  public boolean hasDescriptor() {
+    return agentDescriptor != null;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -109,6 +119,7 @@ public class Worker implements PlanElement {
     private WorkerFunctionHolder<?> functionHolder;
     private ExecutionPolicy executionPolicy;
     private String description;
+    private AgentDescriptor agentDescriptor;
 
     private Builder() {}
 
@@ -157,6 +168,11 @@ public class Worker implements PlanElement {
       return this;
     }
 
+    public Builder agentDescriptor(AgentDescriptor agentDescriptor) {
+      this.agentDescriptor = agentDescriptor;
+      return this;
+    }
+
     public Worker build() {
       Worker worker =
           new Worker(
@@ -167,6 +183,7 @@ public class Worker implements PlanElement {
         worker.setExecutionPolicy(executionPolicy);
       }
       worker.setDescription(description);
+      worker.agentDescriptor = agentDescriptor;
       return worker;
     }
   }

--- a/api/src/test/java/io/casehub/api/model/WorkerTest.java
+++ b/api/src/test/java/io/casehub/api/model/WorkerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.eidos.api.AgentDescriptor;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkerTest {
+
+  private static final AgentDescriptor DESCRIPTOR =
+      new AgentDescriptor(
+          "agent-1",
+          "TestAgent",
+          "1.0",
+          "openai",
+          "gpt-4",
+          "4-turbo",
+          null,
+          null,
+          null,
+          null,
+          "code-review",
+          List.of(),
+          null,
+          null,
+          null,
+          "casehubio");
+
+  @Test
+  void hasDescriptor_withDescriptor_returnsTrue() {
+    Worker worker =
+        Worker.builder()
+            .name("agent-worker")
+            .capabilities(
+                Capability.builder().name("review").inputSchema(".x").outputSchema(".y").build())
+            .agentDescriptor(DESCRIPTOR)
+            .function(input -> Map.of())
+            .build();
+
+    assertThat(worker.hasDescriptor()).isTrue();
+  }
+
+  @Test
+  void hasDescriptor_withoutDescriptor_returnsFalse() {
+    Worker worker =
+        Worker.builder()
+            .name("plain-worker")
+            .capabilities(
+                Capability.builder().name("review").inputSchema(".x").outputSchema(".y").build())
+            .function(input -> Map.of())
+            .build();
+
+    assertThat(worker.hasDescriptor()).isFalse();
+  }
+
+  @Test
+  void agentDescriptor_accessor_returnsStoredDescriptor() {
+    Worker worker =
+        Worker.builder()
+            .name("agent-worker")
+            .capabilities(
+                Capability.builder().name("review").inputSchema(".x").outputSchema(".y").build())
+            .agentDescriptor(DESCRIPTOR)
+            .function(input -> Map.of())
+            .build();
+
+    assertThat(worker.agentDescriptor()).isSameAs(DESCRIPTOR);
+  }
+
+  @Test
+  void agentDescriptor_notSet_returnsNull() {
+    Worker worker =
+        Worker.builder()
+            .name("plain-worker")
+            .capabilities(
+                Capability.builder().name("review").inputSchema(".x").outputSchema(".y").build())
+            .function(input -> Map.of())
+            .build();
+
+    assertThat(worker.agentDescriptor()).isNull();
+  }
+}

--- a/docs/specs/2026-05-23-capability-health-design.md
+++ b/docs/specs/2026-05-23-capability-health-design.md
@@ -1,0 +1,120 @@
+# Design Spec — CapabilityHealth integration (engine#341)
+
+**Date:** 2026-05-23
+**Issue:** casehubio/engine#341
+**Branch:** issue-341-capability-health
+
+## Problem
+
+`WorkOrchestrator.buildCandidates()` treats all capability-matched workers as equally
+capable. Agent-backed workers (LLM agents) may be unavailable, overloaded, or
+epistemically weak for the task domain. Without health probing, the broker selects
+from candidates that cannot fulfill the dispatch.
+
+## Design
+
+### Approach
+
+Add `AgentDescriptor` (from `casehub-eidos-api`) as an optional field on `Worker`.
+Inject `CapabilityHealth` into `WorkOrchestrator` with a `@DefaultBean` no-op fallback.
+Probe agent-backed workers after the cheaper capability match and workload checks.
+
+### Tier boundary
+
+`casehub-engine-api` already depends on `dev.langchain4j:langchain4j` for the `Agent`
+worker type. Adding `casehub-eidos-api` (pure Java, no CDI) is architecturally consistent.
+`AgentDescriptor` is a construction-time property of the worker's identity — it belongs
+on the model, not discovered at runtime via registry lookup.
+
+## Changes
+
+### 1. `casehub-engine-api` pom.xml
+
+Add `casehub-eidos-api` as optional compile dependency:
+```xml
+<dependency>
+    <groupId>io.casehub</groupId>
+    <artifactId>casehub-eidos-api</artifactId>
+    <version>${version.io.casehub}</version>
+    <optional>true</optional>
+</dependency>
+```
+
+### 2. `Worker` — add `AgentDescriptor`
+
+- `private final AgentDescriptor agentDescriptor` — nullable
+- `Builder.agentDescriptor(AgentDescriptor)` — setter
+- `AgentDescriptor agentDescriptor()` — accessor
+- `boolean hasDescriptor()` — convenience, `return agentDescriptor != null`
+
+**Null semantics:** no descriptor = non-agent worker (pure Java function). Skip probe,
+assume capable. Non-agent workers are capable by construction.
+
+### 3. `NoOpCapabilityHealth`
+
+`@DefaultBean @ApplicationScoped` in `engine/internal/worker/`. Returns `Ready` for
+all probes. Deployments without eidos get transparent no-op — no filtering, no dependency.
+
+### 4. `WorkOrchestrator.buildCandidates()` — probe integration
+
+After capability match and workload check, for workers with descriptors:
+
+```java
+if (worker.hasDescriptor()) {
+    CapabilityStatus status = capabilityHealth.probe(
+        worker.agentDescriptor(),
+        capabilityName,
+        ProbeContext.of(null));  // no task domain metadata yet
+    // record status for sorting
+}
+```
+
+**Filtering rules:**
+- `Unavailable` → **hard filter** (remove from candidates). Log at WARN.
+- `EpistemicallyWeak` → **preference demotion** (sort last, not removed). Log at INFO.
+- `Degraded` → keep, sort after `Ready`. Log at DEBUG.
+- `Ready` → keep, sort first. Log at DEBUG.
+
+Candidates are returned as a preference-ordered list. If only `EpistemicallyWeak`
+candidates remain, they are still dispatched — weak is better than nothing.
+
+If all candidates are `Unavailable`, the list is empty → `WorkBroker.apply()` returns
+no selection → task not dispatched. This matches the existing "no workers match
+capability" path.
+
+### 5. ProbeContext limitation
+
+The engine does not currently have subject-domain metadata at dispatch time. `taskDomain`
+is passed as `null`, `taskMetadata` is empty. This means `EpistemicallyWeak` will not
+fire (epistemic domain keys like "java", "rust" won't match null). The filter becomes
+effective when the engine threads richer context through binding metadata or case context.
+
+## What doesn't change
+
+- `CaseContextChangedEventHandler` choreography path — probe only applies to
+  orchestrated dispatch via `WorkOrchestrator`
+- `WorkBroker` — receives pre-sorted candidates, unaware of health
+- `Agent` execution wrapper — no descriptor, no change
+- `HumanTaskScheduleHandler` — human tasks have no agent descriptor
+
+## Tests
+
+### `WorkerTest`
+- `hasDescriptor_withDescriptor_returnsTrue()`
+- `hasDescriptor_withoutDescriptor_returnsFalse()`
+- `agentDescriptor_accessor()`
+
+### `WorkOrchestratorTest`
+- `probe_unavailable_workerExcludedFromCandidates()` — inject recording
+  CapabilityHealth returning Unavailable for one worker; assert excluded
+- `probe_epistemicallyWeak_workerDemotedNotExcluded()` — weak candidate
+  still in list, sorted last
+- `probe_allUnavailable_emptyCandidateList()` — no candidates reach broker
+- `probe_noDescriptor_probeSkipped()` — non-agent worker passes through
+  without probing
+
+### `NoOpCapabilityHealthTest`
+- `probe_alwaysReturnsReady()`
+
+### `DefaultWorkerSpiImplementationsTest`
+- Add `NoOpCapabilityHealth` to beans table verification

--- a/ledger/src/test/java/io/casehub/ledger/CaseLedgerEventCaptureTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/CaseLedgerEventCaptureTest.java
@@ -321,14 +321,11 @@ class CaseLedgerEventCaptureTest {
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
-        .untilAsserted(
-            () -> {
-              final List<CaseLedgerEntry> entries = repository.findByCaseId(caseId);
-              assertThat(entries).hasSize(1);
-              assertThat(verificationService.verify(caseId))
-                  .as("Merkle chain must be intact after a single event")
-                  .isTrue();
-            });
+        .untilAsserted(() -> assertThat(repository.findByCaseId(caseId)).hasSize(1));
+
+    assertThat(verificationService.verify(caseId))
+        .as("Merkle chain must be intact after a single event")
+        .isTrue();
   }
 
   @Test
@@ -355,12 +352,10 @@ class CaseLedgerEventCaptureTest {
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
-        .untilAsserted(
-            () -> {
-              assertThat(repository.findByCaseId(caseId)).hasSize(3);
-              assertThat(verificationService.verify(caseId))
-                  .as("Merkle chain must be intact after three events")
-                  .isTrue();
-            });
+        .untilAsserted(() -> assertThat(repository.findByCaseId(caseId)).hasSize(3));
+
+    assertThat(verificationService.verify(caseId))
+        .as("Merkle chain must be intact after three events")
+        .isTrue();
   }
 }

--- a/ledger/src/test/resources/application.properties
+++ b/ledger/src/test/resources/application.properties
@@ -2,6 +2,10 @@
 quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.database.generation=none
 
+# Index casehub-ledger so Hibernate discovers LedgerEntry base entity (JOINED inheritance)
+quarkus.index-dependency.ledger.group-id=io.casehub
+quarkus.index-dependency.ledger.artifact-id=casehub-ledger
+
 # Flyway: run casehub-ledger migrations (V1000+) then our V2000
 quarkus.flyway.migrate-at-start=true
 quarkus.flyway.locations=db/ledger/migration,db/migration

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,11 @@
                 <version>${version.io.casehub}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>io.casehub</groupId>
+                <artifactId>casehub-eidos-api</artifactId>
+                <version>${version.io.casehub}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>casehub-engine-schema</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-eidos-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/runtime/src/main/java/io/casehub/engine/internal/orchestration/WorkOrchestrator.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/orchestration/WorkOrchestrator.java
@@ -26,6 +26,9 @@ import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
+import io.casehub.eidos.api.CapabilityHealth;
+import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
+import io.casehub.eidos.api.CapabilityHealth.ProbeContext;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkerScheduleEvent;
 import io.casehub.engine.internal.history.EventLog;
@@ -79,6 +82,7 @@ public class WorkOrchestrator {
   private final CaseInstanceRepository caseInstanceRepository;
   private final EventLogRepository eventLogRepository;
   private final JQEvaluator jqEvaluator;
+  private final CapabilityHealth capabilityHealth;
 
   @Inject
   public WorkOrchestrator(
@@ -90,7 +94,8 @@ public class WorkOrchestrator {
       CaseDefinitionRegistry caseDefinitionRegistry,
       CaseInstanceRepository caseInstanceRepository,
       EventLogRepository eventLogRepository,
-      JQEvaluator jqEvaluator) {
+      JQEvaluator jqEvaluator,
+      CapabilityHealth capabilityHealth) {
     this.workBroker = workBroker;
     this.selectionStrategy = selectionStrategy;
     this.workloadProvider = workloadProvider;
@@ -100,6 +105,7 @@ public class WorkOrchestrator {
     this.caseInstanceRepository = caseInstanceRepository;
     this.eventLogRepository = eventLogRepository;
     this.jqEvaluator = jqEvaluator;
+    this.capabilityHealth = capabilityHealth;
   }
 
   /**
@@ -244,11 +250,34 @@ public class WorkOrchestrator {
       }
       boolean hasCapability =
           worker.getCapabilities().stream().anyMatch(c -> c.getName().equals(capabilityName));
-      if (hasCapability) {
-        int workload = workloadProvider.getActiveWorkCount(worker.getName());
-        candidates.add(
-            new WorkerCandidate(worker.getName(), java.util.Set.of(capabilityName), workload));
+      if (!hasCapability) {
+        continue;
       }
+
+      if (worker.hasDescriptor()) {
+        CapabilityStatus status =
+            capabilityHealth.probe(worker.agentDescriptor(), capabilityName, ProbeContext.of(null));
+        if (status instanceof CapabilityStatus.Unavailable u) {
+          LOG.warnf(
+              "Worker '%s' unavailable for capability '%s': %s — excluded",
+              worker.getName(), capabilityName, u.reason());
+          continue;
+        }
+        if (status instanceof CapabilityStatus.EpistemicallyWeak ew) {
+          LOG.infof(
+              "Worker '%s' epistemically weak for '%s' (domain=%s, confidence=%.2f) — kept, preference demotion not yet implemented",
+              worker.getName(), capabilityName, ew.domain(), ew.confidence());
+        }
+        if (status instanceof CapabilityStatus.Degraded d) {
+          LOG.debugf(
+              "Worker '%s' degraded for '%s': %s — %s",
+              worker.getName(), capabilityName, d.reason(), d.detail());
+        }
+      }
+
+      int workload = workloadProvider.getActiveWorkCount(worker.getName());
+      candidates.add(
+          new WorkerCandidate(worker.getName(), java.util.Set.of(capabilityName), workload));
     }
     return candidates;
   }

--- a/runtime/src/main/java/io/casehub/engine/internal/worker/NoOpCapabilityHealth.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/worker/NoOpCapabilityHealth.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.worker;
+
+import io.casehub.eidos.api.AgentDescriptor;
+import io.casehub.eidos.api.CapabilityHealth;
+import io.quarkus.arc.DefaultBean;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@DefaultBean
+@ApplicationScoped
+public class NoOpCapabilityHealth implements CapabilityHealth {
+
+  @Override
+  public CapabilityStatus probe(
+      AgentDescriptor descriptor, String capabilityTag, ProbeContext context) {
+    return new CapabilityStatus.Ready();
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/orchestration/WorkOrchestratorTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/orchestration/WorkOrchestratorTest.java
@@ -29,6 +29,9 @@ import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.Worker;
+import io.casehub.eidos.api.AgentDescriptor;
+import io.casehub.eidos.api.CapabilityHealth;
+import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
 import io.casehub.engine.internal.engine.cache.CaseInstanceCacheImpl;
 import io.casehub.engine.internal.event.WorkerScheduleEvent;
 import io.casehub.engine.internal.jq.JQEvaluator;
@@ -41,6 +44,7 @@ import io.casehub.engine.spi.CaseInstanceRepository;
 import io.casehub.engine.spi.EventLogRepository;
 import io.casehub.engine.spi.cache.CaseInstanceCache;
 import io.casehub.work.api.AssignmentDecision;
+import io.casehub.work.api.WorkerCandidate;
 import io.casehub.work.api.WorkloadProvider;
 import io.casehub.work.core.strategy.LeastLoadedStrategy;
 import io.casehub.work.core.strategy.WorkBroker;
@@ -65,6 +69,7 @@ class WorkOrchestratorTest {
   private EventLogRepository eventLogRepository;
   private CaseInstanceCache cache;
   private JQEvaluator jqEvaluator;
+  private CapabilityHealth capabilityHealth;
   private WorkOrchestrator orchestrator;
 
   @BeforeEach
@@ -79,7 +84,10 @@ class WorkOrchestratorTest {
     eventLogRepository = mock(EventLogRepository.class);
     cache = new CaseInstanceCacheImpl();
     jqEvaluator = mock(JQEvaluator.class);
+    capabilityHealth = mock(CapabilityHealth.class);
 
+    when(capabilityHealth.probe(any(), any(), any()))
+        .thenReturn(new CapabilityHealth.CapabilityStatus.Ready());
     when(workloadProvider.getActiveWorkCount(any())).thenReturn(0);
     when(caseInstanceRepository.updateStateAndAppendEvent(any(), any()))
         .thenReturn(Uni.createFrom().voidItem());
@@ -101,7 +109,8 @@ class WorkOrchestratorTest {
             caseDefinitionRegistry,
             caseInstanceRepository,
             eventLogRepository,
-            jqEvaluator);
+            jqEvaluator,
+            capabilityHealth);
   }
 
   // ---- happy path -----------------------------------------------------------
@@ -172,7 +181,135 @@ class WorkOrchestratorTest {
     assertThat(future.isCompletedExceptionally()).isTrue();
   }
 
+  // ---- capability health probe -----------------------------------------------
+
+  private static final AgentDescriptor AGENT_DESCRIPTOR =
+      new AgentDescriptor(
+          "agent-1",
+          "TestAgent",
+          "1.0",
+          "openai",
+          "gpt-4",
+          "4-turbo",
+          null,
+          null,
+          null,
+          null,
+          "review",
+          List.of(),
+          null,
+          null,
+          null,
+          "casehubio");
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void probe_unavailable_workerExcludedFromCandidates() {
+    when(capabilityHealth.probe(any(), any(), any()))
+        .thenReturn(new CapabilityStatus.Unavailable("model offline"));
+    when(workBroker.apply(any(), any(), any(), any())).thenReturn(AssignmentDecision.noChange());
+
+    CaseInstance instance = runningInstanceWithAgentWorker("analyse");
+    cache.put(instance);
+
+    orchestrator.submit(instance, WorkRequest.of("analyse", Map.of())).toCompletableFuture();
+
+    org.mockito.ArgumentCaptor<List<WorkerCandidate>> captor =
+        org.mockito.ArgumentCaptor.forClass(List.class);
+    verify(workBroker).apply(any(), any(), captor.capture(), any());
+    assertThat(captor.getValue()).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void probe_epistemicallyWeak_workerKeptInCandidates() {
+    when(capabilityHealth.probe(any(), any(), any()))
+        .thenReturn(new CapabilityStatus.EpistemicallyWeak("rust", 0.25));
+    when(workBroker.apply(any(), any(), any(), any()))
+        .thenReturn(AssignmentDecision.assignTo("agent-worker"));
+
+    CaseInstance instance = runningInstanceWithAgentWorker("analyse");
+    cache.put(instance);
+
+    orchestrator.submit(instance, WorkRequest.of("analyse", Map.of()));
+
+    org.mockito.ArgumentCaptor<List<WorkerCandidate>> captor =
+        org.mockito.ArgumentCaptor.forClass(List.class);
+    verify(workBroker).apply(any(), any(), captor.capture(), any());
+    assertThat(captor.getValue()).hasSize(1);
+    assertThat(captor.getValue().get(0).id()).isEqualTo("agent-worker");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void probe_allUnavailable_emptyCandidateList() {
+    when(capabilityHealth.probe(any(), any(), any()))
+        .thenReturn(new CapabilityStatus.Unavailable("all offline"));
+    when(workBroker.apply(any(), any(), any(), any())).thenReturn(AssignmentDecision.noChange());
+
+    CaseInstance instance = runningInstanceWithAgentWorker("analyse");
+    cache.put(instance);
+
+    orchestrator.submit(instance, WorkRequest.of("analyse", Map.of())).toCompletableFuture();
+
+    org.mockito.ArgumentCaptor<List<WorkerCandidate>> captor =
+        org.mockito.ArgumentCaptor.forClass(List.class);
+    verify(workBroker).apply(any(), any(), captor.capture(), any());
+    assertThat(captor.getValue()).isEmpty();
+  }
+
+  @Test
+  void probe_noDescriptor_probeSkipped() {
+    CaseInstance instance = runningInstance("analyse");
+    cache.put(instance);
+    when(workBroker.apply(any(), any(), any(), any()))
+        .thenReturn(AssignmentDecision.assignTo("analyst-worker"));
+
+    orchestrator.submit(instance, WorkRequest.of("analyse", Map.of()));
+
+    verify(capabilityHealth, never()).probe(any(), any(), any());
+  }
+
   // ---- helper ---------------------------------------------------------------
+
+  private CaseInstance runningInstanceWithAgentWorker(String capabilityName) {
+    Capability capability =
+        Capability.builder()
+            .name(capabilityName)
+            .inputSchema("{ doc: .doc }")
+            .outputSchema("{ result: .result }")
+            .build();
+
+    Worker worker =
+        Worker.builder()
+            .name("agent-worker")
+            .capabilities(capability)
+            .function(input -> Map.of("result", "done"))
+            .agentDescriptor(AGENT_DESCRIPTOR)
+            .build();
+
+    CaseDefinition definition =
+        CaseDefinition.builder()
+            .namespace("test-orch")
+            .name("Orchestration Test Case")
+            .version("1.0.0")
+            .capabilities(capability)
+            .workers(worker)
+            .build();
+
+    CaseMetaModel metaModel = mock(CaseMetaModel.class);
+    when(caseDefinitionRegistry.getCaseDefinition(metaModel)).thenReturn(definition);
+
+    CaseInstance instance = new CaseInstance();
+    instance.setUuid(UUID.randomUUID());
+    instance.setState(CaseStatus.RUNNING);
+    instance.setCaseMetaModel(metaModel);
+    CaseContext ctx = mock(CaseContext.class);
+    when(ctx.asJsonNode())
+        .thenReturn(new com.fasterxml.jackson.databind.ObjectMapper().createObjectNode());
+    instance.setCaseContext(ctx);
+    return instance;
+  }
 
   private CaseInstance runningInstance(String capabilityName) {
     Capability capability =

--- a/runtime/src/test/java/io/casehub/engine/internal/worker/NoOpCapabilityHealthTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/worker/NoOpCapabilityHealthTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.eidos.api.AgentDescriptor;
+import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
+import io.casehub.eidos.api.CapabilityHealth.ProbeContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NoOpCapabilityHealthTest {
+
+  @Test
+  void probe_alwaysReturnsReady() {
+    NoOpCapabilityHealth health = new NoOpCapabilityHealth();
+    AgentDescriptor descriptor =
+        new AgentDescriptor(
+            "agent-1",
+            "Test",
+            "1.0",
+            "openai",
+            "gpt-4",
+            "4-turbo",
+            null,
+            null,
+            null,
+            null,
+            "review",
+            List.of(),
+            null,
+            null,
+            null,
+            "casehubio");
+
+    CapabilityStatus status = health.probe(descriptor, "code-review", ProbeContext.of(null));
+
+    assertThat(status).isInstanceOf(CapabilityStatus.Ready.class);
+  }
+}


### PR DESCRIPTION
## Summary

- **fix(ledger-test)**: index `casehub-ledger` for `LedgerEntry` entity discovery + separate async wait from merkle verification  
- **feat(spi)**: CapabilityHealth.probe() integration (engine#341) + NoOpCapabilityHealth @DefaultBean
- **docs**: CLAUDE.md updates for new SPI no-ops