### PR TITLE
fix: engine correctness batch — #342 #331 #248 #338

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,11 @@ TESTCONTAINERS_RYUK_DISABLED=true mvn clean test -pl casehub-blackboard
   per handler that uses `eventBus.publish()` + `await()` to confirm `@ConsumeEvent` routing.
   See `HumanTaskScheduleHandlerTest` (engine#290).
 
+**Key blackboard handlers:**
+- `PlanItemCompletionHandler` — marks PlanItems COMPLETED on `WORKER_EXECUTION_FINISHED` and `SUBCASE_EXECUTION_COMPLETED`; delegates stage autocomplete to `StageAutocompleteEvaluator`
+- `WorkerRetryExhaustionHandler` — marks CapabilityTarget PlanItems FAULTED on `WORKER_RETRIES_EXHAUSTED` (both guard-blocked and Quartz-exhausted paths); delegates stage autocomplete to `StageAutocompleteEvaluator`. Refs engine#331.
+- `StageAutocompleteEvaluator` — evaluates stage autocomplete after any PlanItem terminal transition; fires `STAGE_COMPLETED` when all required items are terminal (COMPLETED, REJECTED, FAULTED, or CANCELLED). See ADR-0002 for the semantic decision on FAULTED/REJECTED triggering autocomplete.
+
 ## Quartz
 
 Use RAM store — no JDBC store, no Quartz tables:
@@ -262,7 +267,7 @@ Activated by adding `casehub-engine-work-adapter` to the consumer's classpath (t
 **YAML DSL:** `humanTask` is a first-class binding target type in `CaseDefinition.yaml` (alongside `capability` and `subCase`). `CaseDefinitionYamlMapper` converts it to `HumanTaskTarget`. Inline mode requires `title`; template mode requires `templateRef`. Both modes support `outputMapping`, `inputMapping`, `candidateGroups`, `candidateUsers`, `expiresIn`, and `scope` (hierarchical path for SLA preference resolution, e.g. `"casehubio/devtown/pr-review"`).
 
 Two-way bridge between casehub-work and CaseHub plan items:
-- **Inbound** (`WorkItemLifecycleAdapter`) — translates `WorkItemLifecycleEvent` CDI events (COMPLETED, REJECTED, CANCELLED, EXPIRED — not ESCALATED, which is non-terminal) to `PlanItem` transitions, evaluates `outputMapping` against the WorkItem resolution JSON, and fires `CONTEXT_CHANGED` for engine re-evaluation. Also observes `WorkItemGroupLifecycleEvent` for M-of-N SpawnGroup outcomes (COMPLETED → `PlanItem.markCompleted()`; REJECTED → `PlanItem.markFaulted()`). ESCALATED is intentionally excluded — the WorkItem re-enters PENDING with new candidate groups; the PlanItem stays in its current state until the WorkItem reaches a true terminal status.
+- **Inbound** (`WorkItemLifecycleAdapter`) — translates `WorkItemLifecycleEvent` CDI events (COMPLETED, REJECTED, CANCELLED, EXPIRED — not ESCALATED, which is non-terminal) to `PlanItem` transitions, evaluates `outputMapping` against the WorkItem resolution JSON, and fires `CONTEXT_CHANGED` for engine re-evaluation. Terminal status mapping: COMPLETED → `markCompleted()`; REJECTED → `markRejected()` (intentional human refusal — PlanItem must be DELEGATED); EXPIRED → `markFaulted()` (deadline failure); CANCELLED → `markCancelled()`. Also observes `WorkItemGroupLifecycleEvent` for M-of-N SpawnGroup outcomes (COMPLETED → `PlanItem.markCompleted()`; REJECTED → `PlanItem.markRejected()`). ESCALATED is intentionally excluded — the WorkItem re-enters PENDING with new candidate groups; the PlanItem stays in its current state until the WorkItem reaches a true terminal status. Refs engine#338.
 - **Outbound** (`HumanTaskScheduleHandler`) — consumes `HUMAN_TASK_SCHEDULE` event bus messages, looks up the `PlanItem` by binding name, then:
   - **Inline mode** (`HumanTaskTarget.inline()`): creates a `WorkItem` via `WorkItemService`, then `planItemStore.save(DELEGATED)`, then `item.markDelegated()`
   - **Template mode** (`HumanTaskTarget.template(ref)`): parses `ref` as UUID and resolves via `WorkItemTemplateService.findById`; invalid UUID or not-found → warn + leave PlanItem PENDING; on success calls `WorkItemTemplateService.instantiate(template, titleOverride, assigneeId, createdBy)` with `target.title()` as titleOverride, `null` as assigneeId, and `"casehub-engine"` as createdBy, then manually sets `workItem.callerRef`, `workItem.scope`, and `workItem.payload` (serialized `inputData`, honours `inputMapping` contract), persists with `workItem.persist()`, then `planItemStore.save(DELEGATED)`, then `item.markDelegated()`

--- a/blackboard/src/main/java/io/casehub/blackboard/event/PlanItemCompletedEvent.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/event/PlanItemCompletedEvent.java
@@ -18,9 +18,13 @@ package io.casehub.blackboard.event;
 import java.util.UUID;
 
 /**
- * CDI event fired after a {@link io.casehub.blackboard.plan.PlanItem} is marked COMPLETED in the
- * BlackboardRegistry. Fired via {@code Event.fireAsync()} from {@link
+ * CDI event fired after a {@link io.casehub.blackboard.plan.PlanItem} is marked {@code COMPLETED}
+ * (successful outcome only). Fired via {@code Event.fireAsync()} from {@link
  * io.casehub.blackboard.handler.PlanItemCompletionHandler}.
+ *
+ * <p><strong>Contract:</strong> This event fires only on {@code COMPLETED} terminal state. Faulted,
+ * rejected, and cancelled PlanItems do NOT emit this event — observers must not assume every
+ * terminal transition produces one.
  *
  * <p>By the time observers receive this event, the specific {@code planItemId} is guaranteed to
  * have COMPLETED status in the registry — no polling required.

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemCompletionHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemCompletionHandler.java
@@ -17,12 +17,10 @@ package io.casehub.blackboard.handler;
 
 import io.casehub.blackboard.event.BlackboardEventBusAddresses;
 import io.casehub.blackboard.event.PlanItemCompletedEvent;
-import io.casehub.blackboard.event.StageCompletedEvent;
 import io.casehub.blackboard.event.SubCaseExecutionCompleted;
 import io.casehub.blackboard.plan.CasePlanModel;
 import io.casehub.blackboard.plan.PlanItem;
 import io.casehub.blackboard.registry.BlackboardRegistry;
-import io.casehub.blackboard.stage.Stage;
 import io.casehub.engine.internal.event.EventBusAddresses;
 import io.casehub.engine.internal.event.WorkflowExecutionCompleted;
 import io.casehub.engine.internal.model.PlanItemStatus;
@@ -64,15 +62,18 @@ public class PlanItemCompletionHandler {
   private final BlackboardRegistry registry;
   private final EventBus eventBus;
   private final Event<PlanItemCompletedEvent> planItemCompletedEvents;
+  private final StageAutocompleteEvaluator stageAutocompleteEvaluator;
 
   @Inject
   public PlanItemCompletionHandler(
       BlackboardRegistry registry,
       EventBus eventBus,
-      Event<PlanItemCompletedEvent> planItemCompletedEvents) {
+      Event<PlanItemCompletedEvent> planItemCompletedEvents,
+      StageAutocompleteEvaluator stageAutocompleteEvaluator) {
     this.registry = registry;
     this.eventBus = eventBus;
     this.planItemCompletedEvents = planItemCompletedEvents;
+    this.stageAutocompleteEvaluator = stageAutocompleteEvaluator;
   }
 
   @ConsumeEvent(EventBusAddresses.WORKER_EXECUTION_FINISHED)
@@ -109,34 +110,12 @@ public class PlanItemCompletionHandler {
               item.markCompleted();
               // activeByBinding self-cleans lazily in hasActivePlanItem() — completed items remain
               // in itemsById for post-completion observability.
-              evaluateStageAutocomplete(caseId, plan, planItemId);
+              stageAutocompleteEvaluator.evaluate(caseId, plan, planItemId);
               // Fire after markCompleted() so observers see the exact planItemId that completed.
               planItemCompletedEvents.fireAsync(
                   new PlanItemCompletedEvent(caseId, planItemId, trackingKey));
             });
 
     return Uni.createFrom().voidItem();
-  }
-
-  private void evaluateStageAutocomplete(UUID caseId, CasePlanModel plan, String completedItemId) {
-    for (Stage stage : plan.getActiveStages()) {
-      if (!stage.isAutocomplete()) continue;
-      if (!stage.getRequiredItemIds().contains(completedItemId)) continue;
-
-      boolean allDone =
-          stage.getRequiredItemIds().stream()
-              .allMatch(
-                  itemId ->
-                      plan.getPlanItem(itemId)
-                          .map(pi -> pi.getStatus() == PlanItemStatus.COMPLETED)
-                          .orElse(
-                              false)); // unregistered item — treat as not done, blocks autocomplete
-
-      if (allDone) {
-        stage.complete();
-        eventBus.publish(
-            BlackboardEventBusAddresses.STAGE_COMPLETED, new StageCompletedEvent(caseId, stage));
-      }
-    }
   }
 }

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/StageAutocompleteEvaluator.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/StageAutocompleteEvaluator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import io.casehub.blackboard.event.BlackboardEventBusAddresses;
+import io.casehub.blackboard.event.StageCompletedEvent;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.stage.Stage;
+import io.casehub.engine.internal.model.PlanItemStatus;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+
+/**
+ * Evaluates stage autocomplete after a PlanItem reaches a terminal state.
+ *
+ * <p>A stage autocompletes when all its required items have settled — reached any terminal state
+ * (COMPLETED, REJECTED, FAULTED, CANCELLED). The outcome is the business concern of the case
+ * definition; the engine's job is to propagate the stage-concluded signal.
+ *
+ * <p>Shared by {@link PlanItemCompletionHandler} and {@link WorkerRetryExhaustionHandler}.
+ * Extracted to avoid duplicating the isTerminal() logic and to keep both handlers in sync on future
+ * changes. See ADR-0002.
+ */
+@ApplicationScoped
+public class StageAutocompleteEvaluator {
+
+  private static final Logger LOG = Logger.getLogger(StageAutocompleteEvaluator.class);
+
+  private final EventBus eventBus;
+
+  @Inject
+  public StageAutocompleteEvaluator(final EventBus eventBus) {
+    this.eventBus = eventBus;
+  }
+
+  /**
+   * Checks all active autocomplete stages in the plan. For each stage that contains {@code
+   * changedItemId} as a required item, fires stage completion if all required items are terminal.
+   */
+  public void evaluate(final UUID caseId, final CasePlanModel plan, final String changedItemId) {
+    for (final Stage stage : plan.getActiveStages()) {
+      if (!stage.isAutocomplete()) continue;
+      if (!stage.getRequiredItemIds().contains(changedItemId)) continue;
+
+      final boolean allTerminal =
+          stage.getRequiredItemIds().stream()
+              .allMatch(
+                  itemId ->
+                      plan.getPlanItem(itemId).map(pi -> isTerminal(pi.getStatus())).orElse(false));
+
+      if (allTerminal) {
+        stage.complete();
+        eventBus.publish(
+            BlackboardEventBusAddresses.STAGE_COMPLETED, new StageCompletedEvent(caseId, stage));
+        LOG.debugf(
+            "Stage autocomplete fired for caseId=%s after item=%s settled", caseId, changedItemId);
+      }
+    }
+  }
+
+  public static boolean isTerminal(final PlanItemStatus status) {
+    return status == PlanItemStatus.COMPLETED
+        || status == PlanItemStatus.REJECTED
+        || status == PlanItemStatus.FAULTED
+        || status == PlanItemStatus.CANCELLED;
+  }
+}

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/WorkerRetryExhaustionHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/WorkerRetryExhaustionHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
+import io.casehub.engine.internal.model.PlanItemStatus;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+/**
+ * Marks a CapabilityTarget PlanItem FAULTED when its Quartz worker exhausts all retries or is
+ * blocked by the execution guard.
+ *
+ * <p>Listens to {@code WORKER_RETRIES_EXHAUSTED} — the same event published by both {@link
+ * io.casehub.engine.internal.engine.handler.WorkerScheduleEventHandler} (guard-blocked path) and
+ * {@link io.casehub.engine.scheduler.quartz.QuartzWorkerExecutionJobListener} (retry-exhausted
+ * path). Both fire-sites use {@code worker.getName()} as the {@code workerId} field, which equals
+ * the tracking key stored by {@link BlackboardRegistry#indexForCompletion}.
+ *
+ * <p>Without this handler, a RUNNING PlanItem stays active indefinitely after exhaustion, blocking
+ * re-triggering, stage autocomplete, and {@code PlanItemCompletedEvent} delivery.
+ *
+ * <p>Refs engine#331, engine#369.
+ */
+@ApplicationScoped
+public class WorkerRetryExhaustionHandler {
+
+  private static final Logger LOG = Logger.getLogger(WorkerRetryExhaustionHandler.class);
+
+  private final BlackboardRegistry registry;
+  private final StageAutocompleteEvaluator stageAutocompleteEvaluator;
+
+  @Inject
+  public WorkerRetryExhaustionHandler(
+      final BlackboardRegistry registry,
+      final StageAutocompleteEvaluator stageAutocompleteEvaluator) {
+    this.registry = registry;
+    this.stageAutocompleteEvaluator = stageAutocompleteEvaluator;
+  }
+
+  @ConsumeEvent(EventBusAddresses.WORKER_RETRIES_EXHAUSTED)
+  public Uni<Void> onWorkerRetriesExhausted(final WorkerRetriesExhaustedEvent event) {
+    final CasePlanModel plan = registry.get(event.caseId()).orElse(null);
+    if (plan == null) return Uni.createFrom().voidItem();
+
+    final String planItemId = registry.getPlanItemId(event.caseId(), event.workerId()).orElse(null);
+    if (planItemId == null) {
+      LOG.debugf(
+          "No PlanItem indexed for worker '%s' in case %s — guard-blocked or already evicted",
+          event.workerId(), event.caseId());
+      return Uni.createFrom().voidItem();
+    }
+
+    plan.getPlanItem(planItemId)
+        .ifPresent(
+            item -> {
+              if (item.getStatus() != PlanItemStatus.RUNNING) {
+                LOG.debugf(
+                    "PlanItem %s for worker '%s' in case %s has status %s — not RUNNING, skipping",
+                    planItemId, event.workerId(), event.caseId(), item.getStatus());
+                return;
+              }
+              item.markFaulted();
+              stageAutocompleteEvaluator.evaluate(event.caseId(), plan, planItemId);
+              LOG.warnf(
+                  "PlanItem %s marked FAULTED — worker '%s' retries exhausted in case %s",
+                  planItemId, event.workerId(), event.caseId());
+            });
+
+    return Uni.createFrom().voidItem();
+  }
+}

--- a/blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java
@@ -122,6 +122,7 @@ public class PlanItem implements Comparable<PlanItem> {
   public void markFaulted() {
     if (status == PlanItemStatus.COMPLETED
         || status == PlanItemStatus.FAULTED
+        || status == PlanItemStatus.REJECTED
         || status == PlanItemStatus.CANCELLED) {
       throw new IllegalStateException(
           "Cannot fault a terminal PlanItem (status="
@@ -133,10 +134,28 @@ public class PlanItem implements Comparable<PlanItem> {
     status = PlanItemStatus.FAULTED;
   }
 
+  /**
+   * Transitions DELEGATED → REJECTED.
+   *
+   * <p>DELEGATED-only: only human task refusals ({@code WorkItemStatus.REJECTED}) and M-of-N group
+   * threshold failures ({@code GroupStatus.REJECTED} on human task SpawnGroups) reach this path.
+   * CapabilityTarget PlanItems are always RUNNING — they fault via retry exhaustion, never via
+   * rejection. If a group-of-capability-targets path is added in future, this guard must be
+   * revisited to allow RUNNING → REJECTED.
+   */
+  public void markRejected() {
+    if (status != PlanItemStatus.DELEGATED) {
+      throw new IllegalStateException(
+          "Cannot transition to REJECTED from " + status + " (planItemId=" + planItemId + ")");
+    }
+    status = PlanItemStatus.REJECTED;
+  }
+
   /** Cancels from PENDING, RUNNING, or DELEGATED. Throws if already terminal. */
   public void markCancelled() {
     if (status == PlanItemStatus.COMPLETED
         || status == PlanItemStatus.FAULTED
+        || status == PlanItemStatus.REJECTED
         || status == PlanItemStatus.CANCELLED) {
       throw new IllegalStateException(
           "Cannot cancel a terminal PlanItem (status="

--- a/blackboard/src/main/java/io/casehub/blackboard/subcase/SubCaseCompletionService.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/subcase/SubCaseCompletionService.java
@@ -272,6 +272,11 @@ public class SubCaseCompletionService {
    * Cancels the SubCase PlanItem in the BlackboardRegistry when a grouped SubCase group is REJECTED
    * (threshold unreachable). Called before the parent case is cancelled and the registry is
    * evicted, so the terminal state is observable for the eviction window.
+   *
+   * <p>Uses {@code markCancelled()} rather than {@code markRejected()} intentionally: the PlanItem
+   * is being administratively stopped as part of case cancellation, not because an external actor
+   * refused it. The group's child SubCases may have faulted or been cancelled — the group threshold
+   * being unreachable is a structural failure, not a refusal. {@code CANCELLED} is correct here.
    */
   void cancelPlanItemOnRejected(UUID parentCaseId, UUID childCaseId) {
     registry
@@ -282,6 +287,7 @@ public class SubCaseCompletionService {
             pi ->
                 pi.getStatus() != PlanItemStatus.COMPLETED
                     && pi.getStatus() != PlanItemStatus.FAULTED
+                    && pi.getStatus() != PlanItemStatus.REJECTED
                     && pi.getStatus() != PlanItemStatus.CANCELLED)
         .ifPresent(pi -> pi.markCancelled());
   }

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
@@ -57,7 +57,10 @@ class PlanItemCompletionHandlerTest {
     mockBus = mock(EventBus.class);
     handler =
         new PlanItemCompletionHandler(
-            registry, mockBus, mock(jakarta.enterprise.event.Event.class));
+            registry,
+            mockBus,
+            mock(jakarta.enterprise.event.Event.class),
+            new StageAutocompleteEvaluator(mockBus));
     caseId = UUID.randomUUID();
     plan = (DefaultCasePlanModel) registry.getOrCreate(caseId);
   }

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/StageAutocompleteEvaluatorTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/StageAutocompleteEvaluatorTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.casehub.blackboard.event.StageCompletedEvent;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.stage.Stage;
+import io.casehub.engine.internal.model.PlanItemStatus;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for StageAutocompleteEvaluator. Covers the terminal-state gate: a stage autocompletes
+ * when all required items have reached any terminal state.
+ *
+ * <p>Refs engine#338, ADR-0002.
+ */
+class StageAutocompleteEvaluatorTest {
+
+  private StageAutocompleteEvaluator evaluator;
+  private EventBus eventBus;
+
+  @BeforeEach
+  void setUp() {
+    eventBus = mock(EventBus.class);
+    evaluator = new StageAutocompleteEvaluator(eventBus);
+  }
+
+  // --- autocomplete DOES fire ---
+
+  @Test
+  void all_completed_triggers_autocomplete() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = planWith("item-1", PlanItemStatus.COMPLETED);
+    Stage stage = autocompleteStage("item-1");
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage).complete();
+    verify(eventBus)
+        .publish(
+            io.casehub.blackboard.event.BlackboardEventBusAddresses.STAGE_COMPLETED,
+            new StageCompletedEvent(caseId, stage));
+  }
+
+  @Test
+  void all_rejected_triggers_autocomplete() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = planWith("item-1", PlanItemStatus.REJECTED);
+    Stage stage = autocompleteStage("item-1");
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage).complete();
+  }
+
+  @Test
+  void all_faulted_triggers_autocomplete() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = planWith("item-1", PlanItemStatus.FAULTED);
+    Stage stage = autocompleteStage("item-1");
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage).complete();
+  }
+
+  @Test
+  void all_cancelled_triggers_autocomplete() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = planWith("item-1", PlanItemStatus.CANCELLED);
+    Stage stage = autocompleteStage("item-1");
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage).complete();
+  }
+
+  @Test
+  void mixed_terminal_states_triggers_autocomplete() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = mock(CasePlanModel.class);
+    PlanItem item1 = itemWithStatus("item-1", PlanItemStatus.COMPLETED);
+    PlanItem item2 = itemWithStatus("item-2", PlanItemStatus.REJECTED);
+    PlanItem item3 = itemWithStatus("item-3", PlanItemStatus.FAULTED);
+    when(plan.getPlanItem("item-1")).thenReturn(Optional.of(item1));
+    when(plan.getPlanItem("item-2")).thenReturn(Optional.of(item2));
+    when(plan.getPlanItem("item-3")).thenReturn(Optional.of(item3));
+    Stage stage = autocompleteStage("item-1", "item-2", "item-3");
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage).complete();
+  }
+
+  // --- autocomplete does NOT fire ---
+
+  @Test
+  void non_terminal_item_blocks_autocomplete() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = mock(CasePlanModel.class);
+    PlanItem item1 = itemWithStatus("item-1", PlanItemStatus.COMPLETED);
+    PlanItem item2 = itemWithStatus("item-2", PlanItemStatus.RUNNING);
+    when(plan.getPlanItem("item-1")).thenReturn(Optional.of(item1));
+    when(plan.getPlanItem("item-2")).thenReturn(Optional.of(item2));
+    Stage stage = autocompleteStage("item-1", "item-2");
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage, never()).complete();
+  }
+
+  @Test
+  void delegated_item_blocks_autocomplete() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = mock(CasePlanModel.class);
+    PlanItem item1 = itemWithStatus("item-1", PlanItemStatus.COMPLETED);
+    PlanItem item2 = itemWithStatus("item-2", PlanItemStatus.DELEGATED);
+    when(plan.getPlanItem("item-1")).thenReturn(Optional.of(item1));
+    when(plan.getPlanItem("item-2")).thenReturn(Optional.of(item2));
+    Stage stage = autocompleteStage("item-1", "item-2");
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage, never()).complete();
+  }
+
+  @Test
+  void non_autocomplete_stage_never_fires() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = planWith("item-1", PlanItemStatus.COMPLETED);
+    Stage stage = mock(Stage.class);
+    when(stage.isAutocomplete()).thenReturn(false);
+    when(stage.getRequiredItemIds()).thenReturn(List.of("item-1"));
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage, never()).complete();
+  }
+
+  @Test
+  void stage_not_containing_changed_item_is_skipped() {
+    UUID caseId = UUID.randomUUID();
+    CasePlanModel plan = planWith("item-1", PlanItemStatus.COMPLETED);
+    Stage stage = autocompleteStage("item-99"); // different item
+    when(plan.getActiveStages()).thenReturn(List.of(stage));
+
+    evaluator.evaluate(caseId, plan, "item-1");
+
+    verify(stage, never()).complete();
+  }
+
+  // --- helpers ---
+
+  private CasePlanModel planWith(String itemId, PlanItemStatus status) {
+    CasePlanModel plan = mock(CasePlanModel.class);
+    PlanItem item = itemWithStatus(itemId, status);
+    when(plan.getPlanItem(itemId)).thenReturn(Optional.of(item));
+    return plan;
+  }
+
+  private PlanItem itemWithStatus(String itemId, PlanItemStatus status) {
+    PlanItem item = mock(PlanItem.class);
+    when(item.getStatus()).thenReturn(status);
+    return item;
+  }
+
+  private Stage autocompleteStage(String... requiredIds) {
+    Stage stage = mock(Stage.class);
+    when(stage.isAutocomplete()).thenReturn(true);
+    when(stage.getRequiredItemIds()).thenReturn(List.of(requiredIds));
+    return stage;
+  }
+}

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/WorkerRetryExhaustionHandlerTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/WorkerRetryExhaustionHandlerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.casehub.blackboard.plan.DefaultCasePlanModel;
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
+import io.casehub.engine.internal.model.PlanItemStatus;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for WorkerRetryExhaustionHandler.
+ *
+ * <p>Proves: RUNNING PlanItem is marked FAULTED when its worker exhausts retries; workerId on the
+ * event equals the tracking key in BlackboardRegistry (the invariant is documented in the spec).
+ * Refs engine#331, engine#369.
+ */
+class WorkerRetryExhaustionHandlerTest {
+
+  private BlackboardRegistry registry;
+  private EventBus eventBus;
+  private WorkerRetryExhaustionHandler handler;
+  private UUID caseId;
+  private DefaultCasePlanModel plan;
+
+  @BeforeEach
+  void setUp() {
+    registry = new BlackboardRegistry();
+    eventBus = mock(EventBus.class);
+    handler = new WorkerRetryExhaustionHandler(registry, new StageAutocompleteEvaluator(eventBus));
+    caseId = UUID.randomUUID();
+    plan = (DefaultCasePlanModel) registry.getOrCreate(caseId);
+  }
+
+  @Test
+  void running_planItem_is_marked_faulted_on_retries_exhausted() {
+    PlanItem item = PlanItem.create("capability-binding", "worker-a", 0);
+    plan.addPlanItem(item);
+    item.markRunning();
+    registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler
+        .onWorkerRetriesExhausted(new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123"))
+        .await()
+        .indefinitely();
+
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED);
+  }
+
+  @Test
+  void unknown_case_is_a_noop() {
+    handler
+        .onWorkerRetriesExhausted(
+            new WorkerRetriesExhaustedEvent(UUID.randomUUID(), "worker-x", "hash"))
+        .await()
+        .indefinitely();
+    // no exception
+  }
+
+  @Test
+  void unknown_worker_is_a_noop() {
+    handler
+        .onWorkerRetriesExhausted(new WorkerRetriesExhaustedEvent(caseId, "unknown-worker", "hash"))
+        .await()
+        .indefinitely();
+    // no exception
+  }
+
+  @Test
+  void already_faulted_planItem_is_not_double_transitioned() {
+    PlanItem item = PlanItem.create("capability-binding", "worker-a", 0);
+    plan.addPlanItem(item);
+    item.markRunning();
+    item.markFaulted(); // already terminal
+    registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler
+        .onWorkerRetriesExhausted(new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123"))
+        .await()
+        .indefinitely();
+
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED); // unchanged, no throw
+  }
+
+  @Test
+  void pending_planItem_is_not_transitioned() {
+    // Guard-blocked path fires WORKER_RETRIES_EXHAUSTED before the job is submitted.
+    // The PlanItem may still be PENDING if indexing happened before the guard check.
+    PlanItem item = PlanItem.create("capability-binding", "worker-a", 0);
+    plan.addPlanItem(item);
+    // PENDING — no markRunning()
+    registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler
+        .onWorkerRetriesExhausted(new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123"))
+        .await()
+        .indefinitely();
+
+    // PENDING is not RUNNING — handler must not transition it (guard fires before plan item
+    // indexing in the guard-blocked path, so lookup returns empty; this tests a theoretical edge)
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.PENDING);
+  }
+}

