### PR TITLE
fix(ledger-test): restore merkle tests with proper frontier repo

### DIFF
--- a/ledger/pom.xml
+++ b/ledger/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-ledger-memory</artifactId>
+            <version>${version.io.casehub.ledger}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ledger/src/test/java/io/casehub/ledger/CaseLedgerEventCaptureTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/CaseLedgerEventCaptureTest.java
@@ -21,6 +21,7 @@ import io.casehub.engine.internal.event.CaseLifecycleEvent;
 import io.casehub.ledger.api.model.LedgerEntryType;
 import io.casehub.ledger.model.CaseLedgerEntry;
 import io.casehub.ledger.repository.CaseLedgerEntryRepository;
+import io.casehub.ledger.runtime.service.LedgerVerificationService;
 import io.casehub.platform.api.identity.ActorType;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.event.Event;
@@ -45,6 +46,7 @@ class CaseLedgerEventCaptureTest {
 
   @Inject CaseLedgerEntryRepository repository;
 
+  @Inject LedgerVerificationService verificationService;
 
   @Test
   void happyPath_singleEvent_writesLedgerEntry() {
@@ -305,4 +307,55 @@ class CaseLedgerEventCaptureTest {
             });
   }
 
+  // ── Correctness: Merkle chain integrity ────────────────────────────────────
+
+  @Test
+  void merkleChain_singleEntry_verifies() {
+    final UUID caseId = UUID.randomUUID();
+
+    lifecycleEvents
+        .fireAsync(
+            new CaseLifecycleEvent(caseId, "StartCase", "CaseStarted", "RUNNING", null, "System"))
+        .toCompletableFuture()
+        .join();
+
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(repository.findByCaseId(caseId)).hasSize(1));
+
+    assertThat(verificationService.verify(caseId))
+        .as("Merkle chain must be intact after a single event")
+        .isTrue();
+  }
+
+  @Test
+  void merkleChain_multipleEntries_verifies() {
+    final UUID caseId = UUID.randomUUID();
+
+    lifecycleEvents
+        .fireAsync(
+            new CaseLifecycleEvent(caseId, "StartCase", "CaseStarted", "RUNNING", null, "System"))
+        .toCompletableFuture()
+        .join();
+    lifecycleEvents
+        .fireAsync(
+            new CaseLifecycleEvent(
+                caseId, "SuspendCase", "CaseSuspended", "SUSPENDED", null, "System"))
+        .toCompletableFuture()
+        .join();
+    lifecycleEvents
+        .fireAsync(
+            new CaseLifecycleEvent(
+                caseId, "CompleteCase", "CaseCompleted", "COMPLETED", null, "System"))
+        .toCompletableFuture()
+        .join();
+
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(repository.findByCaseId(caseId)).hasSize(3));
+
+    assertThat(verificationService.verify(caseId))
+        .as("Merkle chain must be intact after three events")
+        .isTrue();
+  }
 }

--- a/ledger/src/test/resources/application.properties
+++ b/ledger/src/test/resources/application.properties
@@ -5,6 +5,10 @@ quarkus.hibernate-orm.database.generation=none
 # Index casehub-ledger so Hibernate discovers LedgerEntry base entity (JOINED inheritance)
 quarkus.index-dependency.ledger.group-id=io.casehub
 quarkus.index-dependency.ledger.artifact-id=casehub-ledger
+quarkus.index-dependency.ledger-memory.group-id=io.casehub
+quarkus.index-dependency.ledger-memory.artifact-id=casehub-ledger-memory
+
+quarkus.arc.selected-alternatives=io.casehub.ledger.memory.InMemoryLedgerMerkleFrontierRepository
 
 # Flyway: run casehub-ledger migrations (V1000+) then our V2000
 quarkus.flyway.migrate-at-start=true


### PR DESCRIPTION
Add casehub-ledger-memory test dep for InMemoryLedgerMerkleFrontierRepository. Merkle chain tests now pass — 14/14 green locally.