### PR TITLE
fix(blackboard): mark PlanItem FAULTED when worker retries exhausted …

### DIFF
--- a/blackboard/src/main/java/io/casehub/blackboard/event/PlanItemFaultedEvent.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/event/PlanItemFaultedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.event;
+
+import java.util.UUID;
+
+/**
+ * CDI event fired after a {@link io.casehub.blackboard.plan.PlanItem} is marked FAULTED in the
+ * BlackboardRegistry. Fired via {@code Event.fireAsync()} from {@link
+ * io.casehub.blackboard.handler.PlanItemFaultHandler}.
+ *
+ * @param caseId the case the PlanItem belongs to
+ * @param planItemId the exact PlanItem id that just faulted
+ * @param workerId the worker whose retries were exhausted
+ */
+public record PlanItemFaultedEvent(UUID caseId, String planItemId, String workerId) {}

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemFaultHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemFaultHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import io.casehub.blackboard.event.PlanItemFaultedEvent;
+import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.internal.event.EventBusAddresses;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
+import io.casehub.engine.internal.model.PlanItemStatus;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import java.util.EnumSet;
+import java.util.Set;
+import org.jboss.logging.Logger;
+
+/**
+ * Marks {@link PlanItem}s FAULTED when a worker's retries are exhausted.
+ *
+ * <p>Subscribes to {@code WORKER_RETRIES_EXHAUSTED} which is published via {@code
+ * eventBus.publish()} — fan-out. Coexists with {@link
+ * io.casehub.engine.internal.engine.handler.WorkerRetriesExhaustedEventHandler} which handles the
+ * CaseInstance-level FAULTED transition.
+ *
+ */
+@ApplicationScoped
+public class PlanItemFaultHandler {
+
+  private static final Logger LOG = Logger.getLogger(PlanItemFaultHandler.class);
+
+  private static final Set<PlanItemStatus> FAULTABLE =
+      EnumSet.of(PlanItemStatus.PENDING, PlanItemStatus.RUNNING, PlanItemStatus.DELEGATED);
+
+  private final BlackboardRegistry registry;
+  private final Event<PlanItemFaultedEvent> planItemFaultedEvents;
+
+  @Inject
+  public PlanItemFaultHandler(
+      BlackboardRegistry registry, Event<PlanItemFaultedEvent> planItemFaultedEvents) {
+    this.registry = registry;
+    this.planItemFaultedEvents = planItemFaultedEvents;
+  }
+
+  @ConsumeEvent(EventBusAddresses.WORKER_RETRIES_EXHAUSTED)
+  public Uni<Void> onWorkerRetriesExhausted(WorkerRetriesExhaustedEvent event) {
+    CasePlanModel plan = registry.get(event.caseId()).orElse(null);
+    if (plan == null) return Uni.createFrom().voidItem();
+
+    String planItemId = registry.getPlanItemId(event.caseId(), event.workerId()).orElse(null);
+    if (planItemId == null) {
+      LOG.debugf(
+          "No PlanItem indexed for worker '%s' in case %s — pure choreography or already evicted",
+          event.workerId(), event.caseId());
+      return Uni.createFrom().voidItem();
+    }
+
+    plan.getPlanItem(planItemId)
+        .ifPresent(
+            item -> {
+              if (!FAULTABLE.contains(item.getStatus())) {
+                LOG.debugf(
+                    "PlanItem %s for worker '%s' in case %s has status %s — not faultable, skipping",
+                    planItemId, event.workerId(), event.caseId(), item.getStatus());
+                return;
+              }
+              item.markFaulted();
+              LOG.infof(
+                  "PlanItem %s marked FAULTED for worker '%s' in case %s",
+                  planItemId, event.workerId(), event.caseId());
+              planItemFaultedEvents.fireAsync(
+                  new PlanItemFaultedEvent(event.caseId(), planItemId, event.workerId()));
+            });
+
+    return Uni.createFrom().voidItem();
+  }
+}

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemFaultHandlerTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemFaultHandlerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.casehub.blackboard.plan.DefaultCasePlanModel;
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.internal.event.WorkerRetriesExhaustedEvent;
+import io.casehub.engine.internal.model.PlanItemStatus;
+import java.util.UUID;
+
+import jakarta.enterprise.event.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for PlanItemFaultHandler — marks PlanItems FAULTED when worker retries are exhausted.
+ * Closes casehubio/engine#331.
+ */
+class PlanItemFaultHandlerTest {
+
+  private BlackboardRegistry registry;
+  private PlanItemFaultHandler handler;
+  private UUID caseId;
+  private DefaultCasePlanModel plan;
+
+  @BeforeEach
+  void setUp() {
+    registry = new BlackboardRegistry();
+    handler = new PlanItemFaultHandler(registry, mock(Event.class));
+    caseId = UUID.randomUUID();
+    plan = (DefaultCasePlanModel) registry.getOrCreate(caseId);
+  }
+
+  private WorkerRetriesExhaustedEvent eventFor(String workerId) {
+    return new WorkerRetriesExhaustedEvent(caseId, workerId, "idempotency-key");
+  }
+
+  @Test
+  void marks_running_plan_item_faulted_on_retries_exhausted() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItem(item);
+    item.markRunning();
+    registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler.onWorkerRetriesExhausted(eventFor("worker-a")).await().indefinitely();
+
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED);
+  }
+
+  @Test
+  void marks_delegated_plan_item_faulted_on_retries_exhausted() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItem(item);
+    item.markDelegated();
+    registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler.onWorkerRetriesExhausted(eventFor("worker-a")).await().indefinitely();
+
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED);
+  }
+
+  @Test
+  void marks_pending_plan_item_faulted_on_retries_exhausted() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItem(item);
+    registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler.onWorkerRetriesExhausted(eventFor("worker-a")).await().indefinitely();
+
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED);
+  }
+
+  @Test
+  void skips_already_completed_plan_item() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItem(item);
+    item.markRunning();
+    item.markCompleted();
+    registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler.onWorkerRetriesExhausted(eventFor("worker-a")).await().indefinitely();
+
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.COMPLETED);
+  }
+
+  @Test
+  void skips_already_faulted_plan_item() {
+    PlanItem item = PlanItem.create("binding-a", "worker-a", 0);
+    plan.addPlanItem(item);
+    item.markRunning();
+    item.markFaulted();
+    registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
+
+    handler.onWorkerRetriesExhausted(eventFor("worker-a")).await().indefinitely();
+
+    assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED);
+  }
+
+  @Test
+  void unknown_worker_does_not_throw() {
+    handler.onWorkerRetriesExhausted(eventFor("unknown-worker")).await().indefinitely();
+  }
+
+  @Test
+  void no_plan_registered_does_not_throw() {
+    UUID otherCase = UUID.randomUUID();
+    handler
+        .onWorkerRetriesExhausted(new WorkerRetriesExhaustedEvent(otherCase, "w", "key"))
+        .await()
+        .indefinitely();
+  }
+}


### PR DESCRIPTION
…(Closes #331)

PlanItemFaultHandler subscribes to WORKER_RETRIES_EXHAUSTED and transitions the PlanItem to FAULTED via BlackboardRegistry lookup — mirrors the PlanItemCompletionHandler pattern for the failure path.