--- a/blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java
@@ -187,4 +187,49 @@ class PlanItemTest {
     item.markFaulted();
     assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED);
   }
+
+  // --- REJECTED state ---
+
+  @Test
+  void markRejected_from_delegated_transitions_to_rejected() {
+    PlanItem item = PlanItem.create("binding-a", "unknown", 0);
+    item.markDelegated();
+    item.markRejected();
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.REJECTED);
+  }
+
+  @Test
+  void markRejected_from_pending_throws() {
+    PlanItem item = PlanItem.create("binding-a", "unknown", 0);
+    assertThatThrownBy(item::markRejected).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void markRejected_from_running_throws() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    item.markRunning();
+    assertThatThrownBy(item::markRejected).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void markRejected_from_completed_throws() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    item.markRunning();
+    item.markCompleted();
+    assertThatThrownBy(item::markRejected).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void markRejected_from_faulted_throws() {
+    PlanItem item = PlanItem.create("binding-a", "unknown", 0);
+    item.markFaulted();
+    assertThatThrownBy(item::markRejected).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void markRejected_from_cancelled_throws() {
+    PlanItem item = PlanItem.create("binding-a", "unknown", 0);
+    item.markCancelled();
+    assertThatThrownBy(item::markRejected).isInstanceOf(IllegalStateException.class);
+  }
 }

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseCompletionServiceTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseCompletionServiceTest.java
@@ -107,7 +107,7 @@ class SubCaseCompletionServiceTest {
 
   private CaseLifecycleEvent completionEvent(UUID caseId) {
     return new CaseLifecycleEvent(
-        caseId, "CompleteCase", "CaseCompleted", "COMPLETED", null, "system");
+        caseId, "CompleteCase", "CaseCompleted", "COMPLETED", null, "system", null);
   }
 
   @Test

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseMofNIntegrationTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseMofNIntegrationTest.java
@@ -89,10 +89,10 @@ class SubCaseMofNIntegrationTest {
     // CDI @ObservesAsync delivery which is unreliable in the test context.
     CaseLifecycleEvent completedEvent0 =
         new CaseLifecycleEvent(
-            childIds.get(0), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System");
+            childIds.get(0), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System", null);
     CaseLifecycleEvent completedEvent1 =
         new CaseLifecycleEvent(
-            childIds.get(1), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System");
+            childIds.get(1), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System", null);
 
     subCaseCompletionListener.onCaseLifecycle(completedEvent0);
     subCaseCompletionListener.onCaseLifecycle(completedEvent1);

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseParallelIntegrationTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseParallelIntegrationTest.java
@@ -87,13 +87,13 @@ class SubCaseParallelIntegrationTest {
     // This bypasses CDI @ObservesAsync delivery which is unreliable in the test context.
     CaseLifecycleEvent completedEvent0 =
         new CaseLifecycleEvent(
-            childIds.get(0), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System");
+            childIds.get(0), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System", null);
     CaseLifecycleEvent completedEvent1 =
         new CaseLifecycleEvent(
-            childIds.get(1), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System");
+            childIds.get(1), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System", null);
     CaseLifecycleEvent completedEvent2 =
         new CaseLifecycleEvent(
-            childIds.get(2), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System");
+            childIds.get(2), "CompleteCase", "CaseCompleted", "COMPLETED", null, "System", null);
 
     subCaseCompletionListener.onCaseLifecycle(completedEvent0);
     subCaseCompletionListener.onCaseLifecycle(completedEvent1);

--- a/common/src/main/java/io/casehub/engine/internal/event/CaseLifecycleEvent.java
+++ b/common/src/main/java/io/casehub/engine/internal/event/CaseLifecycleEvent.java
@@ -30,6 +30,9 @@ import java.util.UUID;
  * @param caseStatus snapshot of CaseStatus at transition time; null for non-status events
  * @param actorId the initiating actor; null for system-triggered events
  * @param actorRole the actor's role in this transition; null when not applicable
+ * @param traceId the W3C trace ID captured synchronously from the originating thread before {@code
+ *     fireAsync()} — null when no OTel span is active at the fire-site. Pre-populating here
+ *     bypasses the {@code @ObservesAsync} thread boundary where OTel context is lost.
  */
 public record CaseLifecycleEvent(
     UUID caseId,
@@ -37,4 +40,5 @@ public record CaseLifecycleEvent(
     String eventType,
     String caseStatus,
     String actorId,
-    String actorRole) {}
+    String actorRole,
+    String traceId) {}

--- a/common/src/main/java/io/casehub/engine/internal/model/PlanItemStatus.java
+++ b/common/src/main/java/io/casehub/engine/internal/model/PlanItemStatus.java
@@ -22,6 +22,10 @@ package io.casehub.engine.internal.model;
  * control has passed to an external actor (SubCase, HumanTask, Extension) and the engine is waiting
  * for a completion signal. These two active states are semantically distinct — consumers and LLMs
  * must not conflate "local computation running" with "waiting for external actor".
+ *
+ * <p>REJECTED: an external actor explicitly refused the work (human task refusal or M-of-N group
+ * threshold failure). Distinct from FAULTED (computation or timeout failure). Stored as STRING in
+ * JPA — ordinal safety is not a concern.
  */
 public enum PlanItemStatus {
   PENDING,
@@ -29,5 +33,6 @@ public enum PlanItemStatus {
   DELEGATED,
   COMPLETED,
   FAULTED,
+  REJECTED,
   CANCELLED
 }

--- a/docs/adr/0002-stage-autocomplete-on-any-terminal-planitem-state.md
+++ b/docs/adr/0002-stage-autocomplete-on-any-terminal-planitem-state.md
@@ -1,0 +1,81 @@
+# 0002 — Stage Autocomplete Triggers on Any Terminal PlanItem State
+
+Date: 2026-05-26
+Status: Accepted
+
+## Context and Problem Statement
+
+`PlanItemCompletionHandler.evaluateStageAutocomplete()` previously triggered stage
+autocomplete only when all required PlanItems reached `COMPLETED`. If a required item
+faulted or was rejected, the stage stalled indefinitely — no stage-level signal fired,
+no downstream evaluation occurred.
+
+With the addition of `PlanItemStatus.REJECTED` (engine#338), there are now four
+terminal states: COMPLETED, REJECTED, FAULTED, CANCELLED. Keeping the COMPLETED-only
+gate means stages stall whenever any required item reaches a non-success terminal state,
+which is increasingly common as the work adapter distinguishes intentional refusals from
+timeouts.
+
+## Decision Drivers
+
+* A stage whose required items are all settled (no more work possible) should always
+  propagate — regardless of how each item terminated
+* Case definitions already receive the PlanItem status and case context; downstream
+  logic can inspect outcomes and branch accordingly
+* Stalled stages require manual operator intervention with no self-healing path
+
+## Considered Options
+
+* **Option A** — Trigger on any terminal state (COMPLETED, REJECTED, FAULTED, CANCELLED)
+* **Option B** — Trigger on COMPLETED only (existing behaviour); raise a separate signal
+  for non-success terminal states
+* **Option C** — Make the autocomplete trigger condition configurable per-Stage
+
+## Decision Outcome
+
+Chosen option: **Option A**, because stages represent units of work, not units of
+success. When all items are settled, the stage has concluded — the outcome is the
+business concern of the case definition, not the engine's scheduling layer.
+
+### Positive Consequences
+
+* Stages always advance when their work is done, regardless of outcome
+* Case definitions gain a clear signal to implement compensation, retry, or escalation
+  flows using existing context inspection
+* No manual operator intervention required for faulted or rejected item paths
+
+### Negative Consequences / Tradeoffs
+
+* **Runtime behavioural change on deploy:** cases in flight that have a required item
+  in FAULTED or CANCELLED state will now trigger stage autocomplete on the next
+  evaluation cycle. Operators monitoring stage RUNNING status will see stages complete
+  that previously stalled. This is the correct long-term behaviour but is visible
+  immediately on upgrade.
+* Case definitions that relied on stages stalling after a fault (e.g. to hold for
+  operator remediation) will need explicit compensation steps to replicate that
+  behaviour.
+
+## Pros and Cons of the Options
+
+### Option A — Trigger on any terminal state
+
+* ✅ Stages always resolve; no indefinite stalls
+* ✅ Consistent semantics: settled = done
+* ❌ Runtime-visible change for in-flight cases on deploy
+
+### Option B — COMPLETED-only trigger (status quo)
+
+* ✅ No change to existing in-flight behaviour
+* ❌ Stages stall on fault or rejection; requires manual intervention
+* ❌ Increasingly broken as REJECTED becomes a first-class state
+
+### Option C — Configurable trigger per Stage
+
+* ✅ Backward compatible; existing definitions unchanged
+* ❌ Adds configuration surface; most definitions want Option A semantics
+* ❌ Complexity disproportionate to benefit at current scale
+
+## Links
+
+* engine#338 — WorkItemLifecycleAdapter status collapse fix (introduces PlanItemStatus.REJECTED)
+* engine#369 — umbrella tracking issue for this correctness batch

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -3,3 +3,4 @@
 | ID | Title | Status | Date |
 |----|-------|--------|------|
 | 0001 | [humanTask as first-class YAML binding target](0001-humantask-yaml-binding-target.md) | Accepted | 2026-05-20 |
+| 0002 | [Stage autocomplete triggers on any terminal PlanItem state](0002-stage-autocomplete-on-any-terminal-planitem-state.md) | Accepted | 2026-05-26 |

--- a/docs/specs/2026-05-26-engine-correctness-batch-design.md
+++ b/docs/specs/2026-05-26-engine-correctness-batch-design.md
@@ -1,0 +1,341 @@
+# Design: Engine Correctness Batch — #342 #331 #248 #338
+
+**Branch:** `issue-369-engine-correctness-batch`  
+**Date:** 2026-05-26  
+**Issues:** engine#342, engine#331, engine#248, engine#338  
+**Umbrella:** engine#369
+
+---
+
+## Fix 1 — engine#342: CaseLedgerEntry.traceId always null
+
+### Root Cause
+
+`CaseLedgerEventCapture.onCaseLifecycleEvent()` is `@ObservesAsync` — it runs on a managed
+executor thread. OTel context is `ThreadLocal` and is not propagated across the async CDI event
+boundary. At persist time, the `LedgerTraceListener` (@EntityListeners on `LedgerEntry`, in
+casehub-ledger) delegates to `LedgerEnricherPipeline`, which runs `TraceIdEnricher.enrich()`.
+That enricher calls `LedgerTraceIdProvider.currentTraceId()` — returning empty because no span
+is active on the async thread — and writes nothing. `CaseLedgerEntry.traceId` stays null on
+every row.
+
+`TraceIdEnricher.enrich()` is idempotent: it guards with `if (entry.traceId != null) return;`.
+Pre-setting `entry.traceId` before `save()` is therefore sufficient — the enricher will not
+overwrite a non-null value.
+
+### Design
+
+Capture the trace ID **synchronously** on the originating thread (where the HTTP span is live),
+carry it inside `CaseLifecycleEvent`, and set it explicitly on the entry before `save()`.
+
+**`CaseLifecycleEvent` record** (`common/`) — add `traceId` component:
+```java
+public record CaseLifecycleEvent(
+    UUID caseId,
+    String commandType,
+    String eventType,
+    String caseStatus,
+    String actorId,
+    String actorRole,
+    String traceId)   // nullable — null when no active span at fire-site
+{}
+```
+
+**All `CaseLifecycleEvent` instantiation sites** — inject `LedgerTraceIdProvider`, capture
+before `fireAsync()`. Grep for `new CaseLifecycleEvent(` (covers both `fire()` and `fireAsync()`
+call sites — all must be updated for compilation regardless):
+```java
+String traceId = traceIdProvider.currentTraceId().orElse(null);
+lifecycleEvents.fireAsync(new CaseLifecycleEvent(caseId, cmd, evt, status, actor, role, traceId));
+```
+
+**`CaseLedgerEventCapture`** — set on entry before `ledgerRepo.save()`:
+```java
+entry.traceId = event.traceId();  // null-safe — TraceIdEnricher skips if non-null already set
+```
+
+### Test
+
+New `@QuarkusTest` in `ledger/src/test/`: fire a `CaseLifecycleEvent` via **`fireAsync()`** (not
+`fire()`) and call `.toCompletableFuture().get()` to wait for the `@ObservesAsync` observer to
+complete. Assert `CaseLedgerEntry.traceId` equals the expected trace ID. Existing test
+`CaseLedgerEventCaptureTest` verifies the null path (no traceId on event → null in entry).
+
+### Files Changed
+- `common/src/main/java/io/casehub/engine/internal/event/CaseLifecycleEvent.java`
+- All `CaseLifecycleEvent` instantiation sites (grep: `new CaseLifecycleEvent(`)
+- `ledger/src/main/java/io/casehub/ledger/service/CaseLedgerEventCapture.java`
+
+---
+
+## Fix 2 — engine#331: CapabilityTarget PlanItem stays RUNNING when retries exhausted
+
+### Root Cause
+
+`WorkerRetriesExhaustedEventHandler` (in `runtime/`) faults the **case** but never touches the
+**PlanItem** in the blackboard. Two paths both leave the PlanItem in `RUNNING`:
+
+1. Quartz exhausts retries → `QuartzWorkerExecutionJobListener` publishes `WORKER_RETRIES_EXHAUSTED`
+2. `WorkerScheduleEventHandler` guard blocks the worker → also publishes `WORKER_RETRIES_EXHAUSTED`
+
+In both cases `hasActivePlanItem()` returns true forever, re-triggering is blocked, and stage
+autocomplete never fires.
+
+### Key Invariant
+
+`WorkerRetriesExhaustedEvent.workerId()` equals `worker.getName()`, which equals the tracking
+key stored by `BlackboardRegistry.indexForCompletion()`. Traced:
+- `QuartzWorkerExecutionManager.scheduleQuartzJob()` stores `worker.getName()` as `"workerId"`
+  in the Quartz job data map
+- `QuartzWorkerExecutionJobListener` reads `"workerId"` from the job data map and publishes
+  `WorkerRetriesExhaustedEvent(caseId, workerId=worker.getName(), ...)`
+- `WorkerScheduleEventHandler` guard path publishes `WorkerRetriesExhaustedEvent(uuid,
+  worker.getName(), ...)`
+- `BlackboardRegistry.indexForCompletion(caseId, worker.getName(), planItemId)` uses the same key
+
+The lookup `registry.getPlanItemId(event.caseId(), event.workerId())` will find the PlanItem.
+
+### Design
+
+New handler **`WorkerRetryExhaustionHandler`** in `blackboard/handler/`, following the pattern
+of `PlanItemCompletionHandler`. Delegates stage autocomplete to `StageAutocompleteEvaluator`
+(see below). Does **not** fire `PlanItemCompletedEvent` — the fault is already signalled via
+`CASE_STATUS_CHANGED`; firing a "completed" event after `markFaulted()` would mislead consumers.
+
+```java
+@ApplicationScoped
+public class WorkerRetryExhaustionHandler {
+
+    @ConsumeEvent(EventBusAddresses.WORKER_RETRIES_EXHAUSTED)
+    public Uni<Void> onWorkerRetriesExhausted(WorkerRetriesExhaustedEvent event) {
+        CasePlanModel plan = registry.get(event.caseId()).orElse(null);
+        if (plan == null) return Uni.createFrom().voidItem();
+
+        String planItemId = registry.getPlanItemId(event.caseId(), event.workerId()).orElse(null);
+        if (planItemId == null) return Uni.createFrom().voidItem();
+
+        plan.getPlanItem(planItemId).ifPresent(item -> {
+            if (item.getStatus() != PlanItemStatus.RUNNING) return;
+            item.markFaulted();
+            stageAutocompleteEvaluator.evaluate(event.caseId(), plan, planItemId);
+        });
+
+        return Uni.createFrom().voidItem();
+    }
+}
+```
+
+**`StageAutocompleteEvaluator`** — new `@ApplicationScoped` bean in `io.casehub.blackboard.handler`.
+Extracted from `PlanItemCompletionHandler` so both handlers share the logic. The `evaluate()`
+method is **public** (not package-private) to avoid fragility with CDI proxy subclassing.
+Uses the updated terminal-state gate (see Fix 4f).
+
+`PlanItemCompletionHandler` refactored to inject and delegate to `StageAutocompleteEvaluator`.
+
+### Files Changed
+- `blackboard/src/main/java/io/casehub/blackboard/handler/StageAutocompleteEvaluator.java` (new)
+- `blackboard/src/main/java/io/casehub/blackboard/handler/WorkerRetryExhaustionHandler.java` (new)
+- `blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemCompletionHandler.java` (delegates to `StageAutocompleteEvaluator`)
+- `blackboard/src/test/java/io/casehub/blackboard/handler/WorkerRetryExhaustionHandlerTest.java` (new)
+- `blackboard/src/test/java/io/casehub/blackboard/handler/StageAutocompleteEvaluatorTest.java` (new)
+
+---
+
+## Fix 3 — engine#248: JpaSubCaseGroupRepository atomicity
+
+### Root Cause
+
+`incrementCompleted()` and `incrementRejected()` use read-modify-write (`e.completedCount++`).
+Under PostgreSQL READ COMMITTED, two concurrent transactions can both read `completedCount = N`,
+both write `N+1`, and one increment is silently lost. The `markPolicyTriggered()` conditional
+UPDATE is already correct — the race is in the counter increments.
+
+`MemorySubCaseGroupRepository` already uses `synchronized(g)` on both increment methods —
+no changes needed there.
+
+### Design
+
+Replace read-modify-write with **atomic JPQL increments** + null-safe re-read:
+
+```java
+@Override
+public Uni<SubCaseGroup> incrementCompleted(UUID parentCaseId, String groupId) {
+    return Panache.withTransaction(() ->
+        SubCaseGroupEntity.update(
+            "completedCount = completedCount + 1 WHERE parentCaseId = ?1 AND groupId = ?2",
+            parentCaseId, groupId)
+        .chain(count -> {
+            if (count == 0)
+                return Uni.createFrom().failure(
+                    new IllegalStateException("Group not found: " + parentCaseId + ":" + groupId));
+            return SubCaseGroupEntity
+                .<SubCaseGroupEntity>find("parentCaseId = ?1 and groupId = ?2", parentCaseId, groupId)
+                .firstResult()
+                .onItem().ifNotNull().transform(this::toDomain)
+                .onItem().ifNull().failWith(() ->
+                    new IllegalStateException("Group vanished after increment: " + parentCaseId));
+        }));
+}
+```
+
+Same pattern for `incrementRejected()`.
+
+**Re-read semantics note for callers:** The returned `SubCaseGroup` reflects the database state
+at the moment of the SELECT, which may include increments from other concurrent transactions.
+Callers must not assume the returned count equals "their" increment plus the previous value —
+they may see a higher count if concurrent increments committed between the UPDATE and SELECT.
+`SubCaseGroupPolicy.evaluate()` already handles this correctly: it reads `completedCount` and
+`requiredCount` and compares them, so a higher-than-expected count is safe.
+
+### Files Changed
+- `persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaSubCaseGroupRepository.java`
+- `persistence-hibernate/src/test/java/io/casehub/persistence/jpa/JpaSubCaseGroupRepositoryTest.java`
+
+---
+
+## Fix 4 — engine#338: WorkItemLifecycleAdapter collapses REJECTED/EXPIRED/ESCALATED → FAULTED
+
+### Root Cause
+
+`applyStatus()` maps two semantically distinct `WorkItemStatus` values to `markFaulted()`:
+```java
+case REJECTED, EXPIRED -> item.markFaulted();
+```
+REJECTED (intentional human refusal) and EXPIRED (deadline missed) are not the same — case
+definitions cannot distinguish them.
+
+ESCALATED is correctly excluded at the filter before `applyStatus()` is ever called (lines 76–80
+of `WorkItemLifecycleAdapter`). The WorkItem re-enters PENDING with new candidate groups; the
+PlanItem stays in its current state until the WorkItem reaches a true terminal status. No state
+transition occurs, and no PlanItem-level audit entry is written — this is intentional. ESCALATED
+is not a terminal state; the engine does not close the plan item.
+
+### Design
+
+#### 4a — Add `PlanItemStatus.REJECTED`
+
+```java
+public enum PlanItemStatus {
+    PENDING, RUNNING, DELEGATED, COMPLETED, FAULTED, REJECTED, CANCELLED
+}
+```
+
+Stored as `@Enumerated(EnumType.STRING)` in `PlanItemEntity` — confirmed. No ordinal migration
+required.
+
+REJECTED is semantically distinct from FAULTED: an external actor (human or group policy)
+explicitly refused the work. FAULTED means computation failure or timeout.
+
+#### 4b — Add `PlanItem.markRejected()`
+
+Transitions from `DELEGATED` only. REJECTED arrives via human task refusal
+(`WorkItemStatus.REJECTED`) or M-of-N group policy failure (`GroupStatus.REJECTED`). Both of
+these dispatch through `HumanTaskScheduleHandler` which calls `item.markDelegated()` before
+the WorkItem is created — so the PlanItem is always in DELEGATED state when a rejection arrives.
+CapabilityTarget PlanItems (RUNNING state) do not participate in SpawnGroups and have no
+REJECTED path; they fault via retries exhaustion.
+
+```java
+/**
+ * Transitions DELEGATED → REJECTED.
+ *
+ * DELEGATED-only guard rationale: only human task refusals (WorkItemStatus.REJECTED) and
+ * M-of-N group threshold failures (GroupStatus.REJECTED on human task SpawnGroups) reach
+ * this path. CapabilityTarget PlanItems are always in RUNNING — they fault via retries
+ * exhaustion, never via rejection. If a group-of-capability-targets path is ever added,
+ * this guard must be revisited to allow RUNNING → REJECTED.
+ */
+public void markRejected() {
+    if (status != PlanItemStatus.DELEGATED) {
+        throw new IllegalStateException(
+            "Cannot reject from " + status + " (planItemId=" + planItemId + ")");
+    }
+    status = PlanItemStatus.REJECTED;
+}
+```
+
+#### 4c — Update `WorkItemLifecycleAdapter.applyStatus()`
+
+```java
+case COMPLETED -> item.markCompleted();
+case REJECTED  -> item.markRejected();   // intentional refusal — was markFaulted()
+case EXPIRED   -> item.markFaulted();    // deadline missed — unchanged
+case CANCELLED -> item.markCancelled();
+```
+
+#### 4d — Update `WorkItemLifecycleAdapter.applyGroupStatus()`
+
+```java
+case COMPLETED -> item.markCompleted();
+case REJECTED  -> item.markRejected();   // group threshold unreachable — was markFaulted()
+```
+
+#### 4e — Update `SubCaseCompletionService.cancelPlanItemOnRejected()` terminal guard
+
+Add `PlanItemStatus.REJECTED` to the terminal-state exclusion:
+```java
+.filter(pi ->
+    pi.getStatus() != PlanItemStatus.COMPLETED &&
+    pi.getStatus() != PlanItemStatus.FAULTED    &&
+    pi.getStatus() != PlanItemStatus.REJECTED   &&  // new
+    pi.getStatus() != PlanItemStatus.CANCELLED)
+```
+
+#### 4f — Update `StageAutocompleteEvaluator` — terminal-state gate
+
+Currently autocomplete fires only when all required items are `COMPLETED`. Updated to fire when
+all required items have reached **any terminal state** (COMPLETED, REJECTED, FAULTED, CANCELLED).
+This is a deliberate architectural change: a stage has concluded when all its work is settled,
+regardless of outcome. Case logic downstream inspects context to determine what happened.
+
+```java
+public static boolean isTerminal(PlanItemStatus s) {
+    return s == COMPLETED || s == REJECTED || s == FAULTED || s == CANCELLED;
+}
+```
+
+#### 4g — Audit all switches on PlanItemStatus
+
+Before implementation, grep `getStatus\(\)\|PlanItemStatus\.` across all source files. Known
+sites that must handle REJECTED:
+- `PlanItemCompletionHandler.COMPLETABLE` — REJECTED must NOT be added (it's terminal, not
+  completable-from)
+- `SubCaseCompletionService.cancelPlanItemOnRejected()` — covered by 4e
+- Any persistence or serialization code switching on status — covered by STRING enum
+
+### Test Coverage
+
+- `PlanItem.markRejected()` unit test: assert DELEGATED→REJECTED succeeds; assert PENDING,
+  RUNNING, COMPLETED, FAULTED, CANCELLED all throw `IllegalStateException`
+- `StageAutocompleteEvaluator` test: all-REJECTED, all-FAULTED, all-CANCELLED, and mixed
+  terminal states all trigger autocomplete; any non-terminal item blocks it
+- `SubCaseCompletionService.cancelPlanItemOnRejected()` test: REJECTED item is excluded
+  from the cancel sweep
+- `WorkItemLifecycleAdapterTest`: REJECTED→markRejected, EXPIRED→markFaulted, CANCELLED→markCancelled
+
+### Files Changed
+- `common/src/main/java/io/casehub/engine/internal/model/PlanItemStatus.java`
+- `blackboard/src/main/java/io/casehub/blackboard/plan/PlanItem.java`
+- `blackboard/src/main/java/io/casehub/blackboard/handler/StageAutocompleteEvaluator.java` (created in Fix 2)
+- `blackboard/src/main/java/io/casehub/blackboard/subcase/SubCaseCompletionService.java`
+- `work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java`
+- `work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java`
+- `blackboard/src/test/java/io/casehub/blackboard/plan/PlanItemTest.java` (markRejected tests)
+- `blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseCompletionServiceTest.java`
+
+---
+
+## Implementation Order
+
+Fix in dependency order — each builds on the previous:
+
+1. **#338** — `PlanItemStatus.REJECTED` + `markRejected()` + `StageAutocompleteEvaluator` (with
+   updated `isTerminal()` logic) + update `applyStatus()`, `applyGroupStatus()`,
+   `cancelPlanItemOnRejected()`, and `PlanItemCompletionHandler` (delegates to evaluator)
+2. **#331** — `WorkerRetryExhaustionHandler` injects the `StageAutocompleteEvaluator` from step 1.
+   Both handlers share the same evaluator — Fix 2 adds the handler; Fix 4 already updated the
+   evaluator logic. The extraction and logic update happen together in step 1.
+3. **#342** — independent; `CaseLifecycleEvent` record change and ledger capture fix
+4. **#248** — independent; pure persistence layer
+
+Commits: one per issue, each `Closes #N`.

--- a/ledger/src/main/java/io/casehub/ledger/service/CaseLedgerEventCapture.java
+++ b/ledger/src/main/java/io/casehub/ledger/service/CaseLedgerEventCapture.java
@@ -68,9 +68,12 @@ public class CaseLedgerEventCapture {
     entry.actorId = event.actorId() != null ? event.actorId() : "system";
     entry.actorType = deriveActorType(event.actorId());
     entry.actorRole = event.actorRole() != null ? event.actorRole() : "System";
-    // Set before hash computation — @PrePersist runs too late for canonical form
-    // Set before save() — @PrePersist runs too late for the canonical leaf hash.
+    // Set before save() — @PrePersist runs too late for canonical form and leaf hash.
     entry.occurredAt = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    // Pre-populate traceId from the event. TraceIdEnricher (@PrePersist via LedgerTraceListener)
+    // guards: if traceId != null it does nothing. Without this, the @ObservesAsync thread boundary
+    // severs OTel ThreadLocal context and traceId is always null. Refs engine#342.
+    entry.traceId = event.traceId();
 
     // save() handles digest computation and Merkle frontier update internally.
     ledgerRepo.save(entry);

--- a/ledger/src/test/java/io/casehub/ledger/CaseLedgerEventCaptureTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/CaseLedgerEventCaptureTest.java
@@ -53,7 +53,8 @@ class CaseLedgerEventCaptureTest {
     final UUID caseId = UUID.randomUUID();
 
     lifecycleEvents.fireAsync(
-        new CaseLifecycleEvent(caseId, "StartCase", "CaseStarted", "RUNNING", null, "System"));
+        new CaseLifecycleEvent(
+            caseId, "StartCase", "CaseStarted", "RUNNING", null, "System", null));
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
@@ -82,18 +83,20 @@ class CaseLedgerEventCaptureTest {
     // In production, the engine processes one case event at a time — concurrency doesn't arise.
     lifecycleEvents
         .fireAsync(
-            new CaseLifecycleEvent(caseId, "StartCase", "CaseStarted", "RUNNING", null, "System"))
+            new CaseLifecycleEvent(
+                caseId, "StartCase", "CaseStarted", "RUNNING", null, "System", null))
         .toCompletableFuture()
         .join();
     lifecycleEvents
         .fireAsync(
             new CaseLifecycleEvent(
-                caseId, "SuspendCase", "CaseSuspended", "SUSPENDED", null, "System"))
+                caseId, "SuspendCase", "CaseSuspended", "SUSPENDED", null, "System", null))
         .toCompletableFuture()
         .join();
     lifecycleEvents
         .fireAsync(
-            new CaseLifecycleEvent(caseId, "ResumeCase", "CaseResumed", "RUNNING", null, "System"))
+            new CaseLifecycleEvent(
+                caseId, "ResumeCase", "CaseResumed", "RUNNING", null, "System", null))
         .toCompletableFuture()
         .join();
 
@@ -116,18 +119,20 @@ class CaseLedgerEventCaptureTest {
 
     lifecycleEvents
         .fireAsync(
-            new CaseLifecycleEvent(caseA, "StartCase", "CaseStarted", "RUNNING", null, "System"))
-        .toCompletableFuture()
-        .join();
-    lifecycleEvents
-        .fireAsync(
-            new CaseLifecycleEvent(caseB, "StartCase", "CaseStarted", "RUNNING", null, "System"))
+            new CaseLifecycleEvent(
+                caseA, "StartCase", "CaseStarted", "RUNNING", null, "System", null))
         .toCompletableFuture()
         .join();
     lifecycleEvents
         .fireAsync(
             new CaseLifecycleEvent(
-                caseA, "CompleteCase", "CaseCompleted", "COMPLETED", null, "System"))
+                caseB, "StartCase", "CaseStarted", "RUNNING", null, "System", null))
+        .toCompletableFuture()
+        .join();
+    lifecycleEvents
+        .fireAsync(
+            new CaseLifecycleEvent(
+                caseA, "CompleteCase", "CaseCompleted", "COMPLETED", null, "System", null))
         .toCompletableFuture()
         .join();
 
@@ -153,7 +158,8 @@ class CaseLedgerEventCaptureTest {
             "CaseStarted",
             "RUNNING",
             "claude:casehub-agent@v1",
-            "Orchestrator"));
+            "Orchestrator",
+            null));
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
@@ -173,7 +179,7 @@ class CaseLedgerEventCaptureTest {
 
     lifecycleEvents.fireAsync(
         new CaseLifecycleEvent(
-            caseId, "SuspendCase", "CaseSuspended", "SUSPENDED", "alice", "Administrator"));
+            caseId, "SuspendCase", "CaseSuspended", "SUSPENDED", "alice", "Administrator", null));
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
@@ -190,7 +196,8 @@ class CaseLedgerEventCaptureTest {
     final UUID caseId = UUID.randomUUID();
 
     lifecycleEvents.fireAsync(
-        new CaseLifecycleEvent(caseId, "StartCase", "CaseStarted", "RUNNING", null, "System"));
+        new CaseLifecycleEvent(
+            caseId, "StartCase", "CaseStarted", "RUNNING", null, "System", null));
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
@@ -209,13 +216,14 @@ class CaseLedgerEventCaptureTest {
 
     lifecycleEvents
         .fireAsync(
-            new CaseLifecycleEvent(caseId, "StartCase", "CaseStarted", "RUNNING", null, "System"))
+            new CaseLifecycleEvent(
+                caseId, "StartCase", "CaseStarted", "RUNNING", null, "System", null))
         .toCompletableFuture()
         .join();
     lifecycleEvents
         .fireAsync(
             new CaseLifecycleEvent(
-                caseId, "CompleteCase", "CaseCompleted", "COMPLETED", null, "System"))
+                caseId, "CompleteCase", "CaseCompleted", "COMPLETED", null, "System", null))
         .toCompletableFuture()
         .join();
 
@@ -235,7 +243,7 @@ class CaseLedgerEventCaptureTest {
     final UUID caseId = UUID.randomUUID();
 
     lifecycleEvents.fireAsync(
-        new CaseLifecycleEvent(caseId, "SignalCase", "SignalReceived", null, null, "System"));
+        new CaseLifecycleEvent(caseId, "SignalCase", "SignalReceived", null, null, "System", null));
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
@@ -266,7 +274,7 @@ class CaseLedgerEventCaptureTest {
 
     lifecycleEvents.fireAsync(
         new CaseLifecycleEvent(
-            caseId, "ExecuteWorker", "WorkerExecutionStarted", null, workerId, "WORKER"));
+            caseId, "ExecuteWorker", "WorkerExecutionStarted", null, workerId, "WORKER", null));
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
@@ -290,7 +298,13 @@ class CaseLedgerEventCaptureTest {
 
     lifecycleEvents.fireAsync(
         new CaseLifecycleEvent(
-            caseId, "ExecuteWorker", "WorkerExecutionCompleted", "RUNNING", workerId, "WORKER"));
+            caseId,
+            "ExecuteWorker",
+            "WorkerExecutionCompleted",
+            "RUNNING",
+            workerId,
+            "WORKER",
+            null));
 
     Awaitility.await()
         .atMost(5, TimeUnit.SECONDS)
@@ -315,7 +329,8 @@ class CaseLedgerEventCaptureTest {
 
     lifecycleEvents
         .fireAsync(
-            new CaseLifecycleEvent(caseId, "StartCase", "CaseStarted", "RUNNING", null, "System"))
+            new CaseLifecycleEvent(
+                caseId, "StartCase", "CaseStarted", "RUNNING", null, "System", null))
         .toCompletableFuture()
         .join();
 
@@ -334,19 +349,20 @@ class CaseLedgerEventCaptureTest {
 
     lifecycleEvents
         .fireAsync(
-            new CaseLifecycleEvent(caseId, "StartCase", "CaseStarted", "RUNNING", null, "System"))
+            new CaseLifecycleEvent(
+                caseId, "StartCase", "CaseStarted", "RUNNING", null, "System", null))
         .toCompletableFuture()
         .join();
     lifecycleEvents
         .fireAsync(
             new CaseLifecycleEvent(
-                caseId, "SuspendCase", "CaseSuspended", "SUSPENDED", null, "System"))
+                caseId, "SuspendCase", "CaseSuspended", "SUSPENDED", null, "System", null))
         .toCompletableFuture()
         .join();
     lifecycleEvents
         .fireAsync(
             new CaseLifecycleEvent(
-                caseId, "CompleteCase", "CaseCompleted", "COMPLETED", null, "System"))
+                caseId, "CompleteCase", "CaseCompleted", "COMPLETED", null, "System", null))
         .toCompletableFuture()
         .join();
 
@@ -357,5 +373,54 @@ class CaseLedgerEventCaptureTest {
     assertThat(verificationService.verify(caseId))
         .as("Merkle chain must be intact after three events")
         .isTrue();
+  }
+
+  @Test
+  void traceId_on_event_is_propagated_to_ledger_entry() {
+    // fireAsync() is mandatory — fire() would keep OTel context on the calling thread, defeating
+    // the purpose. The bug is that @ObservesAsync severs thread-local OTel context.
+    // This test verifies that carrying traceId explicitly through the event record fixes it.
+    final UUID caseId = UUID.randomUUID();
+    final String expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+
+    lifecycleEvents
+        .fireAsync(
+            new CaseLifecycleEvent(
+                caseId, "StartCase", "CaseStarted", "RUNNING", null, "System", expectedTraceId))
+        .toCompletableFuture()
+        .join();
+
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              final List<CaseLedgerEntry> entries = repository.findByCaseId(caseId);
+              assertThat(entries).hasSize(1);
+              assertThat(entries.get(0).traceId)
+                  .as("traceId must be propagated from CaseLifecycleEvent to the ledger entry")
+                  .isEqualTo(expectedTraceId);
+            });
+  }
+
+  @Test
+  void null_traceId_on_event_leaves_entry_traceId_null() {
+    final UUID caseId = UUID.randomUUID();
+
+    lifecycleEvents
+        .fireAsync(
+            new CaseLifecycleEvent(
+                caseId, "StartCase", "CaseStarted", "RUNNING", null, "System", null))
+        .toCompletableFuture()
+        .join();
+
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              final List<CaseLedgerEntry> entries = repository.findByCaseId(caseId);
+              assertThat(entries).hasSize(1);
+              // null traceId — TraceIdEnricher will also find nothing; entry stays null
+              assertThat(entries.get(0).traceId).isNull();
+            });
   }
 }

--- a/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaSubCaseGroupRepository.java
+++ b/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/JpaSubCaseGroupRepository.java
@@ -74,20 +74,35 @@ public class JpaSubCaseGroupRepository implements SubCaseGroupRepository {
 
   @Override
   public Uni<SubCaseGroup> incrementCompleted(UUID parentCaseId, String groupId) {
+    // Atomic JPQL increment — avoids read-modify-write race under PostgreSQL READ COMMITTED.
+    // The returned SubCaseGroup reflects DB state at SELECT time; may include concurrent
+    // increments.
+    // SubCaseGroupPolicy.evaluate() reads counts and handles any total correctly. Refs engine#248.
     return Panache.withTransaction(
         () ->
-            SubCaseGroupEntity.<SubCaseGroupEntity>find(
-                    "parentCaseId = ?1 and groupId = ?2", parentCaseId, groupId)
-                .firstResult()
-                .flatMap(
-                    e -> {
-                      if (e == null)
+            SubCaseGroupEntity.update(
+                    "completedCount = completedCount + 1 WHERE parentCaseId = ?1 AND groupId = ?2",
+                    parentCaseId,
+                    groupId)
+                .chain(
+                    count -> {
+                      if (count == 0)
                         return Uni.createFrom()
                             .failure(
                                 new IllegalStateException(
                                     "Group not found: " + parentCaseId + ":" + groupId));
-                      e.completedCount++;
-                      return Uni.createFrom().item(toDomain(e));
+                      return SubCaseGroupEntity.<SubCaseGroupEntity>find(
+                              "parentCaseId = ?1 and groupId = ?2", parentCaseId, groupId)
+                          .firstResult()
+                          .onItem()
+                          .ifNotNull()
+                          .transform(this::toDomain)
+                          .onItem()
+                          .ifNull()
+                          .failWith(
+                              () ->
+                                  new IllegalStateException(
+                                      "Group vanished after increment: " + parentCaseId));
                     }));
   }
 
@@ -95,18 +110,29 @@ public class JpaSubCaseGroupRepository implements SubCaseGroupRepository {
   public Uni<SubCaseGroup> incrementRejected(UUID parentCaseId, String groupId) {
     return Panache.withTransaction(
         () ->
-            SubCaseGroupEntity.<SubCaseGroupEntity>find(
-                    "parentCaseId = ?1 and groupId = ?2", parentCaseId, groupId)
-                .firstResult()
-                .flatMap(
-                    e -> {
-                      if (e == null)
+            SubCaseGroupEntity.update(
+                    "rejectedCount = rejectedCount + 1 WHERE parentCaseId = ?1 AND groupId = ?2",
+                    parentCaseId,
+                    groupId)
+                .chain(
+                    count -> {
+                      if (count == 0)
                         return Uni.createFrom()
                             .failure(
                                 new IllegalStateException(
                                     "Group not found: " + parentCaseId + ":" + groupId));
-                      e.rejectedCount++;
-                      return Uni.createFrom().item(toDomain(e));
+                      return SubCaseGroupEntity.<SubCaseGroupEntity>find(
+                              "parentCaseId = ?1 and groupId = ?2", parentCaseId, groupId)
+                          .firstResult()
+                          .onItem()
+                          .ifNotNull()
+                          .transform(this::toDomain)
+                          .onItem()
+                          .ifNull()
+                          .failWith(
+                              () ->
+                                  new IllegalStateException(
+                                      "Group vanished after increment: " + parentCaseId));
                     }));
   }
 

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
@@ -27,6 +27,7 @@ import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.scheduler.SchedulerService;
 import io.casehub.engine.spi.EventLogRepository;
+import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -52,8 +53,11 @@ public class CaseStartedEventHandler {
 
   @Inject CaseChannelProvider caseChannelProvider;
 
+  @Inject LedgerTraceIdProvider traceIdProvider;
+
   @ConsumeEvent(value = EventBusAddresses.CASE_STARTED, blocking = true)
   public Uni<Void> onCaseStarted(CaseStartedEvent event) {
+    final String traceId = traceIdProvider.currentTraceId().orElse(null);
     final CaseInstance instance = event.instance();
     final JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
 
@@ -81,7 +85,8 @@ public class CaseStartedEventHandler {
                       "CaseStarted",
                       instance.getState().name(),
                       null,
-                      "System"));
+                      "System",
+                      traceId));
             });
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
@@ -28,6 +28,7 @@ import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.scheduler.SchedulerService;
 import io.casehub.engine.spi.CaseInstanceRepository;
+import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -57,8 +58,11 @@ public class CaseStatusChangedHandler {
 
   @Inject CaseChannelProvider caseChannelProvider;
 
+  @Inject LedgerTraceIdProvider traceIdProvider;
+
   @ConsumeEvent(value = EventBusAddresses.CASE_STATUS_CHANGED)
   public Uni<Void> onCaseStatusChangedHandler(CaseStatusChanged event) {
+    final String traceId = traceIdProvider.currentTraceId().orElse(null);
     final CaseInstance caseInstance = event.instance();
     final CaseStatus newState = CaseStatus.valueOf(event.newStatus());
     final String oldStatus = event.oldStatus();
@@ -112,7 +116,8 @@ public class CaseStatusChangedHandler {
                       resolveEventType(newState),
                       newState.name(),
                       null,
-                      "System"));
+                      "System",
+                      traceId));
             });
   }
 

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/GoalReachedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/GoalReachedEventHandler.java
@@ -33,6 +33,7 @@ import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.spi.CaseDefinitionRegistry;
 import io.casehub.engine.spi.EventLogRepository;
+import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -58,10 +59,13 @@ public class GoalReachedEventHandler {
 
   @Inject Event<CaseLifecycleEvent> lifecycleEvents;
 
+  @Inject LedgerTraceIdProvider traceIdProvider;
+
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @ConsumeEvent(value = EventBusAddresses.GOAL_REACHED)
   public Uni<Void> onGoalReachedEventHandler(GoalReachedEvent event) {
+    final String traceId = traceIdProvider.currentTraceId().orElse(null);
     final CaseInstance caseInstance = event.caseInstance();
     CaseDefinition definition =
         caseDefinitionRegistry.getCaseDefinition(caseInstance.getCaseMetaModel());
@@ -91,7 +95,8 @@ public class GoalReachedEventHandler {
                         "GoalReached",
                         caseInstance.getState().name(),
                         null,
-                        "System")))
+                        "System",
+                        traceId)))
         .chain(() -> evaluateCompletion(caseInstance, definition.getCompletion()));
   }
 

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/MilestoneReachedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/MilestoneReachedEventHandler.java
@@ -26,6 +26,7 @@ import io.casehub.engine.internal.event.MilestoneReachedEvent;
 import io.casehub.engine.internal.history.EventLog;
 import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.spi.EventLogRepository;
+import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -43,8 +44,11 @@ public class MilestoneReachedEventHandler {
 
   @Inject Event<CaseLifecycleEvent> lifecycleEvents;
 
+  @Inject LedgerTraceIdProvider traceIdProvider;
+
   @ConsumeEvent(value = EventBusAddresses.MILESTONE_REACHED)
   public Uni<Void> onMilestoneReachedEventHandler(MilestoneReachedEvent event) {
+    final String traceId = traceIdProvider.currentTraceId().orElse(null);
     final CaseInstance caseInstance = event.caseInstance();
     final Milestone milestone = event.milestone();
 
@@ -70,6 +74,7 @@ public class MilestoneReachedEventHandler {
                         "MilestoneReached",
                         caseInstance.getState().name(),
                         null,
-                        "System")));
+                        "System",
+                        traceId)));
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
@@ -30,6 +30,7 @@ import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.spi.EventLogRepository;
 import io.casehub.engine.spi.cache.CaseInstanceCache;
 import io.casehub.engine.spi.recovery.WorkerExecutionRecoveryService;
+import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
@@ -64,6 +65,8 @@ public class SignalReceivedEventHandler {
 
   @Inject Event<CaseLifecycleEvent> lifecycleEvents;
 
+  @Inject LedgerTraceIdProvider traceIdProvider;
+
   @ConsumeEvent(value = EventBusAddresses.SIGNAL_RECEIVED)
   public Uni<Void> onSignalReceived(SignalReceivedEvent event) {
     CaseInstance cached = caseInstanceCache.get(event.caseId());
@@ -77,17 +80,17 @@ public class SignalReceivedEventHandler {
   }
 
   private Uni<Void> applySignal(CaseInstance instance, SignalReceivedEvent event) {
-    // One lock per (caseId, path): concurrent signals to the same field are serialized so that
-    // the second signal always sees the context state written by the first one.
+    // Capture traceId synchronously before the async chain — the OTel ThreadLocal is intact here.
+    final String traceId = traceIdProvider.currentTraceId().orElse(null);
     String lockKey = "signal:" + instance.getUuid() + ":" + event.path();
     return vertx
         .sharedData()
         .getLocalLock(lockKey)
-        .chain(lock -> applySignalUnderLock(instance, event, lock));
+        .chain(lock -> applySignalUnderLock(instance, event, lock, traceId));
   }
 
   private Uni<Void> applySignalUnderLock(
-      CaseInstance instance, SignalReceivedEvent event, Lock lock) {
+      CaseInstance instance, SignalReceivedEvent event, Lock lock, String traceId) {
     Optional<JsonNode> maybeDiff;
     try {
       maybeDiff = instance.getCaseContext().applyAndDiff(event.path(), event.value());
@@ -121,7 +124,8 @@ public class SignalReceivedEventHandler {
                       "SignalReceived",
                       instance.getState().name(),
                       null,
-                      "System"));
+                      "System",
+                      traceId));
             })
         .replaceWithVoid()
         .onFailure()

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -40,6 +40,7 @@ import io.casehub.engine.internal.model.CaseInstance;
 import io.casehub.engine.internal.work.CaseResumptionService;
 import io.casehub.engine.spi.CaseDefinitionRegistry;
 import io.casehub.engine.spi.EventLogRepository;
+import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -65,12 +66,14 @@ public class WorkflowExecutionCompletedHandler {
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
   @Inject CaseResumptionService caseResumptionService;
   @Inject WorkerStatusListener workerStatusListener;
+  @Inject LedgerTraceIdProvider traceIdProvider;
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Logger LOG = Logger.getLogger(WorkflowExecutionCompletedHandler.class);
 
   @ConsumeEvent(value = EventBusAddresses.WORKER_EXECUTION_FINISHED)
   public Uni<Void> onWorkflowExecutionCompletedHandler(WorkflowExecutionCompleted event) {
+    final String traceId = traceIdProvider.currentTraceId().orElse(null);
     final CaseInstance caseInstance = event.caseInstance();
     final Worker worker = event.worker();
     final Map<String, Object> rawOutput = event.output() == null ? Map.of() : event.output();
@@ -109,7 +112,8 @@ public class WorkflowExecutionCompletedHandler {
                         "WorkerExecutionCompleted",
                         caseInstance.getState().name(),
                         worker.getName(),
-                        "WORKER")))
+                        "WORKER",
+                        traceId)))
         .invoke(
             () ->
                 eventBus.publish(

--- a/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJobListener.java
+++ b/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJobListener.java
@@ -37,6 +37,7 @@ import io.casehub.engine.internal.utils.ReactiveUtils;
 import io.casehub.engine.spi.CaseDefinitionRegistry;
 import io.casehub.engine.spi.EventLogRepository;
 import io.casehub.engine.spi.recovery.WorkerExecutionRecoveryService;
+import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -75,6 +76,8 @@ class QuartzWorkerExecutionJobListener implements JobListener {
 
   @Inject EventLogRepository eventLogRepository;
 
+  @Inject LedgerTraceIdProvider traceIdProvider;
+
   private static final Logger LOG = Logger.getLogger(QuartzWorkerExecutionJobListener.class);
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -103,7 +106,8 @@ class QuartzWorkerExecutionJobListener implements JobListener {
             "WorkerExecutionStarted",
             null,
             workerId,
-            "WORKER"));
+            "WORKER",
+            traceIdProvider.currentTraceId().orElse(null)));
 
     EventLog eventLog =
         createEventLog(

--- a/work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
@@ -158,7 +158,7 @@ public class WorkItemLifecycleAdapter {
     try {
       switch (status) {
         case COMPLETED -> item.markCompleted();
-        case REJECTED -> item.markFaulted();
+        case REJECTED -> item.markRejected();
         default -> {
           return false;
         }
@@ -225,8 +225,9 @@ public class WorkItemLifecycleAdapter {
     try {
       switch (status) {
         case COMPLETED -> item.markCompleted();
+        case REJECTED -> item.markRejected();
+        case EXPIRED -> item.markFaulted();
         case CANCELLED -> item.markCancelled();
-        case REJECTED, EXPIRED -> item.markFaulted();
         default -> {
           return false;
         }

--- a/work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java
@@ -103,21 +103,45 @@ class WorkItemLifecycleAdapterTest {
   }
 
   @Test
-  void workItemRejected_marksPlanItemFaulted() {
-    lifecycleEvents.fireAsync(buildEvent(WorkItemStatus.REJECTED, null));
+  void workItemRejected_marksPlanItemRejected() {
+    // Human task refusal — PlanItem must be DELEGATED (human task lifecycle)
+    PlanItem delegatedItem = PlanItem.create("review-ht", "ht-worker", 10);
+    delegatedItem.markDelegated();
+    registry.getOrCreate(caseId).addPlanItem(delegatedItem);
+    String delegatedItemId = delegatedItem.getPlanItemId();
+
+    WorkItem workItem = new WorkItem();
+    workItem.id = UUID.randomUUID();
+    workItem.status = WorkItemStatus.REJECTED;
+    workItem.callerRef = CallerRef.encode(caseId, delegatedItemId);
+    lifecycleEvents.fireAsync(
+        WorkItemLifecycleEvent.of("workitem.rejected", workItem, "system", null));
 
     await()
         .atMost(5, TimeUnit.SECONDS)
-        .untilAsserted(() -> assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.FAULTED));
+        .untilAsserted(
+            () -> assertThat(delegatedItem.getStatus()).isEqualTo(PlanItemStatus.REJECTED));
   }
 
   @Test
   void workItemExpired_marksPlanItemFaulted() {
-    lifecycleEvents.fireAsync(buildEvent(WorkItemStatus.EXPIRED, null));
+    // Deadline expiry — a time-based failure, maps to FAULTED
+    PlanItem delegatedItem = PlanItem.create("review-ht-expired", "ht-worker", 10);
+    delegatedItem.markDelegated();
+    registry.getOrCreate(caseId).addPlanItem(delegatedItem);
+    String delegatedItemId = delegatedItem.getPlanItemId();
+
+    WorkItem workItem = new WorkItem();
+    workItem.id = UUID.randomUUID();
+    workItem.status = WorkItemStatus.EXPIRED;
+    workItem.callerRef = CallerRef.encode(caseId, delegatedItemId);
+    lifecycleEvents.fireAsync(
+        WorkItemLifecycleEvent.of("workitem.expired", workItem, "system", null));
 
     await()
         .atMost(5, TimeUnit.SECONDS)
-        .untilAsserted(() -> assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.FAULTED));
+        .untilAsserted(
+            () -> assertThat(delegatedItem.getStatus()).isEqualTo(PlanItemStatus.FAULTED));
   }
 
   @Test
@@ -318,12 +342,28 @@ class WorkItemLifecycleAdapterTest {
   }
 
   @Test
-  void workItemGroupRejected_marksPlanItemFaulted() {
-    groupLifecycleEvents.fireAsync(buildGroupEvent(GroupStatus.REJECTED));
+  void workItemGroupRejected_marksPlanItemRejected() {
+    // Group threshold unreachable — group PlanItems are always DELEGATED (HumanTask SpawnGroup)
+    PlanItem delegatedItem = PlanItem.create("group-binding", "group-worker", 10);
+    delegatedItem.markDelegated();
+    registry.getOrCreate(caseId).addPlanItem(delegatedItem);
+    String delegatedItemId = delegatedItem.getPlanItemId();
+
+    groupLifecycleEvents.fireAsync(
+        WorkItemGroupLifecycleEvent.of(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            3,
+            2,
+            0,
+            3,
+            GroupStatus.REJECTED,
+            CallerRef.encode(caseId, delegatedItemId)));
 
     await()
         .atMost(5, TimeUnit.SECONDS)
-        .untilAsserted(() -> assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.FAULTED));
+        .untilAsserted(
+            () -> assertThat(delegatedItem.getStatus()).isEqualTo(PlanItemStatus.REJECTED));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Four correctness fixes landed in one branch, one commit per issue. All tests passing. ADR-0002 filed for the stage autocomplete semantic change.

- **#342** — `CaseLedgerEntry.traceId` always null: `@ObservesAsync` severs OTel ThreadLocal. Fix: add `traceId` to `CaseLifecycleEvent` record, capture synchronously at every fire-site before `fireAsync()`, pre-populate in `CaseLedgerEventCapture` before `save()`. `TraceIdEnricher`'s existing null-guard preserves the value through `@PrePersist`.
- **#331** — CapabilityTarget PlanItem stays RUNNING when Quartz retries exhausted: new `WorkerRetryExhaustionHandler` in blackboard module, listens to `WORKER_RETRIES_EXHAUSTED`, marks PlanItem FAULTED, evaluates stage autocomplete.
- **#248** — `JpaSubCaseGroupRepository` read-modify-write race under PostgreSQL READ COMMITTED: replaced with atomic JPQL `UPDATE SET count = count + 1`.
- **#338** — `WorkItemLifecycleAdapter` collapses REJECTED/EXPIRED → FAULTED: added `PlanItemStatus.REJECTED`, `PlanItem.markRejected()` (DELEGATED→REJECTED), split `applyStatus()` (REJECTED→markRejected, EXPIRED→markFaulted). `StageAutocompleteEvaluator` extracted from `PlanItemCompletionHandler`; updated to fire when all required items reach any terminal state (COMPLETED, REJECTED, FAULTED, CANCELLED). See ADR-0002.

## Test plan

- [x] `blackboard`: 221 tests GREEN (PlanItemTest +6, StageAutocompleteEvaluatorTest +9, WorkerRetryExhaustionHandlerTest +5)
- [x] `work-adapter`: 37 tests GREEN (WorkItemLifecycleAdapterTest updated: REJECTED→REJECTED, EXPIRED→FAULTED)
- [x] `ledger`: 16 tests GREEN (CaseLedgerEventCaptureTest +2: traceId propagation via `fireAsync().toCompletableFuture().join()`)
- [x] `persistence-hibernate`: 24 JpaSubCaseGroupRepositoryTest GREEN (atomic increment behaviorally equivalent to old approach)

Closes #342, Closes #331, Closes #248, Closes #338, Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)