### PR TITLE
feat(routing): sealed AgentAssignment, reactive SPI, TrustCandidateClassifier, borderline escalation, SemanticAgentRoutingStrategy

### DIFF
--- a/api/src/main/java/io/casehub/api/model/CaseChannel.java
+++ b/api/src/main/java/io/casehub/api/model/CaseChannel.java
@@ -47,6 +47,17 @@ public record CaseChannel(
     return CASE_CHANNEL_PREFIX + caseId + "/" + purpose;
   }
 
+  /**
+   * Constructs the canonical oversight channel name for a case. Equivalent to {@code
+   * channelName(caseId, "oversight")}.
+   *
+   * <p>Oversight channels carry human governance decisions. See protocol {@code
+   * qhorus-per-entity-governance-channels.md}.
+   */
+  public static String oversightChannelName(final UUID caseId) {
+    return channelName(caseId, "oversight");
+  }
+
   public CaseChannel {
     if (id == null || id.isBlank()) throw new IllegalArgumentException("id must not be blank");
     if (backendType == null || backendType.isBlank())

--- a/api/src/main/java/io/casehub/api/spi/routing/AgentAssignment.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/AgentAssignment.java
@@ -16,20 +16,47 @@
 package io.casehub.api.spi.routing;
 
 /**
- * Result of {@link AgentRoutingStrategy#select}. A null {@code workerId} signals that no suitable
- * candidate was found — use {@link #noOp()} to construct and {@link #isNoOp()} to check.
+ * Result of {@link AgentRoutingStrategy#select}. A sealed type with three distinct outcomes:
  *
- * @param workerId the selected worker name, or null when no worker qualifies
+ * <ul>
+ *   <li>{@link Assigned} — a specific worker was selected
+ *   <li>{@link Unresolvable} — no candidate passed trust filters (none were borderline)
+ *   <li>{@link EscalateToOversight} — all trust-eligible candidates are borderline; human oversight
+ *       is required per trust-maturity-model.md Phase 2
+ * </ul>
+ *
+ * <p>Callers must switch exhaustively on the sealed type. The previous {@code isNoOp()} pattern is
+ * removed — the three outcomes are semantically distinct and the engine's response to each differs.
  */
-public record AgentAssignment(String workerId) {
+public sealed interface AgentAssignment
+    permits AgentAssignment.Assigned,
+        AgentAssignment.Unresolvable,
+        AgentAssignment.EscalateToOversight {
 
-  /** Sentinel indicating no worker was selected. */
-  public static AgentAssignment noOp() {
-    return new AgentAssignment(null);
+  /** A specific worker was selected for the capability. */
+  record Assigned(String workerId) implements AgentAssignment {}
+
+  /**
+   * No candidate passed trust filters. None were borderline — the pool simply lacks qualified
+   * agents. Engine falls to {@code tryProvision()}.
+   */
+  record Unresolvable() implements AgentAssignment {}
+
+  /**
+   * All trust-eligible candidates are borderline (score within {@code borderlineMargin} of {@code
+   * threshold}). Engine must route to human oversight per trust-maturity-model.md Phase 2.
+   */
+  record EscalateToOversight(String capabilityName) implements AgentAssignment {}
+
+  static AgentAssignment assign(final String workerId) {
+    return new Assigned(workerId);
   }
 
-  /** True when no worker was selected. */
-  public boolean isNoOp() {
-    return workerId == null;
+  static AgentAssignment unresolvable() {
+    return new Unresolvable();
+  }
+
+  static AgentAssignment escalate(final String capabilityName) {
+    return new EscalateToOversight(capabilityName);
   }
 }

--- a/api/src/main/java/io/casehub/api/spi/routing/AgentCandidate.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/AgentCandidate.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.api.spi.routing;
 
+import io.casehub.eidos.api.AgentDescriptor;
 import java.util.Set;
 
 /**
@@ -24,12 +25,22 @@ import java.util.Set;
  * WorkerExecutionManager} — not WorkItem counts. This correctly represents agent load.
  *
  * <p>{@code capabilities} is the worker's full declared capability set, not just the one being
- * matched. Future semantic strategies may use this for embedding-based comparison.
+ * matched.
+ *
+ * <p>{@code agentDescriptor} carries the agent's full vocabulary (domain, slot, disposition,
+ * capability descriptions) for semantic routing strategies. Nullable — strategies that receive a
+ * null descriptor must treat the candidate as bootstrap (availability routing only).
  *
  * @param workerId the worker name from the case definition YAML
  * @param capabilities all capabilities declared by this worker
  * @param runningJobs count of currently active Quartz execution jobs for this worker
  * @param health pre-probed health status; UNAVAILABLE workers are never included
+ * @param agentDescriptor the agent's registered descriptor from casehub-eidos; null if no
+ *     descriptor is registered for this worker
  */
 public record AgentCandidate(
-    String workerId, Set<String> capabilities, int runningJobs, AgentHealth health) {}
+    String workerId,
+    Set<String> capabilities,
+    int runningJobs,
+    AgentHealth health,
+    AgentDescriptor agentDescriptor) {}

--- a/api/src/main/java/io/casehub/api/spi/routing/AgentRoutingContext.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/AgentRoutingContext.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.api.spi.routing;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.UUID;
 
 /**
@@ -23,10 +24,14 @@ import java.util.UUID;
  * <p>{@code caseId} is included per the {@code spi-case-id-parameter.md} protocol — it enables a
  * future {@code PerCaseDynamicAgentRoutingStrategy} to dispatch per-case without call-site changes.
  *
- * <p>{@code caseContext} is intentionally omitted here. Semantic routing (engine#376) will add
- * {@code JsonNode caseContext} when {@code SemanticAgentRoutingStrategy} is implemented.
+ * <p>{@code caseContext} is the full case context map serialized as a {@link JsonNode}. Semantic
+ * routing strategies (e.g. {@code SemanticAgentRoutingStrategy}) extract a text summary via a
+ * configurable JQ expression before embedding. Strategies that do not use the context may ignore
+ * it.
  *
  * @param caseId the case instance UUID
  * @param capabilityName the capability being routed — used for trust score lookups and filtering
+ * @param caseContext the current case context as a JSON node; may be {@code NullNode} when the case
+ *     has no context
  */
-public record AgentRoutingContext(UUID caseId, String capabilityName) {}
+public record AgentRoutingContext(UUID caseId, String capabilityName, JsonNode caseContext) {}

--- a/api/src/main/java/io/casehub/api/spi/routing/AgentRoutingStrategy.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/AgentRoutingStrategy.java
@@ -15,16 +15,22 @@
  */
 package io.casehub.api.spi.routing;
 
+import io.smallrye.mutiny.Uni;
 import java.util.List;
 
 /**
  * Engine-owned SPI for agent worker selection. Replaces the borrowed {@code
- * WorkerSelectionStrategy} from casehub-work, which was designed for human task routing and carried
- * semantics incompatible with agent scheduling (WorkItem counts, claim-first model, null-padded
- * SelectionContext).
+ * WorkerSelectionStrategy} from casehub-work.
  *
  * <p>Implement as {@code @ApplicationScoped @Alternative @Priority(N)} where N > 0 to override
  * {@link io.casehub.engine.internal.routing.LeastLoadedAgentStrategy}. Higher priority wins.
+ *
+ * <p>Implementations that do only in-memory work (e.g. trust scoring against a local cache) should
+ * return {@code Uni.createFrom().item(result)}. Implementations that make blocking calls (e.g. an
+ * embedding service) must return a reactive chain that executes on a worker thread — never blocking
+ * the Vert.x IO thread.
+ *
+ * <p>Implementations MUST be thread-safe — {@code select()} may be called concurrently.
  *
  * <p>Known implementations:
  *
@@ -32,9 +38,11 @@ import java.util.List;
  *   <li>{@code LeastLoadedAgentStrategy} — {@code @DefaultBean}, prefers fewest running Quartz jobs
  *   <li>{@code TrustWeightedAgentStrategy} — {@code @Alternative @Priority(1)}, trust maturity
  *       model
+ *   <li>{@code SemanticAgentRoutingStrategy} — {@code @Alternative @Priority(2)}, optional module
+ *       {@code casehub-engine-ai}, embedding-based semantic re-ranking over trust-qualified
+ *       candidates
  * </ul>
  */
-@FunctionalInterface
 public interface AgentRoutingStrategy {
 
   /**
@@ -44,9 +52,10 @@ public interface AgentRoutingStrategy {
    * EPISTEMICALLY_WEAK} and {@code DEGRADED} workers are included — implementations may apply
    * preference demotion via {@link AgentCandidate#health()}.
    *
-   * @param context routing context carrying caseId and capabilityName
+   * @param context routing context carrying caseId, capabilityName, and caseContext
    * @param candidates non-empty list of eligible candidates (filtered, health-probed)
-   * @return assignment decision; use {@link AgentAssignment#noOp()} when no candidate qualifies
+   * @return a {@code Uni} resolving to one of: {@link AgentAssignment.Assigned}, {@link
+   *     AgentAssignment.Unresolvable}, or {@link AgentAssignment.EscalateToOversight}
    */
-  AgentAssignment select(AgentRoutingContext context, List<AgentCandidate> candidates);
+  Uni<AgentAssignment> select(AgentRoutingContext context, List<AgentCandidate> candidates);
 }

--- a/api/src/test/java/io/casehub/api/spi/AgentAssignmentTest.java
+++ b/api/src/test/java/io/casehub/api/spi/AgentAssignmentTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.spi.routing.AgentAssignment;
+import org.junit.jupiter.api.Test;
+
+class AgentAssignmentTest {
+
+  @Test
+  void assign_createsAssigned_withWorkerId() {
+    final AgentAssignment assignment = AgentAssignment.assign("worker-1");
+
+    assertThat(assignment).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) assignment).workerId()).isEqualTo("worker-1");
+  }
+
+  @Test
+  void unresolvable_createsUnresolvable() {
+    final AgentAssignment assignment = AgentAssignment.unresolvable();
+
+    assertThat(assignment).isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  @Test
+  void escalate_createsEscalateToOversight_withCapabilityName() {
+    final AgentAssignment assignment = AgentAssignment.escalate("data-analysis");
+
+    assertThat(assignment).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) assignment).capabilityName())
+        .isEqualTo("data-analysis");
+  }
+
+  @Test
+  void patternSwitch_Assigned_extractsWorkerId() {
+    final AgentAssignment assignment = AgentAssignment.assign("analyst-1");
+
+    final String result =
+        switch (assignment) {
+          case AgentAssignment.Assigned a -> a.workerId();
+          case AgentAssignment.Unresolvable() -> "none";
+          case AgentAssignment.EscalateToOversight e -> "escalate:" + e.capabilityName();
+        };
+
+    assertThat(result).isEqualTo("analyst-1");
+  }
+
+  @Test
+  void patternSwitch_Unresolvable_branchesCorrectly() {
+    final AgentAssignment assignment = AgentAssignment.unresolvable();
+
+    final String result =
+        switch (assignment) {
+          case AgentAssignment.Assigned a -> "assigned";
+          case AgentAssignment.Unresolvable() -> "unresolvable";
+          case AgentAssignment.EscalateToOversight e -> "escalate";
+        };
+
+    assertThat(result).isEqualTo("unresolvable");
+  }
+
+  @Test
+  void patternSwitch_EscalateToOversight_branchesCorrectly() {
+    final AgentAssignment assignment = AgentAssignment.escalate("review");
+
+    final String result =
+        switch (assignment) {
+          case AgentAssignment.Assigned a -> "assigned";
+          case AgentAssignment.Unresolvable() -> "unresolvable";
+          case AgentAssignment.EscalateToOversight e -> "escalate:" + e.capabilityName();
+        };
+
+    assertThat(result).isEqualTo("escalate:review");
+  }
+}

--- a/api/src/test/java/io/casehub/api/spi/AgentRoutingStrategyContractTest.java
+++ b/api/src/test/java/io/casehub/api/spi/AgentRoutingStrategyContractTest.java
@@ -17,11 +17,13 @@ package io.casehub.api.spi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.node.NullNode;
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentHealth;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.smallrye.mutiny.Uni;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -30,45 +32,39 @@ import org.junit.jupiter.api.Test;
 class AgentRoutingStrategyContractTest {
 
   @Test
-  void interface_hasSelectMethod() throws Exception {
-    assertThat(
-            AgentRoutingStrategy.class.getMethod("select", AgentRoutingContext.class, List.class))
-        .isNotNull();
+  void interface_hasSelectMethod_returningUni() throws Exception {
+    final var method =
+        AgentRoutingStrategy.class.getMethod("select", AgentRoutingContext.class, List.class);
+    assertThat(method).isNotNull();
+    assertThat(method.getReturnType()).isEqualTo(Uni.class);
   }
 
   @Test
-  void agentAssignment_noOp_isNoOp() {
-    assertThat(AgentAssignment.noOp().isNoOp()).isTrue();
+  void interface_isNotAnnotatedFunctional() {
+    assertThat(AgentRoutingStrategy.class.isAnnotationPresent(FunctionalInterface.class)).isFalse();
   }
 
   @Test
-  void agentAssignment_withWorkerId_isNotNoOp() {
-    assertThat(new AgentAssignment("worker-1").isNoOp()).isFalse();
-  }
-
-  @Test
-  void agentAssignment_noOp_workerIdIsNull() {
-    assertThat(AgentAssignment.noOp().workerId()).isNull();
-  }
-
-  @Test
-  void agentRoutingContext_exposesFields() {
+  void agentRoutingContext_exposesAllThreeFields() {
     final UUID caseId = UUID.randomUUID();
-    final AgentRoutingContext ctx = new AgentRoutingContext(caseId, "data-analysis");
+    final var caseContext = NullNode.instance;
+    final AgentRoutingContext ctx = new AgentRoutingContext(caseId, "data-analysis", caseContext);
 
     assertThat(ctx.caseId()).isEqualTo(caseId);
     assertThat(ctx.capabilityName()).isEqualTo("data-analysis");
+    assertThat(ctx.caseContext()).isSameAs(caseContext);
   }
 
   @Test
-  void agentCandidate_exposesFields() {
+  void agentCandidate_exposesAllFiveFields() {
     final AgentCandidate candidate =
-        new AgentCandidate("agent-1", Set.of("research", "analysis"), 2, AgentHealth.READY);
+        new AgentCandidate("agent-1", Set.of("research", "analysis"), 2, AgentHealth.READY, null);
 
     assertThat(candidate.workerId()).isEqualTo("agent-1");
     assertThat(candidate.capabilities()).containsExactlyInAnyOrder("research", "analysis");
     assertThat(candidate.runningJobs()).isEqualTo(2);
     assertThat(candidate.health()).isEqualTo(AgentHealth.READY);
+    assertThat(candidate.agentDescriptor()).isNull();
   }
 
   @Test
@@ -79,28 +75,47 @@ class AgentRoutingStrategyContractTest {
   }
 
   @Test
-  void anonymousImplementation_compilesAndSelectsCorrectly() {
+  void implementation_canReturnAssigned() {
     final AgentRoutingStrategy strategy =
         (ctx, candidates) ->
             candidates.isEmpty()
-                ? AgentAssignment.noOp()
-                : new AgentAssignment(candidates.get(0).workerId());
+                ? Uni.createFrom().item(AgentAssignment.unresolvable())
+                : Uni.createFrom().item(AgentAssignment.assign(candidates.get(0).workerId()));
 
     final UUID caseId = UUID.randomUUID();
-    final AgentRoutingContext ctx = new AgentRoutingContext(caseId, "research");
+    final AgentRoutingContext ctx = new AgentRoutingContext(caseId, "research", NullNode.instance);
     final AgentCandidate candidate =
-        new AgentCandidate("agent-x", Set.of("research"), 0, AgentHealth.READY);
+        new AgentCandidate("agent-x", Set.of("research"), 0, AgentHealth.READY, null);
 
-    final AgentAssignment result = strategy.select(ctx, List.of(candidate));
+    final AgentAssignment result = strategy.select(ctx, List.of(candidate)).await().indefinitely();
 
-    assertThat(result.workerId()).isEqualTo("agent-x");
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-x");
   }
 
   @Test
-  void anonymousImplementation_emptyCandidates_returnsNoOp() {
-    final AgentRoutingStrategy strategy = (ctx, candidates) -> AgentAssignment.noOp();
-    final AgentRoutingContext ctx = new AgentRoutingContext(UUID.randomUUID(), "research");
+  void implementation_emptyCandidates_returnsUnresolvable() {
+    final AgentRoutingStrategy strategy =
+        (ctx, candidates) -> Uni.createFrom().item(AgentAssignment.unresolvable());
+    final AgentRoutingContext ctx =
+        new AgentRoutingContext(UUID.randomUUID(), "research", NullNode.instance);
 
-    assertThat(strategy.select(ctx, List.of()).isNoOp()).isTrue();
+    final AgentAssignment result = strategy.select(ctx, List.of()).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  @Test
+  void implementation_canReturnEscalateToOversight() {
+    final AgentRoutingStrategy strategy =
+        (ctx, candidates) -> Uni.createFrom().item(AgentAssignment.escalate(ctx.capabilityName()));
+    final AgentRoutingContext ctx =
+        new AgentRoutingContext(UUID.randomUUID(), "sensitive-review", NullNode.instance);
+
+    final AgentAssignment result = strategy.select(ctx, List.of()).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).capabilityName())
+        .isEqualTo("sensitive-review");
   }
 }

--- a/common/src/main/java/io/casehub/engine/common/internal/event/AgentRoutingEscalationEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/AgentRoutingEscalationEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.common.internal.event;
+
+import java.util.UUID;
+
+/**
+ * Published to {@link EventBusAddresses#AGENT_ROUTING_ESCALATION} when all trust-eligible agent
+ * candidates for a capability are borderline (trust score within {@code borderlineMargin} of {@code
+ * threshold}). Signals that human oversight is required to decide which agent should handle the
+ * capability for this case.
+ *
+ * <p>Handler: {@code AgentRoutingEscalationHandler} posts a QUERY to the case's oversight channel
+ * so a human supervisor can make the routing decision.
+ *
+ * <p>PlanItem state during escalation: stays PENDING. Response handling (COMMAND → re-trigger
+ * routing) tracked in engine#383.
+ */
+public record AgentRoutingEscalationEvent(UUID caseId, String capabilityName, String bindingName) {}

--- a/common/src/main/java/io/casehub/engine/common/internal/event/EventBusAddresses.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/EventBusAddresses.java
@@ -46,4 +46,6 @@ public final class EventBusAddresses {
   public static final String SUBCASE_SCHEDULE = "casehub.subcase.schedule";
 
   public static final String HUMAN_TASK_SCHEDULE = "casehub.humantask.schedule";
+
+  public static final String AGENT_ROUTING_ESCALATION = "casehub.agent.routing.escalation";
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -70,45 +70,60 @@ An optional module that writes an immutable, hash-chained audit record for every
 
 ## Execution Models
 
-casehub-engine is a **hybrid choreography+orchestration engine**. Both models share the same worker selection infrastructure (`WorkBroker`, `WorkerSelectionStrategy`, `WorkloadProvider`) and the same Quartz execution layer.
+casehub-engine is a **hybrid choreography+orchestration engine**. Both models share the same worker selection infrastructure (`AgentRoutingStrategy` SPI, `AgentCandidateFactory`) and the same Quartz execution layer.
 
 ### Choreography (Binding-Driven)
 
-Context changes trigger binding evaluations. When a binding's condition is met, `CaseContextChangedEventHandler` builds a `WorkerCandidate` list from capable workers, calls `WorkBroker.apply()` with `LeastLoadedStrategy`, and publishes a `WorkerScheduleEvent` for the selected worker. If no pre-defined workers match a capability, the engine calls `tryProvision()` to attempt dynamic provisioning via the registered `WorkerProvisioner` SPI. The case remains `RUNNING` throughout.
+Context changes trigger binding evaluations. When a binding's condition is met, `CaseContextChangedEventHandler` builds an `AgentCandidate` list (via `AgentCandidateFactory`) from capable workers, then calls `AgentRoutingStrategy.select()` which returns `Uni<AgentAssignment>`. The result is a sealed type with three outcomes. If no pre-defined workers match a capability, the engine calls `tryProvision()` to attempt dynamic provisioning via the registered `WorkerProvisioner` SPI. The case remains `RUNNING` throughout.
 
 ```
 CaseContext change
   → CaseContextChangedEventHandler.publishByTarget()
-      CapabilityTarget → WorkBroker.apply(LeastLoadedStrategy) → WorkerScheduleEvent
+      CapabilityTarget → AgentRoutingStrategy.select(ctx, candidates) → Uni<AgentAssignment>
+                           Assigned(workerId)        → WorkerScheduleEvent
+                           Unresolvable()            → tryProvision()
+                           EscalateToOversight(cap)  → AgentRoutingEscalationEvent
+                                                          → AgentRoutingEscalationHandler
+                                                          → QUERY posted to oversight channel
       SubCaseTarget    → SubCaseScheduleEvent
       HumanTaskTarget  → inputMapping evaluated → HumanTaskScheduleEvent
       ExtensionTarget  → warning log, no dispatch
 
-  [CapabilityTarget path]
+  [Assigned path]
   → WorkerScheduleEvent → WorkerScheduleEventHandler
       → WorkerContextProvider.buildContext()             [always called]
       → Quartz
   → WorkflowExecutionCompleted → CaseContext updated → next binding fires
 
-  → tryProvision(caseInstance, capability)               [no candidates]
+  [Unresolvable path]
+  → tryProvision(caseInstance, capability)
       → WorkerProvisioner.provision() if capability advertised
       → ProvisioningException caught; binding stays eligible
+
+  [EscalateToOversight path — trust-maturity-model.md Phase 2]
+  → AgentRoutingEscalationHandler: QUERY to oversight channel
+  → PlanItem stays PENDING awaiting human routing decision (engine#383)
 ```
 
+**AgentAssignment sealed type** (from `casehub-engine-api`):
+- `Assigned(workerId)` — a specific worker was selected
+- `Unresolvable()` — no candidates passed trust filters (below threshold, not borderline)
+- `EscalateToOversight(capabilityName)` — all trust-eligible candidates are borderline; human oversight required
+
 **Semantics:**
-- No case suspension. Work flows continuously.
+- No case suspension. Work flows continuously (except escalation, which parks pending human decision).
 - Bindings are passive (triggered by context change), not imperative.
 - Worker order emerges from dependency, not direction.
-- All capable workers compete for selection; LeastLoadedStrategy picks the least-loaded.
+- All capable workers compete for selection; routing strategy selects the best candidate.
 - WAITING cases (blackboard active) also receive CONTEXT_CHANGED — PlanItem dedup in `PlanningStrategyLoopControl` prevents re-dispatch of in-flight bindings; external signals (Qhorus human messages, `CaseHubRuntime.signal()`) can unblock a WAITING case.
 
 ### Orchestration (Explicit Work Submission)
 
-`WorkOrchestrator.submit(CaseInstance, WorkRequest)` selects a worker via `WorkBroker`, publishes a `WorkerScheduleEvent`, and returns a `CompletionStage<WorkResult>`. `WorkOrchestrator.submitAndWait()` additionally suspends the case to `WAITING`; `WorkflowExecutionCompletedHandler` resumes it when the matching worker completes.
+`WorkOrchestrator.submit(CaseInstance, WorkRequest)` selects a worker via `AgentRoutingStrategy.select()` (blocking `await().indefinitely()` — not on Vert.x IO thread), publishes a `WorkerScheduleEvent`, and returns a `CompletionStage<WorkResult>`. `WorkOrchestrator.submitAndWait()` additionally suspends the case to `WAITING`; `WorkflowExecutionCompletedHandler` resumes it when the matching worker completes. On `EscalateToOversight`, the future completes exceptionally and an `AgentRoutingEscalationEvent` is published.
 
 ```
 WorkOrchestrator.submitAndWait(instance, request)
-  → WorkBroker selects worker
+  → AgentRoutingStrategy.select(ctx, candidates).await().indefinitely()
   → WORK_SUBMITTED written to EventLog (durable)
   → case transitions to WAITING, waitingForWorkId persisted
   → WorkerScheduleEvent → Quartz executes worker
@@ -124,18 +139,22 @@ WorkOrchestrator.submitAndWait(instance, request)
 - Optionally transitions the case to WAITING (for critical milestones).
 - Survives JVM restart: correlation key persists, futures re-registered on startup.
 
-### Worker Selection (Shared Infrastructure)
+### Agent Routing (Shared Infrastructure)
 
 | Component | Role |
 |---|---|
-| `WorkBroker` (quarkus-work-core) | Trigger gate + capability filter + strategy dispatch |
-| `LeastLoadedStrategy` (quarkus-work-core) | Selects worker with fewest active Quartz jobs |
-| `CasehubWorkloadProvider` | Counts active Quartz jobs per worker name |
-| `NoOpWorkerRegistry` (quarkus-work-core) | Group resolution (no-op; workers come from CaseDefinition) |
+| `AgentRoutingStrategy` (casehub-engine-api SPI) | Selects worker from pre-filtered candidates; returns `Uni<AgentAssignment>` |
+| `LeastLoadedAgentStrategy` (casehub-engine, `@DefaultBean`) | Selects worker with fewest active Quartz jobs |
+| `TrustWeightedAgentStrategy` (casehub-engine-ledger, `@Alternative @Priority(1)`) | Four-phase trust maturity model; escalates when all candidates borderline |
+| `SemanticAgentRoutingStrategy` (casehub-engine-ai, `@Alternative @Priority(2)`, optional) | Trust filtering + embedding-based re-ranking of QUALIFIED candidates |
+| `TrustCandidateClassifier` (casehub-engine-ledger, `@ApplicationScoped`) | Shared CDI bean; classifies candidates by phase (BOOTSTRAP/QUALIFIED/BORDERLINE/EXCLUDED_PHASE2B/EXCLUDED_PHASE3) |
+| `AgentCandidateFactory` (casehub-engine, static) | Builds `AgentCandidate` list from workers; health-probed; shared by both handlers |
+| `AgentRoutingEscalationHandler` (casehub-engine, `@ConsumeEvent(blocking=true)`) | Posts QUERY to oversight channel when all candidates are borderline |
 
-All selection paths converge on `WorkBroker.apply()`:
-- **Input:** `SelectionContext` (workload type, filters), `AssignmentTrigger` (CREATED), `WorkerCandidate` list (capability-filtered workers with load counts), `WorkerSelectionStrategy` (LeastLoadedStrategy)
-- **Output:** `AssignmentDecision` (either `assignTo(workerId)` or `noChange()`)
+All selection paths pass through `AgentRoutingStrategy.select(AgentRoutingContext, List<AgentCandidate>)`:
+- **Input:** `AgentRoutingContext` (caseId, capabilityName, caseContext as JsonNode), pre-filtered `AgentCandidate` list (capability-matched, health-probed, Unavailable excluded)
+- **Output:** `Uni<AgentAssignment>` — sealed type: `Assigned(workerId)`, `Unresolvable()`, or `EscalateToOversight(capabilityName)`
+- **AgentEmbeddingProvider SPI** (casehub-engine-ai): blocking embed() called on worker pool; no `@DefaultBean` — startup fails if module present without a provider (engine#381 tracks LangChain4j impl)
 
 ### SubCaseBinding (casehub-blackboard)
 

--- a/docs/adr/0003-agent-routing-strategy-reactive-spi.md
+++ b/docs/adr/0003-agent-routing-strategy-reactive-spi.md
@@ -1,0 +1,79 @@
+# 0003 — AgentRoutingStrategy Returns Uni<AgentAssignment>
+
+Date: 2026-05-29
+Status: Accepted
+
+## Context and Problem Statement
+
+`AgentRoutingStrategy.select()` was initially synchronous, returning `AgentAssignment`
+directly. When `SemanticAgentRoutingStrategy` was introduced (engine#376), its
+implementations were expected to call external embedding services — a blocking I/O
+operation. Calling blocking code from the Vert.x IO thread (where `@ConsumeEvent`
+handlers run) is a hard violation, not a performance concern.
+
+## Decision Drivers
+
+* `SemanticAgentRoutingStrategy` needs to call a blocking embedding provider over HTTP
+* `CaseContextChangedEventHandler` is a `@ConsumeEvent` handler running on the Vert.x IO thread
+* Retrofitting a synchronous SPI to reactive later is a breaking multi-repo change
+  requiring all call sites (handlers, tests, mocks) to be updated simultaneously
+* At point of change there were exactly two implementations — the smallest possible
+  migration cost
+
+## Considered Options
+
+* **Option A** — Return `Uni<AgentAssignment>` from the SPI (reactive from day one)
+* **Option B** — Keep the SPI synchronous; mark `CaseContextChangedEventHandler` as `blocking = true`
+* **Option C** — Keep the SPI synchronous; wrap `select()` calls in `Uni.createFrom().blocking()`
+  at each call site
+
+## Decision Outcome
+
+Chosen option: **Option A**, because it places the threading contract in the SPI
+itself — the only location that knows which implementations may block. Options B and C
+scatter the threading decision to callers, all of whom would need updating individually
+if the strategy ever moved to async I/O.
+
+### Positive Consequences
+
+* Embedding providers, external trust services, and other blocking implementations
+  are safe to write without caller changes
+* Call sites chain naturally into the existing `Uni<Void>` reactive pipeline in
+  `CaseContextChangedEventHandler`
+* In-memory strategies (`LeastLoadedAgentStrategy`, `TrustWeightedAgentStrategy`)
+  use `Uni.createFrom().item(result)` — zero overhead
+
+### Negative Consequences / Tradeoffs
+
+* `@FunctionalInterface` annotation removed — lambda implementations must be typed
+  explicitly (not inferred)
+* `WorkOrchestrator.doSubmit()` uses `.await().indefinitely()` to bridge to its
+  `CompletableFuture<WorkResult>` return — acceptable because it runs off the IO thread
+
+## Pros and Cons of the Options
+
+### Option A — Reactive SPI (`Uni<AgentAssignment>`)
+
+* ✅ Blocking I/O is safe from any call site
+* ✅ Reactive chain in handlers stays clean
+* ✅ Correct threading contract at the abstraction boundary
+* ❌ Removes `@FunctionalInterface`; lambda implementations need explicit typing
+
+### Option B — Synchronous SPI, blocking handler
+
+* ✅ SPI stays simple
+* ❌ Entire handler dispatches to a worker thread, including all in-memory work before routing
+* ❌ Threading decision buried in handler annotation, not the SPI
+
+### Option C — Synchronous SPI, `Uni.createFrom().blocking()` at call sites
+
+* ✅ SPI stays simple
+* ❌ Every call site must be updated if blocking strategies arrive after a
+  synchronous retrofit
+* ❌ Two implementations updated → four call sites updated → higher migration cost
+
+## Links
+
+* engine#376 — SemanticAgentRoutingStrategy (trigger for this decision)
+* PP-20260529-9f9627 — protocol: strategy SPIs that may block must return Uni<T>
+* GE-20260529-ff186e — garden: correct Mutiny pattern for blocking I/O in reactive SPI

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -4,3 +4,4 @@
 |----|-------|--------|------|
 | 0001 | [humanTask as first-class YAML binding target](0001-humantask-yaml-binding-target.md) | Accepted | 2026-05-20 |
 | 0002 | [Stage autocomplete triggers on any terminal PlanItem state](0002-stage-autocomplete-on-any-terminal-planitem-state.md) | Accepted | 2026-05-26 |
+| 0003 | [AgentRoutingStrategy returns Uni<AgentAssignment>](0003-agent-routing-strategy-reactive-spi.md) | Accepted | 2026-05-29 |

--- a/docs/specs/2026-05-28-semantic-routing-escalation-design.md
+++ b/docs/specs/2026-05-28-semantic-routing-escalation-design.md
@@ -1,0 +1,631 @@
+# Design Spec: Semantic Agent Routing + Borderline Escalation
+
+**Issues:** engine#376, engine#377
+**Branch:** `issue-376-377-semantic-routing-escalation`
+**Date:** 2026-05-28
+**Status:** Approved (rev 2 — post code review)
+
+---
+
+## Context
+
+`TrustWeightedAgentStrategy` (engine#336) implements the four-phase trust maturity model
+(protocol `trust-maturity-model.md`). Two capabilities are missing:
+
+- **Phase 2 escalation (engine#377):** when all trust-eligible candidates are borderline
+  (score within `borderlineMargin` of `threshold`), the strategy returns `noOp()` — a dead
+  end. Phase 2 of the trust maturity model requires routing to human oversight, not silent
+  failure.
+
+- **Semantic routing (engine#376):** `AgentRoutingStrategy` has no access to the case
+  context, so no strategy can match agent vocabulary against the situation being handled.
+  Embedding-based selection was deliberately deferred from the original SPI design.
+
+These two issues share the same architectural seam — `AgentAssignment`,
+`AgentRoutingStrategy`, and the trust-scoring path — and must be designed together.
+
+---
+
+## Design
+
+### 1. `AgentAssignment` — sealed type
+
+The current `AgentAssignment` record collapses three semantically distinct routing
+outcomes into one null discriminant. The engine's response to each is different; the
+type must reflect that.
+
+```java
+// api/src/main/java/io/casehub/api/spi/routing/AgentAssignment.java
+public sealed interface AgentAssignment
+    permits AgentAssignment.Assigned,
+            AgentAssignment.Unresolvable,
+            AgentAssignment.EscalateToOversight {
+
+  /** A specific worker was selected. */
+  record Assigned(String workerId) implements AgentAssignment {}
+
+  /**
+   * No candidate passed trust filters. None were borderline — the pool lacks qualified
+   * agents. Engine falls to tryProvision().
+   */
+  record Unresolvable() implements AgentAssignment {}
+
+  /**
+   * All trust-eligible candidates are borderline (score within borderlineMargin of
+   * threshold). Engine must route to human oversight per trust-maturity-model.md Phase 2.
+   */
+  record EscalateToOversight(String capabilityName) implements AgentAssignment {}
+
+  static AgentAssignment assign(String workerId)         { return new Assigned(workerId); }
+  static AgentAssignment unresolvable()                   { return new Unresolvable(); }
+  static AgentAssignment escalate(String capabilityName) { return new EscalateToOversight(capabilityName); }
+}
+```
+
+`isNoOp()` is removed. All callers switch exhaustively on the sealed type.
+
+**Breaking callers (all must be updated):**
+- `AgentRoutingStrategyContractTest` — validate all three return variants
+- `LeastLoadedAgentStrategy` — returns `Assigned` or `Unresolvable` (never escalates)
+- `TrustWeightedAgentStrategy` — returns correct variant
+- `CaseContextChangedEventHandler` — pattern-match switch
+- `WorkOrchestrator` — see Section 8
+- All `@QuarkusTest` mocks of `AgentRoutingStrategy`
+- All test construction sites that call `AgentAssignment.noOp()` — replaced by
+  `AgentAssignment.unresolvable()` or `AgentAssignment.escalate(...)` as appropriate
+
+---
+
+### 2. `AgentRoutingStrategy` — reactive SPI
+
+The current `select()` is synchronous. `SemanticAgentRoutingStrategy` requires blocking
+HTTP calls to an embedding service. Calling a blocking method on the Vert.x IO thread
+(from a `@ConsumeEvent` handler returning `Uni<Void>`) is a runtime violation, not a
+performance concern — Vert.x detects and logs IO-thread blocking under load.
+
+The correct fix is a reactive SPI:
+
+```java
+// api/src/main/java/io/casehub/api/spi/routing/AgentRoutingStrategy.java
+public interface AgentRoutingStrategy {   // @FunctionalInterface removed
+
+  /**
+   * Select a worker from the pre-filtered candidate list.
+   *
+   * Implementations that do only in-memory work return Uni.createFrom().item(result).
+   * Implementations that call blocking services (e.g. embedding providers) return a
+   * reactive chain that executes on an appropriate executor — never blocking the IO
+   * thread.
+   */
+  Uni<AgentAssignment> select(AgentRoutingContext context, List<AgentCandidate> candidates);
+}
+```
+
+All callers chain `agentRoutingStrategy.select(ctx, candidates)` into the existing
+`Uni<Void>` pipeline.
+
+**`LeastLoadedAgentStrategy`:**
+```java
+public Uni<AgentAssignment> select(...) {
+    return Uni.createFrom().item(() -> /* existing logic */);
+}
+```
+
+**`TrustWeightedAgentStrategy`:**
+```java
+public Uni<AgentAssignment> select(...) {
+    return Uni.createFrom().item(() -> /* existing logic */);
+}
+```
+
+**`SemanticAgentRoutingStrategy`:**
+```java
+public Uni<AgentAssignment> select(...) {
+    // classify synchronously (in-memory trust cache)
+    List<ClassifiedCandidate> classified = classifier.classify(...);
+    // collect QUALIFIED candidates needing embedding
+    // embed in blocking context, then decide
+    return Uni.createFrom().voidItem()
+        .emitOn(Infrastructure.getDefaultWorkerPool())  // move off IO thread
+        .map(ignored -> { /* blocking embed + decide */ });
+}
+```
+
+**`WorkOrchestrator`:** currently uses `CompletableFuture`. Convert the call site to
+`.subscribe().asCompletionStage()`, or wrap in a `Uni.createFrom().item()` call on the
+caller's thread. See Section 8 for full `WorkOrchestrator` treatment.
+
+**`@FunctionalInterface` removed:** lambdas still work as implementations since
+`Uni<AgentAssignment>` lambdas are valid for the SAM shape — but the annotation no
+longer applies because lambdas returning `Uni` may not be concretely inferable without
+explicit typing in all cases. Implementations are concrete classes.
+
+---
+
+### 3. `TrustRoutingPolicy` — phase predicate methods
+
+Per GE-20260511-2b3d3e: trust-phase logic belongs on the value object, not the router.
+
+```java
+// ledger/src/main/java/io/casehub/ledger/routing/TrustRoutingPolicy.java
+public record TrustRoutingPolicy(...) {
+
+  /** True when an agent lacks sufficient decision history for trust-based routing. */
+  public boolean isBootstrap(int decisionCount) {
+    return decisionCount < minimumObservations;
+  }
+
+  /**
+   * True when the trust score is close to the threshold in either direction.
+   * Note: a borderline candidate is NOT qualified for assignment — it is excluded.
+   * Borderline is a distinct Phase 2a state, not a passing check.
+   */
+  public boolean isBorderline(double score) {
+    return Math.abs(score - threshold) <= borderlineMargin;
+  }
+
+  /**
+   * True when the score exceeds the threshold and is not borderline.
+   * This is a Phase 2 first-pass check only — Phase 3 quality floors may still
+   * exclude a candidate that passes this check. Do not interpret as "ready to assign".
+   */
+  public boolean passesThresholdCheck(double score) {
+    return score >= threshold && !isBorderline(score);
+  }
+}
+```
+
+`isBorderline` and `passesThresholdCheck` are named to reflect their meaning precisely
+rather than implying a final verdict. Both strategies call these instead of duplicating
+the arithmetic.
+
+---
+
+### 4. `TrustCandidateClassifier` — `@ApplicationScoped` CDI bean
+
+Both `TrustWeightedAgentStrategy` and `SemanticAgentRoutingStrategy` share the same
+4-phase classification loop and the same outcome decision. This utility is extracted as
+a CDI bean so it is discoverable via the standard Quarkus CDI path (no Maven visibility
+hacks required — both consumers depend on `casehub-engine-ledger`).
+
+`classify()` and `decide()` accept all data as parameters. There is no mutable state;
+singleton (`@ApplicationScoped`) is safe and correct.
+
+```java
+// ledger/src/main/java/io/casehub/ledger/routing/TrustCandidateClassifier.java
+@ApplicationScoped
+public class TrustCandidateClassifier {
+
+  /**
+   * Phase classification for a single candidate.
+   *
+   * BOOTSTRAP        — Phase 0/1: insufficient history; workload routing applies.
+   * QUALIFIED        — Phase 2/3 passed: trust + workload blend applies.
+   * BORDERLINE       — Phase 2a: score within margin of threshold; excluded.
+   *                    Tracked separately from EXCLUDED for escalation decisions.
+   * EXCLUDED_PHASE2B — Phase 2b: score below threshold; excluded.
+   * EXCLUDED_PHASE3  — Phase 3: passed threshold but failed a quality floor; excluded.
+   *                    Distinct from EXCLUDED_PHASE2B for future diagnostic use.
+   */
+  public enum Phase {
+    BOOTSTRAP, QUALIFIED, BORDERLINE, EXCLUDED_PHASE2B, EXCLUDED_PHASE3
+  }
+
+  public record ClassifiedCandidate(
+      AgentCandidate candidate,
+      Phase phase,
+      OptionalDouble trustScore,   // empty for BOOTSTRAP (no signal); present otherwise
+      double workloadScore         // 1/(1+runningJobs) — always computed
+  ) {
+    /** Convenience: true when this candidate is any form of excluded. */
+    public boolean isExcluded() {
+      return phase == Phase.BORDERLINE
+          || phase == Phase.EXCLUDED_PHASE2B
+          || phase == Phase.EXCLUDED_PHASE3;
+    }
+  }
+
+  public List<ClassifiedCandidate> classify(
+      List<AgentCandidate> candidates,
+      String capabilityName,
+      TrustRoutingPolicy policy,
+      TrustScoreCache cache
+  ) { /* full 4-phase classification */ }
+
+  /**
+   * Given classified candidates and their final scores (after strategy-specific
+   * scoring), determine the routing outcome.
+   *
+   * Rule: if any candidate scored > 0.0 → Assigned(highest).
+   *       if all scored 0.0 and any was BORDERLINE → EscalateToOversight.
+   *       if all scored 0.0 and none was BORDERLINE → Unresolvable.
+   */
+  public AgentAssignment decide(
+      List<ClassifiedCandidate> classified,
+      List<ScoredCandidate> scored,
+      String capabilityName
+  ) { /* outcome decision */ }
+
+  /** Internal record — candidate + its final routing score. */
+  public record ScoredCandidate(ClassifiedCandidate classified, double finalScore) {}
+}
+```
+
+`OptionalDouble trustScore` enforces at the type level that BOOTSTRAP candidates carry
+no trust signal. Any code that reads `trustScore` must handle the empty case; it cannot
+accidentally receive NaN.
+
+`EXCLUDED_PHASE2B` vs `EXCLUDED_PHASE3` preserves the diagnostic information about why
+a candidate was excluded. The `decide()` outcome logic is unchanged — both are non-
+borderline exclusions leading to `Unresolvable` when all candidates are in this state.
+
+---
+
+### 5. `TrustWeightedAgentStrategy` — refactored
+
+Uses `TrustCandidateClassifier` (injected) and the `TrustRoutingPolicy` predicate methods:
+
+```
+classify(candidates) → List<ClassifiedCandidate>
+for each classified:
+    BOOTSTRAP         → workloadScore  (unchanged Gastown parity)
+    QUALIFIED         → trust × blendFactor + workload × (1-blendFactor)
+    BORDERLINE        → 0.0
+    EXCLUDED_PHASE2B  → 0.0
+    EXCLUDED_PHASE3   → 0.0
+decide(classified, scored, capabilityName) → AgentAssignment
+return Uni.createFrom().item(result)
+```
+
+Scoring algorithm unchanged. Mixed-pool policy preserved: BOOTSTRAP always produces a
+positive workload score, so bootstrap candidates are selected before the all-zero case
+triggers escalation.
+
+---
+
+### 6. `AgentRoutingContext` — add `caseContext`
+
+```java
+// api/src/main/java/io/casehub/api/spi/routing/AgentRoutingContext.java
+public record AgentRoutingContext(UUID caseId, String capabilityName, JsonNode caseContext) {}
+```
+
+**Construction sites (all must pass caseContext):**
+- `CaseContextChangedEventHandler` — `objectMapper.valueToTree(caseInstance.getContext())`
+- `WorkOrchestrator` — same pattern; `objectMapper` is already in scope
+- All test construction sites of `AgentRoutingContext` — two-arg form no longer compiles;
+  every test file must be updated. Use `NullNode.instance` or a test fixture for tests
+  that don't exercise semantic routing.
+
+`LeastLoadedAgentStrategy` and `TrustWeightedAgentStrategy` ignore `caseContext`.
+
+---
+
+### 7. `AgentCandidate` — add `agentDescriptor`
+
+```java
+// api/src/main/java/io/casehub/api/spi/routing/AgentCandidate.java
+public record AgentCandidate(
+    String workerId,
+    Set<String> capabilities,
+    int runningJobs,
+    AgentHealth health,
+    AgentDescriptor agentDescriptor   // nullable; null if no descriptor registered
+) {}
+```
+
+`AgentDescriptor` from `casehub-eidos-api` is already a transitive dependency of
+`casehub-engine-api` (used in `Worker.java`). No new module dependency.
+
+When `agentDescriptor` is null, `SemanticAgentRoutingStrategy` treats the candidate as
+BOOTSTRAP (availability routing; no semantic signal available). This preserves the
+"never block on missing data" invariant.
+
+---
+
+### 8. `AgentCandidateFactory` — shared construction utility
+
+Both `CaseContextChangedEventHandler` and `WorkOrchestrator` independently implement
+`buildCandidates()`. Both now need the same update (add `agentDescriptor`). Rather than
+update both independently, extract to a shared static utility:
+
+```java
+// runtime/src/main/java/io/casehub/engine/internal/routing/AgentCandidateFactory.java
+public final class AgentCandidateFactory {
+
+  private AgentCandidateFactory() {}
+
+  public static List<AgentCandidate> buildCandidates(
+      CaseInstance caseInstance,
+      List<Worker> workers,
+      Capability capability,
+      WorkerExecutionManager executionManager,
+      CapabilityHealth capabilityHealth
+  ) { /* shared implementation — moved from both handlers */ }
+}
+```
+
+Both handlers call `AgentCandidateFactory.buildCandidates(...)`. The existing logic
+(health probing, filtering unavailable workers, computing `runningJobs`) is unchanged.
+`worker.agentDescriptor()` is passed through; null if the worker has no registered
+descriptor.
+
+---
+
+### 9. `CaseChannel` — `oversightChannelName` convenience method
+
+The escalation handler needs to find the oversight channel by name. Spelling out a string
+literal at each call site is fragile. Add a static convenience consistent with the
+existing `channelName(UUID, String)` pattern:
+
+```java
+// casehub-engine-common/.../CaseChannel.java
+public static String oversightChannelName(UUID caseId) {
+    return channelName(caseId, "oversight");
+}
+```
+
+The escalation handler calls `CaseChannel.oversightChannelName(caseId)` and passes the
+result to `CaseChannelProvider.listChannels(caseId).stream().filter(c ->
+c.name().equals(oversightName)).findFirst()`.
+
+---
+
+### 10. Engine handler — pattern-match on `AgentAssignment`
+
+`CaseContextChangedEventHandler.publishWorkerSchedule()`:
+
+```java
+agentRoutingStrategy.select(ctx, candidates)
+    .chain(assignment -> switch (assignment) {
+        case AgentAssignment.Assigned a ->
+            scheduleWorker(caseInstance, workers, a.workerId(), binding, capability);
+        case AgentAssignment.Unresolvable() ->
+            tryProvision(caseInstance, capability);
+        case AgentAssignment.EscalateToOversight e ->
+            handleEscalation(caseInstance, e, binding);
+    });
+```
+
+**`handleEscalation`:** publishes `AgentRoutingEscalationEvent` to Vert.x event bus at
+`EventBusAddresses.AGENT_ROUTING_ESCALATION`. PlanItem stays PENDING.
+
+```java
+record AgentRoutingEscalationEvent(
+    UUID caseId,
+    String capabilityName,
+    String bindingName
+) {}
+```
+
+---
+
+### 11. `AgentRoutingEscalationHandler`
+
+```java
+@ApplicationScoped
+public class AgentRoutingEscalationHandler {
+
+  @ConsumeEvent(value = EventBusAddresses.AGENT_ROUTING_ESCALATION, blocking = true)
+  public void handle(AgentRoutingEscalationEvent event) {
+    String oversightName = CaseChannel.oversightChannelName(event.caseId());
+    channelProvider.listChannels(event.caseId()).stream()
+        .filter(c -> c.name().equals(oversightName))
+        .findFirst()
+        .ifPresentOrElse(
+            channel -> postQuery(channel, event),
+            () -> LOG.warnf(
+                "[METRIC:escalation.no-oversight-channel] caseId=%s capability=%s — " +
+                "escalation swallowed; no oversight channel open. " +
+                "In production deployments this PlanItem will remain PENDING indefinitely. " +
+                "engine#379 tracks PlanItem state handling during escalation.",
+                event.caseId(), event.capabilityName())
+        );
+  }
+}
+```
+
+The "no oversight channel" case is an operational gap, not just a log line. The warning
+message is prefixed `[METRIC:escalation.no-oversight-channel]` so it can be wired to an
+alert in log-based monitoring. In dev/test with `NoOpCaseChannelProvider`
+(`listChannels()` returns `List.of()`), escalation is silently absorbed — this is
+expected test behavior and is documented in the handler.
+
+---
+
+### 12. `WorkOrchestrator` — three required updates
+
+1. **`AgentRoutingContext` construction:** add `caseContext` argument.
+   `objectMapper.valueToTree(instance.getCaseContext())`.
+
+2. **`buildCandidates()` → `AgentCandidateFactory.buildCandidates(...)`:** same pattern
+   as `CaseContextChangedEventHandler`.
+
+3. **`select()` return type and `EscalateToOversight` handling:**
+   `doSubmit()` calls `agentRoutingStrategy.select(ctx, candidates)` synchronously
+   (inside a CompletableFuture chain on a non-IO thread). Wrap in `.subscribe().asCompletionStage()`.
+   When the result is `EscalateToOversight`: publish the escalation event to the Vert.x
+   event bus (same path as `CaseContextChangedEventHandler.handleEscalation`). The
+   CompletableFuture completes with an empty result (no worker scheduled). Completing
+   exceptionally would signal failure; the escalation is not a failure — it is a pending
+   governance decision.
+
+---
+
+### 13. New module: `casehub-engine-ai`
+
+An optional module. When NOT on the classpath: `TrustWeightedAgentStrategy` is the
+highest-priority routing strategy. When on the classpath:
+`SemanticAgentRoutingStrategy` (@Priority(2)) activates.
+
+**Maven module setup:**
+- Add `<module>casehub-engine-ai</module>` to root `pom.xml`
+- Set `<maven.deploy.skip>true</maven.deploy.skip>` in the module's `pom.xml` — this is
+  optional infrastructure without a stable embedding provider; do not publish to GitHub
+  Packages until engine#381 ships
+- No separate version property needed — follows the engine parent POM version
+
+**`casehub-engine-ai` dependencies:**
+- `casehub-engine-api` (AgentRoutingStrategy SPI, AgentCandidate, AgentRoutingContext)
+- `casehub-engine-ledger` (TrustCandidateClassifier, TrustScoreCache, TrustRoutingPolicyProvider)
+- `casehub-engine-common` (JQEvaluator)
+- `casehub-eidos-api` (AgentDescriptor, AgentCapability)
+
+**`AgentEmbeddingProvider` SPI:**
+
+```java
+// casehub-engine-ai/src/main/java/io/casehub/engine/ai/spi/AgentEmbeddingProvider.java
+public interface AgentEmbeddingProvider {
+
+  /**
+   * Embed text to a float vector. May block (network IO to embedding service).
+   * Callers must invoke from a worker thread, never from the Vert.x IO thread.
+   *
+   * <p>Implementations MUST be thread-safe — this method may be called concurrently
+   * from multiple routing decisions.
+   */
+  float[] embed(String text);
+
+  /** Cosine similarity. Returns 0.0 for zero vectors (no NaN). */
+  static double cosineSimilarity(float[] a, float[] b) {
+    double dot = 0, magA = 0, magB = 0;
+    for (int i = 0; i < a.length; i++) {
+      dot += a[i] * b[i]; magA += a[i] * a[i]; magB += b[i] * b[i];
+    }
+    return (magA == 0 || magB == 0) ? 0.0 : dot / (Math.sqrt(magA) * Math.sqrt(magB));
+  }
+}
+```
+
+No `@DefaultBean`. Including `casehub-engine-ai` without a provider causes an
+unsatisfied dependency error at CDI startup. This is intentional: semantic routing
+without an embedding model is a misconfiguration.
+
+A LangChain4j-backed implementation is tracked in **engine#381**.
+
+**Config:**
+```properties
+# Weight of semantic similarity in the final score
+# (0.0 = pure trust+workload, 1.0 = pure semantic)
+casehub.engine.ai.semantic-weight=0.4
+
+# JQ expression applied to caseContext before embedding; identity by default
+casehub.engine.ai.context-summary-jq=.
+```
+
+**`SemanticAgentRoutingStrategy`** (`@Alternative @Priority(2) @ApplicationScoped`):
+
+```
+classify(candidates, capabilityName, policy, cache) → List<ClassifiedCandidate>
+
+// Executed on worker thread (emitOn):
+queryText  = extractQueryText(context.caseContext(), context.capabilityName())
+queryVector = embeddingProvider.embed(queryText)
+
+for each classified candidate:
+    BOOTSTRAP            → workloadScore (Gastown parity; no semantic signal)
+    BORDERLINE           → 0.0 (tracked; escalation if all excluded)
+    EXCLUDED_PHASE2B/3   → 0.0
+    QUALIFIED (descriptor non-null) →
+        docText   = buildVocabularyText(candidate.agentDescriptor())
+        docVector = embeddingProvider.embed(docText)
+        semantic  = cosineSimilarity(queryVector, docVector)
+        trustBlend = trustScore × blendFactor + workload × (1-blendFactor)
+        finalScore = semantic × semanticWeight + trustBlend × (1-semanticWeight)
+        // effective weights at defaults (semanticWeight=0.4, blendFactor=0.6):
+        //   semantic=0.40, trust=0.36, workload=0.24 — sums to 1.0
+    QUALIFIED (descriptor null) →
+        // no descriptor → treat as BOOTSTRAP (availability routing only)
+
+decide(classified, scored, capabilityName) → AgentAssignment
+return Uni via Infrastructure.getDefaultWorkerPool()
+```
+
+**`extractQueryText` method:**
+
+```java
+private String extractQueryText(JsonNode caseContext, String capabilityName) {
+    if (caseContext == null || caseContext.isNull() || caseContext.isMissingNode()) {
+        return capabilityName;   // capability name has semantic content; "null" does not
+    }
+    ValidationResult result = jqEvaluator.eval(contextSummaryJq, caseContext);
+    if (result.hasErrors() || result.results().isEmpty()) {
+        LOG.warnf("caseContext JQ extraction failed for jq='%s'; falling back to capability name '%s'",
+            contextSummaryJq, capabilityName);
+        return capabilityName;
+    }
+    String extracted = result.results().stream()
+        .map(JsonNode::asText)
+        .filter(s -> !s.isBlank())
+        .collect(Collectors.joining(" "));
+    return extracted.isBlank() ? capabilityName : extracted;
+}
+```
+
+`JQEvaluator.eval(String expression, JsonNode input)` is the existing API — no new
+methods added to `JQEvaluator`. The fallback to `capabilityName` ensures the embedding
+call always receives meaningful text.
+
+**Vocabulary text construction** from `AgentDescriptor`:
+
+```
+{domainVocabulary} {slotVocabulary} {dispositionVocabulary}
+capability:{name} tags:{tags.join(" ")} domains:{epistemicDomains.keySet().join(" ")}
+```
+
+One text string per candidate, embedded fresh at each routing call. Vector caching is
+deferred to **engine#380**.
+
+---
+
+### 14. Testing
+
+| Test class | Module | Covers |
+|---|---|---|
+| `AgentAssignmentTest` | `api` | Sealed variants, factory methods, compile-time exhaustiveness |
+| `AgentRoutingStrategyContractTest` | `api` | Uni<AgentAssignment> return type; three variants; no @FunctionalInterface |
+| `TrustRoutingPolicyTest` | `ledger` | `isBootstrap`, `isBorderline`, `passesThresholdCheck` — edge cases on boundary |
+| `TrustCandidateClassifierTest` | `ledger` | All Phase enum values; quality floor → EXCLUDED_PHASE3; BOOTSTRAP OptionalDouble empty; decide() Escalate vs Unresolvable |
+| `TrustWeightedAgentStrategyTest` | `ledger` | New: all-borderline → EscalateToOversight; mix borderline+excluded_p2b → EscalateToOversight; all excluded no borderline → Unresolvable; BOOTSTRAP+borderline → Assigned; Uni return |
+| `SemanticAgentRoutingStrategyTest` | `casehub-engine-ai` | Mock embedding provider; semantic re-ranking; escalation path; null descriptor → BOOTSTRAP; null caseContext → capability name fallback; empty JQ result → capability name fallback |
+| `CaseContextChangedEventHandlerTest` | `engine` | Pattern-match: each sealed variant triggers correct downstream; Uni chain correctness |
+| `AgentRoutingEscalationHandlerTest` | `engine` | Oversight channel found → postToChannel called; channel not found → warning log with METRIC prefix |
+| `WorkOrchestratorTest` | `engine` | EscalateToOversight → escalation event published; Unresolvable → existing path; Assigned → schedule |
+| `AgentCandidateFactoryTest` | `engine` | Shared construction, null descriptor passthrough |
+
+---
+
+## Protocol coherence review
+
+| Protocol | Status |
+|---|---|
+| `trust-maturity-model.md` — Phase 2 → HumanOversight | ✅ `EscalateToOversight` maps to Phase 2; posts QUERY to oversight channel |
+| `no-workarounds-fix-the-design.md` — break callers | ✅ Sealed type, reactive SPI, record extensions all break callers correctly |
+| `engine-spi-noops-defaultbean.md` — no-op defaults for SPI | `AgentEmbeddingProvider` has NO default (intentional startup-fail on misconfiguration) |
+| `spi-case-id-parameter.md` — caseId through all SPI methods | ✅ `AgentRoutingContext` carries `caseId`; `AgentEmbeddingProvider` is stateless |
+| `qhorus-human-governance-channel-types.md` — oversight QUERY,COMMAND only | ✅ escalation handler posts `MessageType.QUERY` |
+| `qhorus-per-entity-governance-channels.md` — name by entity not actor | ✅ `oversightChannelName(caseId)` = `case-{caseId}/oversight` (entity-scoped) |
+| GE-20260511-2b3d3e — phase logic on policy value object | ✅ `TrustRoutingPolicy.isBootstrap/isBorderline/passesThresholdCheck` |
+
+---
+
+## Issues to file before implementation
+
+| Issue | Title | Reason |
+|---|---|---|
+| engine#378 | Oversight response loop: COMMAND from human → re-trigger routing | Requires listening on oversight channels — separate handler lifecycle |
+| engine#379 | PlanItem state during escalation (ESCALATING state, blackboard autocomplete semantics) | Must not be decided ad hoc at implementation time |
+| engine#380 | Embedding vector cache: per-(workerId, capabilityName) to amortise embed() cost | Scope; not needed for correctness but will be needed for production load |
+| engine#381 | LangChain4j `AgentEmbeddingProvider` implementation | Consumer-scope; lives in downstream module |
+| parent#80 | PLATFORM.md "Worker routing/selection" stale (still references casehub-work WorkBroker) | Already filed; verify open |
+
+---
+
+## Out of scope
+
+- Response handling when human responds to escalation QUERY (engine#378)
+- PlanItem ESCALATING state (engine#379)
+- Embedding vector caching (engine#380)
+- LangChain4j `AgentEmbeddingProvider` implementation (engine#381)
+- Per-case dynamic strategy dispatch — `spi-case-id-parameter.md` ensures the door
+  remains open; no implementation required

--- a/engine-ai/pom.xml
+++ b/engine-ai/pom.xml
@@ -9,78 +9,66 @@
         <version>0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>casehub-engine-ledger</artifactId>
-    <name>Case Hub :: Ledger</name>
-    <description>Optional immutable audit ledger — hash-chained case lifecycle entries via casehub-ledger</description>
+    <artifactId>casehub-engine-ai</artifactId>
+    <name>Case Hub :: Engine AI</name>
+    <description>Optional semantic agent routing — embedding-based candidate selection using trust + semantic similarity.
+        Requires an AgentEmbeddingProvider implementation. Without one, CDI fails at startup with an
+        unsatisfied dependency error.</description>
 
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <!-- Not published — no stable AgentEmbeddingProvider ships with this module.
+             engine#381 tracks a LangChain4j-backed implementation in a downstream module. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>
-        <!-- CaseLifecycleEvent lives in engine-common (no CDI beans — safe as compile dep) -->
-        <dependency>
-            <groupId>io.casehub</groupId>
-            <artifactId>casehub-engine-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <!-- AgentRoutingStrategy SPI — TrustWeightedAgentStrategy implements it -->
+        <!-- AgentRoutingStrategy SPI and AgentRoutingContext/AgentCandidate -->
         <dependency>
             <groupId>io.casehub</groupId>
             <artifactId>casehub-engine-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- AgentDescriptor — AgentCandidate carries it; optional in api, required here -->
+        <!-- TrustCandidateClassifier + TrustScoreCache + TrustRoutingPolicyProvider -->
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-engine-ledger</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- JQEvaluator for caseContext summarization -->
+        <dependency>
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-engine-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- AgentDescriptor and AgentCapability for vocabulary extraction -->
         <dependency>
             <groupId>io.casehub</groupId>
             <artifactId>casehub-eidos-api</artifactId>
-            <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>io.casehub</groupId>
-            <artifactId>casehub-ledger</artifactId>
-        </dependency>
-
-        <!-- CDI + JPA (blocking) for EntityManager -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-orm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-flyway</artifactId>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
         </dependency>
 
         <!-- Test -->
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-h2</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.casehub</groupId>
-            <artifactId>casehub-ledger-memory</artifactId>
-            <version>${version.io.casehub.ledger}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/engine-ai/src/main/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategy.java
+++ b/engine-ai/src/main/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategy.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.ai.routing;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.spi.routing.AgentAssignment;
+import io.casehub.api.spi.routing.AgentCandidate;
+import io.casehub.api.spi.routing.AgentRoutingContext;
+import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.casehub.eidos.api.AgentCapability;
+import io.casehub.eidos.api.AgentDescriptor;
+import io.casehub.engine.ai.spi.AgentEmbeddingProvider;
+import io.casehub.engine.common.internal.jq.JQEvaluator;
+import io.casehub.engine.common.internal.jq.ValidationResult;
+import io.casehub.ledger.routing.TrustCandidateClassifier;
+import io.casehub.ledger.routing.TrustCandidateClassifier.ClassifiedCandidate;
+import io.casehub.ledger.routing.TrustCandidateClassifier.Phase;
+import io.casehub.ledger.routing.TrustCandidateClassifier.ScoredCandidate;
+import io.casehub.ledger.routing.TrustRoutingPolicy;
+import io.casehub.ledger.routing.TrustRoutingPolicyProvider;
+import io.casehub.ledger.routing.TrustScoreCache;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Semantic {@link AgentRoutingStrategy} that re-ranks trust-qualified candidates by embedding
+ * similarity between the case context and each agent's vocabulary.
+ *
+ * <p>Trust filtering runs first (same phases as {@link
+ * io.casehub.ledger.routing.TrustWeightedAgentStrategy}). Only QUALIFIED candidates are re-ranked
+ * by semantic similarity. BORDERLINE candidates still trigger {@link
+ * AgentAssignment.EscalateToOversight} when all candidates are borderline. BOOTSTRAP candidates
+ * receive availability scoring with no semantic signal.
+ *
+ * <p>Activates at {@code @Priority(2)} — overrides {@code TrustWeightedAgentStrategy}
+ * ({@code @Priority(1)}) when on the classpath.
+ *
+ * <h3>Final score formula (effective weights at defaults: semantic=0.4, blendFactor=0.6)</h3>
+ *
+ * <pre>
+ *   trustBlend = trustScore × blendFactor + workload × (1-blendFactor)
+ *   finalScore = semantic × semanticWeight + trustBlend × (1-semanticWeight)
+ *   // defaults: semantic=0.40, trust=0.36, workload=0.24 — sums to 1.0
+ * </pre>
+ *
+ * <p>Embedding calls run on the default worker pool (not the Vert.x IO thread). The returned {@code
+ * Uni} completes on the worker pool after all embed calls finish.
+ *
+ * <p>Embedding caching tracked in engine#380.
+ */
+@Alternative
+@Priority(2)
+@ApplicationScoped
+public class SemanticAgentRoutingStrategy implements AgentRoutingStrategy {
+
+  private static final Logger LOG = Logger.getLogger(SemanticAgentRoutingStrategy.class);
+
+  private final TrustCandidateClassifier classifier;
+  private final TrustScoreCache cache;
+  private final TrustRoutingPolicyProvider policyProvider;
+  private final AgentEmbeddingProvider embeddingProvider;
+  private final JQEvaluator jqEvaluator;
+  private final double semanticWeight;
+  private final String contextSummaryJq;
+
+  @Inject
+  public SemanticAgentRoutingStrategy(
+      final TrustCandidateClassifier classifier,
+      final TrustScoreCache cache,
+      final TrustRoutingPolicyProvider policyProvider,
+      final AgentEmbeddingProvider embeddingProvider,
+      final JQEvaluator jqEvaluator,
+      @ConfigProperty(name = "casehub.engine.ai.semantic-weight", defaultValue = "0.4")
+          final double semanticWeight,
+      @ConfigProperty(name = "casehub.engine.ai.context-summary-jq", defaultValue = ".")
+          final String contextSummaryJq) {
+    this.classifier = classifier;
+    this.cache = cache;
+    this.policyProvider = policyProvider;
+    this.embeddingProvider = embeddingProvider;
+    this.jqEvaluator = jqEvaluator;
+    this.semanticWeight = semanticWeight;
+    this.contextSummaryJq = contextSummaryJq;
+  }
+
+  @Override
+  public Uni<AgentAssignment> select(
+      final AgentRoutingContext context, final List<AgentCandidate> candidates) {
+    if (candidates.isEmpty()) {
+      return Uni.createFrom().item(AgentAssignment.unresolvable());
+    }
+
+    final TrustRoutingPolicy policy = policyProvider.forCapability(context.capabilityName());
+    final List<ClassifiedCandidate> classified =
+        classifier.classify(candidates, context.capabilityName(), policy, cache);
+
+    return Uni.createFrom()
+        .voidItem()
+        .emitOn(Infrastructure.getDefaultWorkerPool())
+        .map(
+            ignored -> {
+              final String queryText =
+                  extractQueryText(context.caseContext(), context.capabilityName());
+              final float[] queryVector = embeddingProvider.embed(queryText);
+
+              final List<ScoredCandidate> scored = new ArrayList<>(classified.size());
+              for (final ClassifiedCandidate cc : classified) {
+                scored.add(new ScoredCandidate(cc, score(cc, queryVector, policy)));
+              }
+
+              return TrustCandidateClassifier.decide(classified, scored, context.capabilityName());
+            });
+  }
+
+  private double score(
+      final ClassifiedCandidate cc, final float[] queryVector, final TrustRoutingPolicy policy) {
+    return switch (cc.phase()) {
+      case Phase.BOOTSTRAP -> cc.workloadScore();
+      case Phase.BORDERLINE, Phase.EXCLUDED_PHASE2B, Phase.EXCLUDED_PHASE3 -> 0.0;
+      case Phase.QUALIFIED -> {
+        if (cc.candidate().agentDescriptor() == null) {
+          // No descriptor → treat as bootstrap (no semantic signal available)
+          yield cc.workloadScore();
+        }
+        final float[] docVector =
+            embeddingProvider.embed(buildVocabularyText(cc.candidate().agentDescriptor()));
+        final double semantic = AgentEmbeddingProvider.cosineSimilarity(queryVector, docVector);
+        final double trust = cc.trustScore().getAsDouble();
+        final double trustBlend =
+            trust * policy.blendFactor() + cc.workloadScore() * (1.0 - policy.blendFactor());
+        yield semantic * semanticWeight + trustBlend * (1.0 - semanticWeight);
+      }
+    };
+  }
+
+  private String extractQueryText(final JsonNode caseContext, final String capabilityName) {
+    if (caseContext == null || caseContext.isNull() || caseContext.isMissingNode()) {
+      return capabilityName;
+    }
+    final ValidationResult result = jqEvaluator.eval(contextSummaryJq, caseContext);
+    if (!result.ok() || result.output() == null || result.output().isEmpty()) {
+      LOG.warnf(
+          "caseContext JQ extraction failed for jq='%s'; falling back to capability name '%s'",
+          contextSummaryJq, capabilityName);
+      return capabilityName;
+    }
+    final String extracted =
+        result.output().stream()
+            .map(JsonNode::asText)
+            .filter(s -> !s.isBlank())
+            .collect(Collectors.joining(" "));
+    return extracted.isBlank() ? capabilityName : extracted;
+  }
+
+  private String buildVocabularyText(final AgentDescriptor descriptor) {
+    final StringBuilder sb = new StringBuilder();
+    appendIfNonBlank(sb, descriptor.domainVocabulary());
+    appendIfNonBlank(sb, descriptor.slotVocabulary());
+    appendIfNonBlank(sb, descriptor.dispositionVocabulary());
+    if (descriptor.capabilities() != null) {
+      for (final AgentCapability cap : descriptor.capabilities()) {
+        sb.append("\ncapability:").append(cap.name());
+        if (cap.tags() != null && !cap.tags().isEmpty()) {
+          sb.append(" tags:").append(String.join(" ", cap.tags()));
+        }
+        if (cap.epistemicDomains() != null && !cap.epistemicDomains().isEmpty()) {
+          sb.append(" domains:").append(String.join(" ", cap.epistemicDomains().keySet()));
+        }
+      }
+    }
+    return sb.toString().trim();
+  }
+
+  private static void appendIfNonBlank(final StringBuilder sb, final String value) {
+    if (value != null && !value.isBlank()) {
+      sb.append(value).append(' ');
+    }
+  }
+}

--- a/engine-ai/src/main/java/io/casehub/engine/ai/spi/AgentEmbeddingProvider.java
+++ b/engine-ai/src/main/java/io/casehub/engine/ai/spi/AgentEmbeddingProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.ai.spi;
+
+/**
+ * SPI for text embedding used by {@link io.casehub.engine.ai.routing.SemanticAgentRoutingStrategy}.
+ *
+ * <p>Implementations MUST be {@code @ApplicationScoped} (or equivalent) and thread-safe — {@link
+ * #embed(String)} may be called concurrently from multiple routing decisions.
+ *
+ * <p>No {@code @DefaultBean} is provided. If {@code casehub-engine-ai} is on the classpath without
+ * a provider, CDI fails at startup with an unsatisfied dependency error — this is intentional.
+ * Semantic routing without an embedding model is a misconfiguration. A LangChain4j-backed
+ * implementation is tracked in engine#381.
+ *
+ * <p>Engine#380 tracks embedding vector caching (per workerId + capabilityName).
+ */
+public interface AgentEmbeddingProvider {
+
+  /**
+   * Embed text to a float vector.
+   *
+   * <p>May block on network IO (embedding service call). Callers invoke this method from a worker
+   * thread — never from the Vert.x IO thread.
+   *
+   * @param text the text to embed; never null or empty
+   * @return the embedding vector; all implementations must return vectors of the same dimension
+   */
+  float[] embed(String text);
+
+  /**
+   * Cosine similarity between two vectors. Returns {@code 0.0} for zero vectors (no NaN).
+   *
+   * @param a first vector
+   * @param b second vector; must be the same length as {@code a}
+   * @return similarity in [-1, 1]; {@code 0.0} if either vector is the zero vector
+   */
+  static double cosineSimilarity(final float[] a, final float[] b) {
+    double dot = 0.0;
+    double magA = 0.0;
+    double magB = 0.0;
+    for (int i = 0; i < a.length; i++) {
+      dot += (double) a[i] * b[i];
+      magA += (double) a[i] * a[i];
+      magB += (double) b[i] * b[i];
+    }
+    if (magA == 0.0 || magB == 0.0) {
+      return 0.0;
+    }
+    return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+  }
+}

--- a/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
+++ b/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.ai.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.casehub.api.spi.routing.AgentAssignment;
+import io.casehub.api.spi.routing.AgentCandidate;
+import io.casehub.api.spi.routing.AgentHealth;
+import io.casehub.api.spi.routing.AgentRoutingContext;
+import io.casehub.eidos.api.AgentCapability;
+import io.casehub.eidos.api.AgentDescriptor;
+import io.casehub.engine.ai.spi.AgentEmbeddingProvider;
+import io.casehub.engine.common.internal.jq.JQEvaluator;
+import io.casehub.engine.common.internal.jq.ValidationResult;
+import io.casehub.ledger.routing.TrustCandidateClassifier;
+import io.casehub.ledger.routing.TrustRoutingPolicy;
+import io.casehub.ledger.routing.TrustRoutingPolicyProvider;
+import io.casehub.ledger.routing.TrustScoreCache;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SemanticAgentRoutingStrategyTest {
+
+  private TrustScoreCache cache;
+  private TrustRoutingPolicyProvider policyProvider;
+  private AgentEmbeddingProvider embeddingProvider;
+  private JQEvaluator jqEvaluator;
+  private SemanticAgentRoutingStrategy strategy;
+
+  private static final TrustRoutingPolicy POLICY =
+      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of());
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    cache = mock(TrustScoreCache.class);
+    policyProvider = mock(TrustRoutingPolicyProvider.class);
+    embeddingProvider = mock(AgentEmbeddingProvider.class);
+    jqEvaluator = mock(JQEvaluator.class);
+
+    when(policyProvider.forCapability(any())).thenReturn(POLICY);
+    when(cache.getCapabilityScore(any(), any())).thenReturn(OptionalDouble.empty());
+    when(cache.getDecisionCount(any(), any())).thenReturn(0);
+    when(cache.getCapabilityDimensionScore(any(), any(), any())).thenReturn(OptionalDouble.empty());
+
+    strategy =
+        new SemanticAgentRoutingStrategy(
+            new TrustCandidateClassifier(),
+            cache,
+            policyProvider,
+            embeddingProvider,
+            jqEvaluator,
+            0.4,
+            ".");
+  }
+
+  @Test
+  void bootstrapCandidates_selectedByWorkloadOnly_notBySemantic() {
+    // BOOTSTRAP candidates (no trust history) score by workload only — semantic is not applied.
+    // The idle candidate wins regardless of semantic similarity.
+    when(jqEvaluator.eval(anyString(), any()))
+        .thenReturn(ValidationResult.ok(List.of(MAPPER.createObjectNode().textNode("research"))));
+    when(embeddingProvider.embed(any())).thenReturn(new float[] {1.0f, 0.0f});
+
+    // agent-idle has 0 jobs, agent-busy has 3; both bootstrap → workload decides
+    final List<AgentCandidate> candidates =
+        List.of(
+            candidateWithDescriptor("agent-idle", 0, "idle"),
+            candidateWithDescriptor("agent-busy", 3, "busy"));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-idle");
+  }
+
+  @Test
+  void qualifiedCandidates_semanticAndTrustCombined() {
+    // agent-a: trust=0.85 (qualified), semantic similarity high
+    // agent-b: trust=0.82 (qualified), semantic similarity low
+    when(cache.getCapabilityScore("agent-a", "research")).thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("agent-a", "research")).thenReturn(10);
+    when(cache.getCapabilityScore("agent-b", "research")).thenReturn(OptionalDouble.of(0.82));
+    when(cache.getDecisionCount("agent-b", "research")).thenReturn(10);
+
+    // Use sequential returns:
+    // call 1: query text (JQ fallback = capability name)
+    // call 2: agent-a vocabulary (high similarity to query)
+    // call 3: agent-b vocabulary (low similarity to query)
+    when(jqEvaluator.eval(anyString(), any()))
+        .thenReturn(
+            ValidationResult.ok(List.of(MAPPER.createObjectNode().textNode("data science"))));
+    when(embeddingProvider.embed(any()))
+        .thenReturn(new float[] {1.0f, 0.0f}) // query vector
+        .thenReturn(new float[] {0.98f, 0.02f}) // agent-a: high cosine similarity
+        .thenReturn(new float[] {0.1f, 0.99f}); // agent-b: low cosine similarity
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            candidateWithDescriptor("agent-a", 0, "agent-a"),
+            candidateWithDescriptor("agent-b", 0, "agent-b"));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-a");
+  }
+
+  @Test
+  void allBorderlineCandidates_escalates() {
+    // Both candidates are borderline — should escalate just like TrustWeightedAgentStrategy
+    when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.65));
+    when(cache.getDecisionCount("agent-1", "research")).thenReturn(10);
+    when(cache.getCapabilityScore("agent-2", "research")).thenReturn(OptionalDouble.of(0.75));
+    when(cache.getDecisionCount("agent-2", "research")).thenReturn(10);
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            candidateWithDescriptor("agent-1", 0, "agent-1"),
+            candidateWithDescriptor("agent-2", 0, "agent-2"));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+  }
+
+  @Test
+  void nullDescriptor_treatedAsBootstrap() {
+    // Candidate without descriptor → bootstrap → availability routing only
+    final AgentCandidate noDescriptor =
+        new AgentCandidate("agent-x", Set.of("research"), 1, AgentHealth.READY, null);
+
+    when(jqEvaluator.eval(anyString(), any()))
+        .thenReturn(ValidationResult.ok(List.of(MAPPER.createObjectNode().textNode("research"))));
+    when(embeddingProvider.embed("research")).thenReturn(new float[] {1.0f, 0.0f});
+
+    final AgentAssignment result =
+        strategy.select(ctx(), List.of(noDescriptor)).await().indefinitely();
+
+    // Bootstrap candidates get availability score (positive) → Assigned
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-x");
+  }
+
+  @Test
+  void nullCaseContext_fallsBackToCapabilityName() {
+    // NullNode context → JQ returns empty → fallback to capability name for embedding
+    when(jqEvaluator.eval(anyString(), any())).thenReturn(ValidationResult.ok(List.of()));
+    when(embeddingProvider.embed("research")).thenReturn(new float[] {1.0f, 0.0f});
+    when(embeddingProvider.embed(vocabularyText("agent-x"))).thenReturn(new float[] {0.9f, 0.1f});
+
+    final AgentCandidate candidate = candidateWithDescriptor("agent-x", 0, "agent-x");
+    final AgentAssignment result =
+        strategy.select(ctx(), List.of(candidate)).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+  }
+
+  @Test
+  void emptyCandidates_returnsUnresolvable() {
+    assertThat(strategy.select(ctx(), List.of()).await().indefinitely())
+        .isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  // ---- Helpers ---------------------------------------------------------------
+
+  private AgentRoutingContext ctx() {
+    return new AgentRoutingContext(UUID.randomUUID(), "research", NullNode.instance);
+  }
+
+  private String vocabularyText(final String agentId) {
+    return "domain-vocab slot-vocab disposition-vocab\ncapability:research tags:analysis ml domains:statistics";
+  }
+
+  private AgentCandidate candidateWithDescriptor(
+      final String workerId, final int jobs, final String agentId) {
+    final AgentDescriptor descriptor =
+        new AgentDescriptor(
+            agentId,
+            agentId,
+            "1.0",
+            "openai",
+            "gpt-4",
+            "4-turbo",
+            null,
+            "domain-vocab",
+            "slot-vocab",
+            "disposition-vocab",
+            "research",
+            List.of(
+                new AgentCapability(
+                    "research",
+                    null,
+                    null,
+                    null,
+                    List.of(),
+                    List.of(),
+                    List.of("analysis", "ml"),
+                    Map.of("statistics", 0.8))),
+            null,
+            null,
+            null,
+            "casehubio");
+    return new AgentCandidate(workerId, Set.of("research"), jobs, AgentHealth.READY, descriptor);
+  }
+}

--- a/ledger/src/main/java/io/casehub/ledger/routing/TrustCandidateClassifier.java
+++ b/ledger/src/main/java/io/casehub/ledger/routing/TrustCandidateClassifier.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.ledger.routing;
+
+import io.casehub.api.spi.routing.AgentAssignment;
+import io.casehub.api.spi.routing.AgentCandidate;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+
+/**
+ * Shared classification utility for trust-based routing strategies. Classifies each candidate by
+ * trust maturity phase and determines the routing outcome.
+ *
+ * <p>Both {@link TrustWeightedAgentStrategy} and {@code SemanticAgentRoutingStrategy} share the
+ * same 4-phase classification loop and the same outcome decision — only the scoring of QUALIFIED
+ * candidates differs between them. This bean encapsulates the common logic to avoid duplication.
+ *
+ * <p>No mutable state — singleton {@code @ApplicationScoped} is safe.
+ */
+@ApplicationScoped
+public class TrustCandidateClassifier {
+
+  /**
+   * Phase classification for a single candidate after trust analysis.
+   *
+   * <ul>
+   *   <li>BOOTSTRAP — Phase 0/1: insufficient history; workload routing applies
+   *   <li>QUALIFIED — Phase 2/3 passed: trust + workload blend applies
+   *   <li>BORDERLINE — Phase 2a: score within margin of threshold; excluded; tracked separately
+   *       from EXCLUDED so that all-borderline pools trigger escalation rather than unresolvable
+   *   <li>EXCLUDED_PHASE2B — Phase 2b: score below threshold; excluded
+   *   <li>EXCLUDED_PHASE3 — Phase 3: passed threshold but failed a quality floor; excluded;
+   *       distinct from EXCLUDED_PHASE2B for future diagnostic use
+   * </ul>
+   */
+  public enum Phase {
+    BOOTSTRAP,
+    QUALIFIED,
+    BORDERLINE,
+    EXCLUDED_PHASE2B,
+    EXCLUDED_PHASE3
+  }
+
+  /**
+   * A candidate with its trust phase classification and scores.
+   *
+   * <p>{@code trustScore} is empty for BOOTSTRAP candidates (no trust signal). Any code that reads
+   * {@code trustScore} must handle the empty case — it cannot accidentally receive NaN.
+   *
+   * <p>{@code workloadScore} = 1/(1+runningJobs) — always computed for all phases.
+   */
+  public record ClassifiedCandidate(
+      AgentCandidate candidate, Phase phase, OptionalDouble trustScore, double workloadScore) {
+
+    /** True when this candidate is excluded from assignment regardless of scoring. */
+    public boolean isExcluded() {
+      return phase == Phase.BORDERLINE
+          || phase == Phase.EXCLUDED_PHASE2B
+          || phase == Phase.EXCLUDED_PHASE3;
+    }
+  }
+
+  /**
+   * A candidate paired with its final routing score after the strategy applies its scoring
+   * algorithm. Strategies create these from {@link ClassifiedCandidate} instances.
+   */
+  public record ScoredCandidate(ClassifiedCandidate classified, double finalScore) {}
+
+  /**
+   * Classify all candidates by trust phase using the given policy and cache.
+   *
+   * <p>BOOTSTRAP: no capability score in cache, OR decision count below {@code
+   * minimumObservations}. BORDERLINE: score within {@code borderlineMargin} of {@code threshold}.
+   * EXCLUDED_PHASE2B: below threshold and not borderline. EXCLUDED_PHASE3: passed threshold check
+   * but failed a quality floor (data present and below floor; no data → not penalised). QUALIFIED:
+   * passed threshold check and all quality floors.
+   */
+  public List<ClassifiedCandidate> classify(
+      final List<AgentCandidate> candidates,
+      final String capabilityName,
+      final TrustRoutingPolicy policy,
+      final TrustScoreCache cache) {
+
+    final List<ClassifiedCandidate> result = new ArrayList<>(candidates.size());
+    for (final AgentCandidate candidate : candidates) {
+      result.add(classifyOne(candidate, capabilityName, policy, cache));
+    }
+    return result;
+  }
+
+  private ClassifiedCandidate classifyOne(
+      final AgentCandidate candidate,
+      final String capabilityName,
+      final TrustRoutingPolicy policy,
+      final TrustScoreCache cache) {
+
+    final double workload = 1.0 / (1.0 + candidate.runningJobs());
+    final OptionalDouble capScore = cache.getCapabilityScore(candidate.workerId(), capabilityName);
+
+    if (capScore.isEmpty()
+        || policy.isBootstrap(cache.getDecisionCount(candidate.workerId(), capabilityName))) {
+      return new ClassifiedCandidate(candidate, Phase.BOOTSTRAP, OptionalDouble.empty(), workload);
+    }
+
+    final double score = capScore.getAsDouble();
+
+    if (policy.isBorderline(score)) {
+      return new ClassifiedCandidate(
+          candidate, Phase.BORDERLINE, OptionalDouble.of(score), workload);
+    }
+
+    if (!policy.passesThresholdCheck(score)) {
+      return new ClassifiedCandidate(
+          candidate, Phase.EXCLUDED_PHASE2B, OptionalDouble.of(score), workload);
+    }
+
+    // Phase 3: quality floor checks
+    for (final Map.Entry<String, Double> floor : policy.qualityFloors().entrySet()) {
+      final OptionalDouble quality =
+          cache.getCapabilityDimensionScore(candidate.workerId(), capabilityName, floor.getKey());
+      if (quality.isPresent() && quality.getAsDouble() < floor.getValue()) {
+        return new ClassifiedCandidate(
+            candidate, Phase.EXCLUDED_PHASE3, OptionalDouble.of(score), workload);
+      }
+    }
+
+    return new ClassifiedCandidate(candidate, Phase.QUALIFIED, OptionalDouble.of(score), workload);
+  }
+
+  /**
+   * Given classified candidates and their final scores, determine the routing outcome.
+   *
+   * <ul>
+   *   <li>Any candidate scored above 0.0 → {@link AgentAssignment#assign(String)} with the highest
+   *   <li>All scored 0.0 AND any was BORDERLINE → {@link AgentAssignment#escalate(String)} (human
+   *       oversight required per trust-maturity-model.md Phase 2)
+   *   <li>All scored 0.0 AND no BORDERLINE → {@link AgentAssignment#unresolvable()}
+   * </ul>
+   */
+  public static AgentAssignment decide(
+      final List<ClassifiedCandidate> classified,
+      final List<ScoredCandidate> scored,
+      final String capabilityName) {
+
+    ScoredCandidate best = null;
+    for (final ScoredCandidate sc : scored) {
+      if (best == null || sc.finalScore() > best.finalScore()) {
+        best = sc;
+      }
+    }
+
+    if (best != null && best.finalScore() > 0.0) {
+      return AgentAssignment.assign(best.classified().candidate().workerId());
+    }
+
+    final boolean anyBorderline = classified.stream().anyMatch(c -> c.phase() == Phase.BORDERLINE);
+
+    return anyBorderline
+        ? AgentAssignment.escalate(capabilityName)
+        : AgentAssignment.unresolvable();
+  }
+}

--- a/ledger/src/main/java/io/casehub/ledger/routing/TrustRoutingPolicy.java
+++ b/ledger/src/main/java/io/casehub/ledger/routing/TrustRoutingPolicy.java
@@ -39,4 +39,29 @@ public record TrustRoutingPolicy(
   /** Conservative defaults: 0.7 threshold, 10 observations, 0.1 margin, 60% trust blend. */
   public static final TrustRoutingPolicy DEFAULT =
       new TrustRoutingPolicy(0.7, 10, 0.1, 0.6, Map.of());
+
+  /** True when an agent lacks sufficient decision history for trust-based routing (Phase 0/1). */
+  public boolean isBootstrap(final int decisionCount) {
+    return decisionCount < minimumObservations;
+  }
+
+  /**
+   * True when the trust score is within {@code borderlineMargin} of {@code threshold}.
+   *
+   * <p>A borderline candidate is NOT qualified for assignment. Borderline is a distinct Phase 2a
+   * state that triggers human oversight when all candidates are in this state.
+   */
+  public boolean isBorderline(final double score) {
+    return Math.abs(score - threshold) <= borderlineMargin;
+  }
+
+  /**
+   * True when the score exceeds the threshold and is not borderline.
+   *
+   * <p>This is a Phase 2 first-pass check only — Phase 3 quality floors may still exclude a
+   * candidate that passes this check. Do not interpret as "ready to assign".
+   */
+  public boolean passesThresholdCheck(final double score) {
+    return score >= threshold && !isBorderline(score);
+  }
 }

--- a/ledger/src/main/java/io/casehub/ledger/routing/TrustWeightedAgentStrategy.java
+++ b/ledger/src/main/java/io/casehub/ledger/routing/TrustWeightedAgentStrategy.java
@@ -19,129 +19,88 @@ import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.casehub.ledger.routing.TrustCandidateClassifier.ClassifiedCandidate;
+import io.casehub.ledger.routing.TrustCandidateClassifier.Phase;
+import io.casehub.ledger.routing.TrustCandidateClassifier.ScoredCandidate;
+import io.smallrye.mutiny.Uni;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.OptionalDouble;
 
 /**
  * Trust-aware {@link AgentRoutingStrategy} implementing the four-phase trust maturity model
  * (trust-maturity-model.md). Activates automatically when {@code casehub-engine-ledger} is on the
  * classpath — no configuration required.
  *
- * <h3>Scoring phases</h3>
+ * <h3>Scoring per phase</h3>
  *
  * <ul>
- *   <li><b>Phase 0:</b> No CAPABILITY history → availability routing (Gastown parity). Score =
- *       1/(1+runningJobs), same as {@code LeastLoadedAgentStrategy}.
- *   <li><b>Phase 1:</b> History exists but {@code decisionCount < minimumObservations} → treated as
- *       Phase 0.
- *   <li><b>Phase 2a:</b> Borderline (|score - threshold| ≤ borderlineMargin) → excluded (score
- *       0.0). See engine#377 for escalation path when all candidates are borderline.
- *   <li><b>Phase 2b:</b> Below threshold → excluded (score 0.0).
- *   <li><b>Phase 3:</b> Quality floor check (CAPABILITY_DIMENSION). If dimension data exists and
- *       score < floor → excluded (score 0.0). Missing dimension data is not penalised (graceful
- *       Phase 0 for that dimension).
- *   <li><b>Passed all checks:</b> blend score = trust × blendFactor + workload × (1 - blendFactor).
+ *   <li><b>BOOTSTRAP</b> (Phase 0/1): availability score = 1/(1+runningJobs). Gastown parity.
+ *   <li><b>QUALIFIED</b> (Phase 2/3 passed): blended score = trust × blendFactor + workload ×
+ *       (1-blendFactor).
+ *   <li><b>BORDERLINE</b> (Phase 2a): score 0.0. When ALL non-bootstrap candidates are borderline,
+ *       returns {@link AgentAssignment.EscalateToOversight} per trust-maturity-model.md Phase 2.
+ *   <li><b>EXCLUDED_PHASE2B/3</b>: score 0.0.
  * </ul>
  *
- * <h3>Mixed-pool policy (explicit)</h3>
+ * <h3>Mixed-pool policy</h3>
  *
- * A Phase 0 candidate (no history) always outscores a borderline Phase 2 candidate (score 0.0). New
- * agents with no track record are preferred over established agents with borderline trust.
+ * A BOOTSTRAP candidate (positive availability score) always outscores a BORDERLINE candidate
+ * (score 0.0). New agents with no track record are preferred over established agents with
+ * borderline trust, and the bootstrap candidate is selected rather than escalating to oversight.
  *
- * <p>Deferred: full-exclusion escalation (all candidates score 0.0 → noOp) tracked in engine#377.
+ * <p>All in-memory work — returns {@code Uni.createFrom().item(result)}.
  */
 @Alternative
 @Priority(1)
 @ApplicationScoped
 public class TrustWeightedAgentStrategy implements AgentRoutingStrategy {
 
+  private final TrustCandidateClassifier classifier;
   private final TrustScoreCache cache;
   private final TrustRoutingPolicyProvider policyProvider;
 
   @Inject
   public TrustWeightedAgentStrategy(
-      final TrustScoreCache cache, final TrustRoutingPolicyProvider policyProvider) {
+      final TrustCandidateClassifier classifier,
+      final TrustScoreCache cache,
+      final TrustRoutingPolicyProvider policyProvider) {
+    this.classifier = classifier;
     this.cache = cache;
     this.policyProvider = policyProvider;
   }
 
   @Override
-  public AgentAssignment select(
+  public Uni<AgentAssignment> select(
       final AgentRoutingContext context, final List<AgentCandidate> candidates) {
     if (candidates.isEmpty()) {
-      return AgentAssignment.noOp();
+      return Uni.createFrom().item(AgentAssignment.unresolvable());
     }
 
     final TrustRoutingPolicy policy = policyProvider.forCapability(context.capabilityName());
+    final List<ClassifiedCandidate> classified =
+        classifier.classify(candidates, context.capabilityName(), policy, cache);
 
-    return candidates.stream()
-        .map(c -> new ScoredCandidate(c, score(c, context.capabilityName(), policy)))
-        .max(Comparator.comparingDouble(ScoredCandidate::score))
-        .filter(sc -> sc.score() > 0.0)
-        .map(sc -> new AgentAssignment(sc.candidate().workerId()))
-        .orElse(AgentAssignment.noOp());
+    final List<ScoredCandidate> scored = new ArrayList<>(classified.size());
+    for (final ClassifiedCandidate cc : classified) {
+      scored.add(new ScoredCandidate(cc, score(cc, policy)));
+    }
+
+    return Uni.createFrom()
+        .item(TrustCandidateClassifier.decide(classified, scored, context.capabilityName()));
   }
 
-  private double score(
-      final AgentCandidate candidate,
-      final String capabilityName,
-      final TrustRoutingPolicy policy) {
-
-    final OptionalDouble capScore = cache.getCapabilityScore(candidate.workerId(), capabilityName);
-
-    // Phase 0: no CAPABILITY history → availability routing (Gastown parity)
-    if (capScore.isEmpty()) {
-      return availabilityScore(candidate);
-    }
-
-    // Phase 1: insufficient observations → availability routing
-    if (cache.getDecisionCount(candidate.workerId(), capabilityName)
-        < policy.minimumObservations()) {
-      return availabilityScore(candidate);
-    }
-
-    final double t = capScore.getAsDouble();
-
-    // Phase 2a: borderline → excluded
-    if (Math.abs(t - policy.threshold()) <= policy.borderlineMargin()) {
-      return 0.0;
-    }
-
-    // Phase 2b: below threshold → excluded
-    if (t < policy.threshold()) {
-      return 0.0;
-    }
-
-    // Phase 3: quality floor checks (CAPABILITY_DIMENSION)
-    for (final Map.Entry<String, Double> floor : policy.qualityFloors().entrySet()) {
-      final OptionalDouble quality =
-          cache.getCapabilityDimensionScore(candidate.workerId(), capabilityName, floor.getKey());
-      // Data present and below floor → excluded
-      if (quality.isPresent() && quality.getAsDouble() < floor.getValue()) {
-        return 0.0;
+  private double score(final ClassifiedCandidate cc, final TrustRoutingPolicy policy) {
+    return switch (cc.phase()) {
+      case Phase.BOOTSTRAP -> cc.workloadScore();
+      case Phase.QUALIFIED -> {
+        final double t = cc.trustScore().getAsDouble();
+        yield t * policy.blendFactor() + cc.workloadScore() * (1.0 - policy.blendFactor());
       }
-      // No data for this dimension → graceful Phase 0 for that dimension; not penalised
-    }
-
-    // All checks passed: blend trust score with workload efficiency
-    return t * policy.blendFactor() + workloadScore(candidate) * (1.0 - policy.blendFactor());
+      case Phase.BORDERLINE, Phase.EXCLUDED_PHASE2B, Phase.EXCLUDED_PHASE3 -> 0.0;
+    };
   }
-
-  // Phase 0/1: Gastown parity — route by workload when no trust signal is available
-  private double availabilityScore(final AgentCandidate candidate) {
-    return workloadScore(candidate);
-  }
-
-  // 1.0 = fully idle, approaches 0 asymptotically as load increases; never exactly 0
-  private double workloadScore(final AgentCandidate candidate) {
-    return 1.0 / (1.0 + candidate.runningJobs());
-  }
-
-  private record ScoredCandidate(AgentCandidate candidate, double score) {}
 }

--- a/ledger/src/test/java/io/casehub/ledger/routing/TrustCandidateClassifierTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/routing/TrustCandidateClassifierTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.ledger.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.casehub.api.spi.routing.AgentAssignment;
+import io.casehub.api.spi.routing.AgentCandidate;
+import io.casehub.api.spi.routing.AgentHealth;
+import io.casehub.ledger.routing.TrustCandidateClassifier.ClassifiedCandidate;
+import io.casehub.ledger.routing.TrustCandidateClassifier.Phase;
+import io.casehub.ledger.routing.TrustCandidateClassifier.ScoredCandidate;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrustCandidateClassifierTest {
+
+  private TrustScoreCache cache;
+  private TrustCandidateClassifier classifier;
+
+  // threshold=0.7, minimumObservations=5, borderlineMargin=0.1
+  private static final TrustRoutingPolicy POLICY =
+      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of());
+  private static final String CAP = "research";
+
+  @BeforeEach
+  void setUp() {
+    cache = mock(TrustScoreCache.class);
+    classifier = new TrustCandidateClassifier();
+    when(cache.getCapabilityScore(any(), any())).thenReturn(OptionalDouble.empty());
+    when(cache.getDecisionCount(any(), any())).thenReturn(0);
+    when(cache.getCapabilityDimensionScore(any(), any(), any())).thenReturn(OptionalDouble.empty());
+  }
+
+  // ---- classify: BOOTSTRAP -------------------------------------------------
+
+  @Test
+  void classify_noTrustHistory_isBootstrap() {
+    final List<ClassifiedCandidate> result =
+        classifier.classify(List.of(candidate("a", 2)), CAP, POLICY, cache);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).phase()).isEqualTo(Phase.BOOTSTRAP);
+    assertThat(result.get(0).trustScore()).isEmpty();
+    assertThat(result.get(0).workloadScore()).isEqualTo(1.0 / (1 + 2));
+  }
+
+  @Test
+  void classify_insufficientObservations_isBootstrap() {
+    when(cache.getCapabilityScore("a", CAP)).thenReturn(OptionalDouble.of(0.9));
+    when(cache.getDecisionCount("a", CAP)).thenReturn(3); // below minimumObservations=5
+
+    final List<ClassifiedCandidate> result =
+        classifier.classify(List.of(candidate("a", 0)), CAP, POLICY, cache);
+
+    assertThat(result.get(0).phase()).isEqualTo(Phase.BOOTSTRAP);
+  }
+
+  // ---- classify: BORDERLINE ------------------------------------------------
+
+  @Test
+  void classify_borderlineScore_isBorderline() {
+    when(cache.getCapabilityScore("a", CAP)).thenReturn(OptionalDouble.of(0.65));
+    when(cache.getDecisionCount("a", CAP)).thenReturn(10);
+
+    final List<ClassifiedCandidate> result =
+        classifier.classify(List.of(candidate("a", 0)), CAP, POLICY, cache);
+
+    assertThat(result.get(0).phase()).isEqualTo(Phase.BORDERLINE);
+    assertThat(result.get(0).trustScore()).hasValue(0.65);
+  }
+
+  // ---- classify: EXCLUDED_PHASE2B ------------------------------------------
+
+  @Test
+  void classify_belowThresholdNotBorderline_isExcludedPhase2b() {
+    when(cache.getCapabilityScore("a", CAP)).thenReturn(OptionalDouble.of(0.5));
+    when(cache.getDecisionCount("a", CAP)).thenReturn(10);
+
+    final List<ClassifiedCandidate> result =
+        classifier.classify(List.of(candidate("a", 0)), CAP, POLICY, cache);
+
+    assertThat(result.get(0).phase()).isEqualTo(Phase.EXCLUDED_PHASE2B);
+  }
+
+  // ---- classify: EXCLUDED_PHASE3 -------------------------------------------
+
+  @Test
+  void classify_qualityFloorFailed_isExcludedPhase3() {
+    final TrustRoutingPolicy policyWithFloor =
+        new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75));
+
+    when(cache.getCapabilityScore("a", CAP)).thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("a", CAP)).thenReturn(10);
+    when(cache.getCapabilityDimensionScore("a", CAP, "thoroughness"))
+        .thenReturn(OptionalDouble.of(0.60)); // below floor
+
+    final List<ClassifiedCandidate> result =
+        classifier.classify(List.of(candidate("a", 0)), CAP, policyWithFloor, cache);
+
+    assertThat(result.get(0).phase()).isEqualTo(Phase.EXCLUDED_PHASE3);
+  }
+
+  // ---- classify: QUALIFIED -------------------------------------------------
+
+  @Test
+  void classify_aboveThresholdNotBorderline_isQualified() {
+    when(cache.getCapabilityScore("a", CAP)).thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("a", CAP)).thenReturn(10);
+
+    final List<ClassifiedCandidate> result =
+        classifier.classify(List.of(candidate("a", 0)), CAP, POLICY, cache);
+
+    assertThat(result.get(0).phase()).isEqualTo(Phase.QUALIFIED);
+    assertThat(result.get(0).trustScore()).hasValue(0.85);
+  }
+
+  @Test
+  void classify_qualityFloorMissing_isQualified() {
+    final TrustRoutingPolicy policyWithFloor =
+        new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75));
+    when(cache.getCapabilityScore("a", CAP)).thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("a", CAP)).thenReturn(10);
+    // no dimension data → graceful; not penalised
+
+    final List<ClassifiedCandidate> result =
+        classifier.classify(List.of(candidate("a", 0)), CAP, policyWithFloor, cache);
+
+    assertThat(result.get(0).phase()).isEqualTo(Phase.QUALIFIED);
+  }
+
+  // ---- decide: outcomes ----------------------------------------------------
+
+  @Test
+  void decide_highestScoredAboveZero_returnsAssigned() {
+    final ClassifiedCandidate cand = classified("worker-1", Phase.QUALIFIED, 0.85, 1.0);
+    final ScoredCandidate scored = new ScoredCandidate(cand, 0.75);
+
+    final AgentAssignment result =
+        TrustCandidateClassifier.decide(List.of(cand), List.of(scored), CAP);
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("worker-1");
+  }
+
+  @Test
+  void decide_allZeroScores_someBorderline_returnsEscalate() {
+    final ClassifiedCandidate cand = classified("worker-1", Phase.BORDERLINE, 0.65, 1.0);
+    final ScoredCandidate scored = new ScoredCandidate(cand, 0.0);
+
+    final AgentAssignment result =
+        TrustCandidateClassifier.decide(List.of(cand), List.of(scored), CAP);
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).capabilityName()).isEqualTo(CAP);
+  }
+
+  @Test
+  void decide_allZeroScores_noBorderline_returnsUnresolvable() {
+    final ClassifiedCandidate cand = classified("worker-1", Phase.EXCLUDED_PHASE2B, 0.5, 1.0);
+    final ScoredCandidate scored = new ScoredCandidate(cand, 0.0);
+
+    final AgentAssignment result =
+        TrustCandidateClassifier.decide(List.of(cand), List.of(scored), CAP);
+
+    assertThat(result).isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  @Test
+  void decide_mixedBorderlineAndExcluded_allZero_returnsEscalate() {
+    final ClassifiedCandidate border = classified("w1", Phase.BORDERLINE, 0.65, 1.0);
+    final ClassifiedCandidate excluded = classified("w2", Phase.EXCLUDED_PHASE2B, 0.5, 1.0);
+    final List<ScoredCandidate> scored =
+        List.of(new ScoredCandidate(border, 0.0), new ScoredCandidate(excluded, 0.0));
+
+    final AgentAssignment result =
+        TrustCandidateClassifier.decide(List.of(border, excluded), scored, CAP);
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+  }
+
+  @Test
+  void decide_bootstrapCandidateWins_returnsAssigned() {
+    final ClassifiedCandidate bootstrap = classified("w1", Phase.BOOTSTRAP, Double.NaN, 0.5);
+    final ClassifiedCandidate borderline = classified("w2", Phase.BORDERLINE, 0.65, 1.0);
+    final List<ScoredCandidate> scored =
+        List.of(
+            new ScoredCandidate(bootstrap, 0.5), // availability score > 0
+            new ScoredCandidate(borderline, 0.0)); // excluded
+
+    final AgentAssignment result =
+        TrustCandidateClassifier.decide(List.of(bootstrap, borderline), scored, CAP);
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("w1");
+  }
+
+  // ---- Helpers ---------------------------------------------------------------
+
+  private static AgentCandidate candidate(final String workerId, final int jobs) {
+    return new AgentCandidate(workerId, Set.of(CAP), jobs, AgentHealth.READY, null);
+  }
+
+  private static ClassifiedCandidate classified(
+      final String workerId, final Phase phase, final double trustScore, final double workload) {
+    final OptionalDouble ts =
+        Double.isNaN(trustScore) ? OptionalDouble.empty() : OptionalDouble.of(trustScore);
+    return new ClassifiedCandidate(candidate(workerId, 0), phase, ts, workload);
+  }
+}

--- a/ledger/src/test/java/io/casehub/ledger/routing/TrustRoutingPolicyTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/routing/TrustRoutingPolicyTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.ledger.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TrustRoutingPolicyTest {
+
+  // threshold=0.7, minimumObservations=5, borderlineMargin=0.1
+  private static final TrustRoutingPolicy POLICY =
+      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of());
+
+  // ---- isBootstrap --------------------------------------------------------
+
+  @Test
+  void isBootstrap_belowMinimumObservations_returnsTrue() {
+    assertThat(POLICY.isBootstrap(4)).isTrue();
+  }
+
+  @Test
+  void isBootstrap_atMinimumObservations_returnsFalse() {
+    assertThat(POLICY.isBootstrap(5)).isFalse();
+  }
+
+  @Test
+  void isBootstrap_aboveMinimumObservations_returnsFalse() {
+    assertThat(POLICY.isBootstrap(10)).isFalse();
+  }
+
+  @Test
+  void isBootstrap_zeroObservations_returnsTrue() {
+    assertThat(POLICY.isBootstrap(0)).isTrue();
+  }
+
+  // ---- isBorderline -------------------------------------------------------
+
+  @Test
+  void isBorderline_scoreExactlyAtThreshold_returnsTrue() {
+    // |0.7 - 0.7| = 0.0 ≤ 0.1
+    assertThat(POLICY.isBorderline(0.7)).isTrue();
+  }
+
+  @Test
+  void isBorderline_scoreAtLowerBoundary_returnsTrue() {
+    // |0.6 - 0.7| = 0.1 ≤ 0.1
+    assertThat(POLICY.isBorderline(0.6)).isTrue();
+  }
+
+  @Test
+  void isBorderline_scoreNearUpperBoundary_returnsTrue() {
+    // |0.79 - 0.7| = 0.09 ≤ 0.1 (avoids IEEE 754 imprecision at the exact 0.8 boundary)
+    assertThat(POLICY.isBorderline(0.79)).isTrue();
+  }
+
+  @Test
+  void isBorderline_scoreJustBelowBoundary_returnsFalse() {
+    // |0.59 - 0.7| = 0.11 > 0.1
+    assertThat(POLICY.isBorderline(0.59)).isFalse();
+  }
+
+  @Test
+  void isBorderline_scoreJustAboveBoundary_returnsFalse() {
+    // |0.81 - 0.7| = 0.11 > 0.1
+    assertThat(POLICY.isBorderline(0.81)).isFalse();
+  }
+
+  @Test
+  void isBorderline_scoreWellBelowThreshold_returnsFalse() {
+    assertThat(POLICY.isBorderline(0.3)).isFalse();
+  }
+
+  // ---- passesThresholdCheck -----------------------------------------------
+
+  @Test
+  void passesThresholdCheck_scoreAboveThresholdAndNotBorderline_returnsTrue() {
+    // |0.85 - 0.7| = 0.15 > 0.1 → not borderline; 0.85 >= 0.7 → passes
+    assertThat(POLICY.passesThresholdCheck(0.85)).isTrue();
+  }
+
+  @Test
+  void passesThresholdCheck_scoreAboveThresholdButBorderline_returnsFalse() {
+    // |0.75 - 0.7| = 0.05 ≤ 0.1 → borderline → does not pass
+    assertThat(POLICY.passesThresholdCheck(0.75)).isFalse();
+  }
+
+  @Test
+  void passesThresholdCheck_scoreBelowThreshold_returnsFalse() {
+    // 0.5 < 0.7
+    assertThat(POLICY.passesThresholdCheck(0.5)).isFalse();
+  }
+
+  @Test
+  void passesThresholdCheck_scoreAtExactThreshold_returnsFalse() {
+    // exactly 0.7 → borderline → does not pass
+    assertThat(POLICY.passesThresholdCheck(0.7)).isFalse();
+  }
+}

--- a/ledger/src/test/java/io/casehub/ledger/routing/TrustWeightedAgentStrategyTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/routing/TrustWeightedAgentStrategyTest.java
@@ -20,6 +20,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentHealth;
 import io.casehub.api.spi.routing.AgentRoutingContext;
@@ -46,11 +48,11 @@ class TrustWeightedAgentStrategyTest {
   void setUp() {
     cache = mock(TrustScoreCache.class);
     policyProvider = mock(TrustRoutingPolicyProvider.class);
-    strategy = new TrustWeightedAgentStrategy(cache, policyProvider);
-    ctx = new AgentRoutingContext(UUID.randomUUID(), "research");
+    strategy =
+        new TrustWeightedAgentStrategy(new TrustCandidateClassifier(), cache, policyProvider);
+    ctx = new AgentRoutingContext(UUID.randomUUID(), "research", NullNode.instance);
 
     when(policyProvider.forCapability("research")).thenReturn(DEFAULT_POLICY);
-    // Default: no scores in cache
     when(cache.getCapabilityScore(any(), any())).thenReturn(OptionalDouble.empty());
     when(cache.getDecisionCount(any(), any())).thenReturn(0);
     when(cache.getCapabilityDimensionScore(any(), any(), any())).thenReturn(OptionalDouble.empty());
@@ -60,93 +62,127 @@ class TrustWeightedAgentStrategyTest {
 
   @Test
   void phase0_noTrustHistory_selectsLeastLoaded() {
-    // No cache entry → Phase 0 → availability score (workload-based)
     final List<AgentCandidate> candidates =
         List.of(candidate("agent-busy", 5), candidate("agent-idle", 0));
 
-    assertThat(strategy.select(ctx, candidates).workerId()).isEqualTo("agent-idle");
+    final AgentAssignment result = select(candidates);
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-idle");
   }
 
   @Test
-  void phase0_emptyCandidates_returnsNoOp() {
-    assertThat(strategy.select(ctx, List.of()).isNoOp()).isTrue();
+  void phase0_emptyCandidates_returnsUnresolvable() {
+    assertThat(select(List.of())).isInstanceOf(AgentAssignment.Unresolvable.class);
   }
 
   // ---- Phase 1: insufficient observations ---------------------------------
 
   @Test
   void phase1_insufficientObservations_fallsToAvailabilityRouting() {
-    // Has score but below minimumObservations (5) → Phase 0/1 treatment
     when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.9));
-    when(cache.getDecisionCount("agent-1", "research")).thenReturn(3); // below 5
+    when(cache.getDecisionCount("agent-1", "research")).thenReturn(3);
 
-    when(cache.getCapabilityScore("agent-2", "research"))
-        .thenReturn(OptionalDouble.empty()); // Phase 0
+    when(cache.getCapabilityScore("agent-2", "research")).thenReturn(OptionalDouble.empty());
     when(cache.getDecisionCount("agent-2", "research")).thenReturn(0);
 
-    // Both are availability-scored; agent-2 has 0 jobs, agent-1 has 2 → agent-2 wins on workload
     final List<AgentCandidate> candidates =
         List.of(candidate("agent-1", 2), candidate("agent-2", 0));
 
-    assertThat(strategy.select(ctx, candidates).workerId()).isEqualTo("agent-2");
+    final AgentAssignment result = select(candidates);
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-2");
   }
 
-  // ---- Phase 2: borderline candidates excluded ----------------------------
+  // ---- Phase 2a: borderline → EscalateToOversight -----------------------
 
   @Test
-  void phase2a_borderlineCandidate_excluded() {
-    // Trust score within borderlineMargin (0.1) of threshold (0.7): 0.65 is borderline
+  void phase2a_singleBorderlineCandidate_escalates() {
+    // 0.65: |0.65 - 0.7| = 0.05 ≤ 0.1 → borderline
     when(cache.getCapabilityScore("agent-border", "research")).thenReturn(OptionalDouble.of(0.65));
     when(cache.getDecisionCount("agent-border", "research")).thenReturn(10);
 
-    // Single candidate: borderline → excluded → noOp
-    assertThat(strategy.select(ctx, List.of(candidate("agent-border", 0))).isNoOp()).isTrue();
+    final AgentAssignment result = select(List.of(candidate("agent-border", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).capabilityName())
+        .isEqualTo("research");
   }
 
   @Test
-  void phase2a_aboveThresholdButBorderline_excluded() {
-    // Trust score above threshold but within borderlineMargin → borderline on the high side
-    // |0.75 - 0.7| = 0.05 ≤ borderlineMargin(0.1) → excluded
+  void phase2a_borderlineAboveThreshold_alsoEscalates() {
+    // |0.75 - 0.7| = 0.05 ≤ 0.1 → borderline (high side)
     when(cache.getCapabilityScore("agent-above-border", "research"))
         .thenReturn(OptionalDouble.of(0.75));
     when(cache.getDecisionCount("agent-above-border", "research")).thenReturn(10);
 
-    assertThat(strategy.select(ctx, List.of(candidate("agent-above-border", 0))).isNoOp()).isTrue();
+    assertThat(select(List.of(candidate("agent-above-border", 0))))
+        .isInstanceOf(AgentAssignment.EscalateToOversight.class);
   }
 
   @Test
-  void phase2b_belowThreshold_excluded() {
-    // Below threshold (0.7) and not borderline (0.5 is 0.2 away)
-    when(cache.getCapabilityScore("agent-low", "research")).thenReturn(OptionalDouble.of(0.5));
+  void phase2a_multipleBorderlineCandidates_escalates() {
+    when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.65));
+    when(cache.getDecisionCount("agent-1", "research")).thenReturn(10);
+    when(cache.getCapabilityScore("agent-2", "research")).thenReturn(OptionalDouble.of(0.75));
+    when(cache.getDecisionCount("agent-2", "research")).thenReturn(10);
+
+    final AgentAssignment result =
+        select(List.of(candidate("agent-1", 0), candidate("agent-2", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+  }
+
+  @Test
+  void phase2a_borderlinePlusBelowThreshold_escalates() {
+    // Mix of borderline + below-threshold → still escalates (borderline is present)
+    when(cache.getCapabilityScore("agent-border", "research")).thenReturn(OptionalDouble.of(0.65));
+    when(cache.getDecisionCount("agent-border", "research")).thenReturn(10);
+    when(cache.getCapabilityScore("agent-low", "research")).thenReturn(OptionalDouble.of(0.3));
     when(cache.getDecisionCount("agent-low", "research")).thenReturn(10);
 
-    assertThat(strategy.select(ctx, List.of(candidate("agent-low", 0))).isNoOp()).isTrue();
+    assertThat(select(List.of(candidate("agent-border", 0), candidate("agent-low", 0))))
+        .isInstanceOf(AgentAssignment.EscalateToOversight.class);
   }
 
   @Test
-  void phase2_aboveThreshold_selected() {
-    // Clearly above threshold and not borderline
-    when(cache.getCapabilityScore("agent-good", "research")).thenReturn(OptionalDouble.of(0.85));
-    when(cache.getDecisionCount("agent-good", "research")).thenReturn(10);
-
-    assertThat(strategy.select(ctx, List.of(candidate("agent-good", 0))).workerId())
-        .isEqualTo("agent-good");
-  }
-
-  @Test
-  void phase0CandidateBeatsPhase2Borderline_explicitPolicy() {
-    // Phase 2 borderline candidate scores 0.0; Phase 0 candidate has availability score > 0
-    when(cache.getCapabilityScore("agent-border", "research")).thenReturn(OptionalDouble.of(0.68));
+  void phase2a_bootstrapPlusBorderline_bootstrapWins() {
+    // Phase 0 candidate has positive availability score → Assigned, not Escalate
+    when(cache.getCapabilityScore("agent-border", "research")).thenReturn(OptionalDouble.of(0.65));
     when(cache.getDecisionCount("agent-border", "research")).thenReturn(10);
     // agent-new has no history → Phase 0
 
     final List<AgentCandidate> candidates =
-        List.of(
-            candidate("agent-border", 0), // borderline → score 0.0
-            candidate("agent-new", 1)); // Phase 0 → workloadScore(1) = 1/(1+1) = 0.5
+        List.of(candidate("agent-border", 0), candidate("agent-new", 1));
 
-    // Phase 0 beats borderline
-    assertThat(strategy.select(ctx, candidates).workerId()).isEqualTo("agent-new");
+    final AgentAssignment result = select(candidates);
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-new");
+  }
+
+  // ---- Phase 2b: below threshold → Unresolvable ---------------------------
+
+  @Test
+  void phase2b_belowThreshold_returnsUnresolvable() {
+    // 0.5: |0.5 - 0.7| = 0.2 > 0.1 → not borderline → EXCLUDED_PHASE2B
+    when(cache.getCapabilityScore("agent-low", "research")).thenReturn(OptionalDouble.of(0.5));
+    when(cache.getDecisionCount("agent-low", "research")).thenReturn(10);
+
+    assertThat(select(List.of(candidate("agent-low", 0))))
+        .isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  @Test
+  void phase2_aboveThreshold_selected() {
+    when(cache.getCapabilityScore("agent-good", "research")).thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("agent-good", "research")).thenReturn(10);
+
+    final AgentAssignment result = select(List.of(candidate("agent-good", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-good");
   }
 
   // ---- Phase 3: quality floor checks --------------------------------------
@@ -160,14 +196,16 @@ class TrustWeightedAgentStrategyTest {
     when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.85));
     when(cache.getDecisionCount("agent-1", "research")).thenReturn(10);
     when(cache.getCapabilityDimensionScore("agent-1", "research", "thoroughness"))
-        .thenReturn(OptionalDouble.of(0.82)); // above floor 0.75
+        .thenReturn(OptionalDouble.of(0.82));
 
-    assertThat(strategy.select(ctx, List.of(candidate("agent-1", 0))).workerId())
-        .isEqualTo("agent-1");
+    final AgentAssignment result = select(List.of(candidate("agent-1", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-1");
   }
 
   @Test
-  void phase3_qualityFloorFailed_candidateExcluded() {
+  void phase3_qualityFloorFailed_returnsUnresolvable() {
     final TrustRoutingPolicy policyWithFloor =
         new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75));
     when(policyProvider.forCapability("research")).thenReturn(policyWithFloor);
@@ -175,9 +213,10 @@ class TrustWeightedAgentStrategyTest {
     when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.85));
     when(cache.getDecisionCount("agent-1", "research")).thenReturn(10);
     when(cache.getCapabilityDimensionScore("agent-1", "research", "thoroughness"))
-        .thenReturn(OptionalDouble.of(0.60)); // below floor 0.75 → excluded
+        .thenReturn(OptionalDouble.of(0.60)); // below floor → EXCLUDED_PHASE3
 
-    assertThat(strategy.select(ctx, List.of(candidate("agent-1", 0))).isNoOp()).isTrue();
+    assertThat(select(List.of(candidate("agent-1", 0))))
+        .isInstanceOf(AgentAssignment.Unresolvable.class);
   }
 
   @Test
@@ -188,11 +227,9 @@ class TrustWeightedAgentStrategyTest {
 
     when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.85));
     when(cache.getDecisionCount("agent-1", "research")).thenReturn(10);
-    when(cache.getCapabilityDimensionScore("agent-1", "research", "thoroughness"))
-        .thenReturn(OptionalDouble.empty()); // no data yet → graceful Phase 0 for this dimension
+    // no dimension data → OptionalDouble.empty() → graceful, not penalised
 
-    // Not penalised — candidate passes through to blend scoring
-    assertThat(strategy.select(ctx, List.of(candidate("agent-1", 0))).workerId())
+    assertThat(((AgentAssignment.Assigned) select(List.of(candidate("agent-1", 0)))).workerId())
         .isEqualTo("agent-1");
   }
 
@@ -200,23 +237,21 @@ class TrustWeightedAgentStrategyTest {
 
   @Test
   void blendScoring_higherTrustWinsOverWorkload() {
-    // blendFactor=0.6 → trust weight 60%, workload weight 40%
     when(cache.getCapabilityScore("agent-high-trust", "research"))
         .thenReturn(OptionalDouble.of(0.95));
     when(cache.getDecisionCount("agent-high-trust", "research")).thenReturn(10);
 
     when(cache.getCapabilityScore("agent-low-trust", "research"))
-        .thenReturn(
-            OptionalDouble.of(0.82)); // 0.82 is not borderline (|0.82-0.7|=0.12 > margin=0.1)
+        .thenReturn(OptionalDouble.of(0.82));
     when(cache.getDecisionCount("agent-low-trust", "research")).thenReturn(10);
 
-    // agent-high-trust: 0.95*0.6 + (1/(1+3))*0.4 = 0.57 + 0.10 = 0.67
-    // agent-low-trust:  0.82*0.6 + (1/(1+0))*0.4 = 0.49 + 0.40 = 0.89
-    // Idle + lower trust beats busy + higher trust when workload dominates the gap
+    // agent-high-trust: 0.95*0.6 + (1/4)*0.4 = 0.57 + 0.10 = 0.67
+    // agent-low-trust:  0.82*0.6 + (1/1)*0.4 = 0.49 + 0.40 = 0.89
     final List<AgentCandidate> candidates =
         List.of(candidate("agent-high-trust", 3), candidate("agent-low-trust", 0));
 
-    assertThat(strategy.select(ctx, candidates).workerId()).isEqualTo("agent-low-trust");
+    assertThat(((AgentAssignment.Assigned) select(candidates)).workerId())
+        .isEqualTo("agent-low-trust");
   }
 
   @Test
@@ -229,13 +264,10 @@ class TrustWeightedAgentStrategyTest {
     when(cache.getCapabilityScore("agent-b", "research")).thenReturn(OptionalDouble.of(0.80));
     when(cache.getDecisionCount("agent-b", "research")).thenReturn(10);
 
-    // With blendFactor=1.0: score = trust only → agent-a wins regardless of jobs
     final List<AgentCandidate> candidates =
-        List.of(
-            candidate("agent-a", 5), // busy but higher trust
-            candidate("agent-b", 0)); // idle but lower trust
+        List.of(candidate("agent-a", 5), candidate("agent-b", 0));
 
-    assertThat(strategy.select(ctx, candidates).workerId()).isEqualTo("agent-a");
+    assertThat(((AgentAssignment.Assigned) select(candidates)).workerId()).isEqualTo("agent-a");
   }
 
   @Test
@@ -248,19 +280,16 @@ class TrustWeightedAgentStrategyTest {
     when(cache.getCapabilityScore("agent-b", "research")).thenReturn(OptionalDouble.of(0.80));
     when(cache.getDecisionCount("agent-b", "research")).thenReturn(10);
 
-    // With blendFactor=0: score = workloadScore only → idle agent wins regardless of trust
     final List<AgentCandidate> candidates =
-        List.of(
-            candidate("agent-a", 5), // high trust but busy
-            candidate("agent-b", 0)); // lower trust but idle
+        List.of(candidate("agent-a", 5), candidate("agent-b", 0));
 
-    assertThat(strategy.select(ctx, candidates).workerId()).isEqualTo("agent-b");
+    assertThat(((AgentAssignment.Assigned) select(candidates)).workerId()).isEqualTo("agent-b");
   }
 
   // ---- All-excluded edge case ---------------------------------------------
 
   @Test
-  void allCandidatesExcluded_returnsNoOp() {
+  void allCandidatesBelowThreshold_noBorderline_returnsUnresolvable() {
     when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.50));
     when(cache.getDecisionCount("agent-1", "research")).thenReturn(10);
     when(cache.getCapabilityScore("agent-2", "research")).thenReturn(OptionalDouble.of(0.30));
@@ -269,12 +298,16 @@ class TrustWeightedAgentStrategyTest {
     final List<AgentCandidate> candidates =
         List.of(candidate("agent-1", 0), candidate("agent-2", 0));
 
-    assertThat(strategy.select(ctx, candidates).isNoOp()).isTrue();
+    assertThat(select(candidates)).isInstanceOf(AgentAssignment.Unresolvable.class);
   }
 
   // ---- Helpers ------------------------------------------------------------
 
+  private AgentAssignment select(final List<AgentCandidate> candidates) {
+    return strategy.select(ctx, candidates).await().indefinitely();
+  }
+
   private static AgentCandidate candidate(final String workerId, final int jobs) {
-    return new AgentCandidate(workerId, Set.of("research"), jobs, AgentHealth.READY);
+    return new AgentCandidate(workerId, Set.of("research"), jobs, AgentHealth.READY, null);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <module>ledger</module>
         <module>testing</module>
         <module>work-adapter</module>
+        <module>engine-ai</module>
     </modules>
 
     <repositories>

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine.handler;
+
+import io.casehub.api.model.CaseChannel;
+import io.casehub.api.spi.CaseChannelProvider;
+import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.qhorus.api.message.MessageType;
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+import org.jboss.logging.Logger;
+
+/**
+ * Handles agent routing escalation events. When all trust-eligible candidates for a capability are
+ * borderline, this handler posts a QUERY to the case's oversight channel so a human supervisor can
+ * make the routing decision.
+ *
+ * <p>PlanItem state during escalation: the PlanItem stays PENDING. The response-handling loop
+ * (human COMMAND response → re-trigger routing) is tracked in engine#383.
+ *
+ * <p>If no oversight channel is open (e.g. in deployments using the no-op channel provider), the
+ * escalation is logged with a {@code [METRIC:escalation.no-oversight-channel]} prefix for log-based
+ * alerting. This is expected behavior in dev/test environments.
+ */
+@ApplicationScoped
+public class AgentRoutingEscalationHandler {
+
+  private static final Logger LOG = Logger.getLogger(AgentRoutingEscalationHandler.class);
+
+  private final CaseChannelProvider channelProvider;
+
+  @Inject
+  public AgentRoutingEscalationHandler(final CaseChannelProvider channelProvider) {
+    this.channelProvider = channelProvider;
+  }
+
+  @ConsumeEvent(value = EventBusAddresses.AGENT_ROUTING_ESCALATION, blocking = true)
+  public void handle(final AgentRoutingEscalationEvent event) {
+    final String oversightName = CaseChannel.oversightChannelName(event.caseId());
+    final List<CaseChannel> channels = channelProvider.listChannels(event.caseId());
+
+    channels.stream()
+        .filter(c -> oversightName.equals(c.name()))
+        .findFirst()
+        .ifPresentOrElse(
+            channel -> postQuery(channel, event),
+            () ->
+                LOG.warnf(
+                    "[METRIC:escalation.no-oversight-channel] caseId=%s capability=%s binding=%s"
+                        + " — escalation absorbed; no oversight channel open."
+                        + " PlanItem stays PENDING indefinitely. engine#383 tracks response handling.",
+                    event.caseId(), event.capabilityName(), event.bindingName()));
+  }
+
+  private void postQuery(final CaseChannel channel, final AgentRoutingEscalationEvent event) {
+    final String message =
+        String.format(
+            "All agent candidates for capability '%s' (binding: '%s') are borderline."
+                + " Human oversight required: please select an agent or approve the next"
+                + " best available agent.",
+            event.capabilityName(), event.bindingName());
+
+    channelProvider.postToChannel(
+        channel, "casehub-engine", message, MessageType.QUERY, null, null);
+
+    LOG.infof(
+        "Agent routing escalation: QUERY posted to oversight channel '%s' for"
+            + " caseId=%s capability=%s",
+        channel.name(), event.caseId(), event.capabilityName());
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -41,12 +41,10 @@ import io.casehub.api.spi.ReactiveWorkerContextProvider;
 import io.casehub.api.spi.ReactiveWorkerProvisioner;
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
-import io.casehub.api.spi.routing.AgentHealth;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
 import io.casehub.eidos.api.CapabilityHealth;
-import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
-import io.casehub.eidos.api.CapabilityHealth.ProbeContext;
+import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
 import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
 import io.casehub.engine.common.internal.event.GoalReachedEvent;
@@ -61,6 +59,7 @@ import io.casehub.engine.common.internal.model.CaseMetaModel;
 import io.casehub.engine.common.spi.CaseDefinitionRegistry;
 import io.casehub.engine.common.spi.ExpressionEngineRegistry;
 import io.casehub.engine.common.spi.scheduler.WorkerExecutionManager;
+import io.casehub.engine.internal.routing.AgentCandidateFactory;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -69,8 +68,6 @@ import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -257,7 +254,9 @@ public class CaseContextChangedEventHandler {
       return tryProvision(caseInstance, capability);
     }
 
-    final List<AgentCandidate> candidates = buildCandidates(caseInstance, workers, capability);
+    final List<AgentCandidate> candidates =
+        AgentCandidateFactory.buildCandidates(
+            caseInstance, workers, capability, executionManager, capabilityHealth);
 
     if (candidates.isEmpty()) {
       LOG.warnf(
@@ -267,32 +266,48 @@ public class CaseContextChangedEventHandler {
     }
 
     final AgentRoutingContext ctx =
-        new AgentRoutingContext(caseInstance.getUuid(), capability.getName());
-    final AgentAssignment assignment = agentRoutingStrategy.select(ctx, candidates);
+        new AgentRoutingContext(
+            caseInstance.getUuid(),
+            capability.getName(),
+            caseInstance.getCaseContext().asJsonNode());
 
-    if (assignment.isNoOp()) {
-      LOG.warnf(
-          "AgentRoutingStrategy returned no assignment for capability '%s' binding '%s'",
-          capability.getName(), binding.getName());
-      return Uni.createFrom().voidItem();
-    }
+    return agentRoutingStrategy
+        .select(ctx, candidates)
+        .chain(
+            assignment ->
+                switch (assignment) {
+                  case AgentAssignment.Assigned a ->
+                      scheduleWorker(caseInstance, workers, binding, capability, a.workerId());
+                  case AgentAssignment.Unresolvable() -> {
+                    LOG.warnf(
+                        "AgentRoutingStrategy: no qualified agent for capability '%s' binding '%s'",
+                        capability.getName(), binding.getName());
+                    yield tryProvision(caseInstance, capability);
+                  }
+                  case AgentAssignment.EscalateToOversight e ->
+                      handleEscalation(caseInstance, e, binding);
+                });
+  }
+
+  private Uni<Void> scheduleWorker(
+      final CaseInstance caseInstance,
+      final List<Worker> workers,
+      final Binding binding,
+      final Capability capability,
+      final String workerId) {
 
     final Worker selectedWorker =
-        workers.stream()
-            .filter(w -> w.getName().equals(assignment.workerId()))
-            .findFirst()
-            .orElse(null);
+        workers.stream().filter(w -> w.getName().equals(workerId)).findFirst().orElse(null);
 
     if (selectedWorker == null) {
       LOG.errorf(
-          "Strategy selected worker '%s' but it was not found in the case definition",
-          assignment.workerId());
+          "Strategy selected worker '%s' but it was not found in the case definition", workerId);
       return Uni.createFrom().voidItem();
     }
 
     LOG.infof(
         "Agent selected: worker='%s' capability='%s' binding='%s'",
-        assignment.workerId(), capability.getName(), binding.getName());
+        workerId, capability.getName(), binding.getName());
 
     eventBus.publish(
         EventBusAddresses.WORKER_SCHEDULE,
@@ -301,48 +316,22 @@ public class CaseContextChangedEventHandler {
     return Uni.createFrom().voidItem();
   }
 
-  private List<AgentCandidate> buildCandidates(
-      final CaseInstance caseInstance, final List<Worker> workers, final Capability capability) {
-    final List<AgentCandidate> candidates = new ArrayList<>();
-    for (final Worker w : workers) {
-      if (w.getCapabilities() == null) continue;
-      final boolean hasCapability =
-          w.getCapabilities().stream().anyMatch(c -> c.getName().equals(capability.getName()));
-      if (!hasCapability) continue;
+  private Uni<Void> handleEscalation(
+      final CaseInstance caseInstance,
+      final AgentAssignment.EscalateToOversight escalation,
+      final Binding binding) {
 
-      final CapabilityStatus status =
-          w.hasDescriptor()
-              ? capabilityHealth.probe(
-                  w.agentDescriptor(),
-                  capability.getName(),
-                  // Pass caseId for future per-case health context (engine#376)
-                  ProbeContext.of(caseInstance.getUuid().toString()))
-              : new CapabilityHealth.CapabilityStatus.Ready();
+    LOG.infof(
+        "Agent routing escalation: all candidates borderline for capability '%s' binding '%s'"
+            + " caseId=%s — publishing escalation event",
+        escalation.capabilityName(), binding.getName(), caseInstance.getUuid());
 
-      if (status instanceof CapabilityStatus.Unavailable u) {
-        LOG.warnf(
-            "Worker '%s' unavailable for capability '%s': %s — excluded",
-            w.getName(), capability.getName(), u.reason());
-        continue;
-      }
+    eventBus.publish(
+        EventBusAddresses.AGENT_ROUTING_ESCALATION,
+        new AgentRoutingEscalationEvent(
+            caseInstance.getUuid(), escalation.capabilityName(), binding.getName()));
 
-      final AgentHealth health =
-          switch (status) {
-            case CapabilityStatus.EpistemicallyWeak ew -> AgentHealth.EPISTEMICALLY_WEAK;
-            case CapabilityStatus.Degraded d -> AgentHealth.DEGRADED;
-            default -> AgentHealth.READY;
-          };
-
-      final Set<String> capabilities =
-          w.getCapabilities().stream()
-              .map(Capability::getName)
-              .collect(Collectors.toUnmodifiableSet());
-
-      candidates.add(
-          new AgentCandidate(
-              w.getName(), capabilities, executionManager.getActiveWorkCount(w.getName()), health));
-    }
-    return candidates;
+    return Uni.createFrom().voidItem();
   }
 
   private Uni<Void> publishHumanTaskSchedule(

--- a/runtime/src/main/java/io/casehub/engine/internal/orchestration/WorkOrchestrator.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/orchestration/WorkOrchestrator.java
@@ -28,12 +28,10 @@ import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
-import io.casehub.api.spi.routing.AgentHealth;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
 import io.casehub.eidos.api.CapabilityHealth;
-import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
-import io.casehub.eidos.api.CapabilityHealth.ProbeContext;
+import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
 import io.casehub.engine.common.internal.event.WorkerScheduleEvent;
 import io.casehub.engine.common.internal.history.EventLog;
@@ -45,18 +43,16 @@ import io.casehub.engine.common.spi.CaseDefinitionRegistry;
 import io.casehub.engine.common.spi.CaseInstanceRepository;
 import io.casehub.engine.common.spi.EventLogRepository;
 import io.casehub.engine.common.spi.scheduler.WorkerExecutionManager;
+import io.casehub.engine.internal.routing.AgentCandidateFactory;
 import io.casehub.engine.internal.work.PendingWorkRegistry;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
 /**
@@ -140,27 +136,54 @@ public class WorkOrchestrator {
 
     // 2. Build AgentCandidate list — health-probed, Unavailable workers excluded
     final List<AgentCandidate> candidates =
-        buildCandidates(instance, definition.getWorkers(), capability);
+        AgentCandidateFactory.buildCandidates(
+            instance, definition.getWorkers(), capability, executionManager, capabilityHealth);
 
-    // 3. Route via AgentRoutingStrategy
+    // 3. Route via AgentRoutingStrategy (blocking await — not on Vert.x IO thread)
     final AgentRoutingContext ctx =
-        new AgentRoutingContext(instance.getUuid(), capability.getName());
-    final AgentAssignment assignment = agentRoutingStrategy.select(ctx, candidates);
+        new AgentRoutingContext(
+            instance.getUuid(), capability.getName(), instance.getCaseContext().asJsonNode());
+    final AgentAssignment assignment =
+        agentRoutingStrategy.select(ctx, candidates).await().indefinitely();
 
-    if (assignment.isNoOp()) {
-      final CompletableFuture<WorkResult> failed = new CompletableFuture<>();
-      failed.completeExceptionally(
-          new IllegalStateException("No worker available for capability: " + capability.getName()));
-      return failed;
+    switch (assignment) {
+      case AgentAssignment.Unresolvable() -> {
+        final CompletableFuture<WorkResult> failed = new CompletableFuture<>();
+        failed.completeExceptionally(
+            new IllegalStateException(
+                "No qualified agent for capability: " + capability.getName()));
+        return failed;
+      }
+      case AgentAssignment.EscalateToOversight e -> {
+        LOG.infof(
+            "Agent routing escalated to oversight for capability '%s' caseId=%s",
+            capability.getName(), instance.getUuid());
+        eventBus.publish(
+            EventBusAddresses.AGENT_ROUTING_ESCALATION,
+            new AgentRoutingEscalationEvent(
+                instance.getUuid(), e.capabilityName(), "(direct-orchestration)"));
+        final CompletableFuture<WorkResult> failed = new CompletableFuture<>();
+        failed.completeExceptionally(
+            new IllegalStateException(
+                "Agent routing escalated to human oversight for capability: "
+                    + capability.getName()
+                    + ". A QUERY has been posted to the oversight channel."));
+        return failed;
+      }
+      case AgentAssignment.Assigned ignored -> {
+        /* fall through — handled below */
+      }
     }
 
-    // 4. Resolve the selected Worker object
-    final Worker selectedWorker = findWorker(definition, assignment.workerId());
+    // 4. Resolve the selected Worker object — assignment is Assigned; exhaustive switch guarantees
+    // it
+    final AgentAssignment.Assigned assigned = (AgentAssignment.Assigned) assignment;
+    final Worker selectedWorker = findWorker(definition, assigned.workerId());
     if (selectedWorker == null) {
       final CompletableFuture<WorkResult> failed = new CompletableFuture<>();
       failed.completeExceptionally(
           new IllegalStateException(
-              "Selected worker not found in definition: " + assignment.workerId()));
+              "Selected worker not found in definition: " + assigned.workerId()));
       return failed;
     }
 
@@ -224,62 +247,6 @@ public class WorkOrchestrator {
         waitMode);
 
     return future;
-  }
-
-  private List<AgentCandidate> buildCandidates(
-      final CaseInstance instance, final List<Worker> workers, final Capability capability) {
-    if (workers == null) return List.of();
-    final List<AgentCandidate> candidates = new ArrayList<>();
-    for (final Worker w : workers) {
-      if (w.getCapabilities() == null) continue;
-      final boolean hasCapability =
-          w.getCapabilities().stream().anyMatch(c -> c.getName().equals(capability.getName()));
-      if (!hasCapability) continue;
-
-      final CapabilityStatus status =
-          w.hasDescriptor()
-              ? capabilityHealth.probe(
-                  w.agentDescriptor(),
-                  capability.getName(),
-                  // Pass caseId for future per-case health context (engine#376)
-                  ProbeContext.of(instance.getUuid().toString()))
-              : new CapabilityHealth.CapabilityStatus.Ready();
-
-      if (status instanceof CapabilityStatus.Unavailable u) {
-        LOG.warnf(
-            "Worker '%s' unavailable for capability '%s': %s — excluded",
-            w.getName(), capability.getName(), u.reason());
-        continue;
-      }
-
-      if (status instanceof CapabilityStatus.EpistemicallyWeak ew) {
-        LOG.infof(
-            "Worker '%s' epistemically weak for '%s' (domain=%s, confidence=%.2f) — kept",
-            w.getName(), capability.getName(), ew.domain(), ew.confidence());
-      }
-      if (status instanceof CapabilityStatus.Degraded d) {
-        LOG.debugf(
-            "Worker '%s' degraded for '%s': %s — %s",
-            w.getName(), capability.getName(), d.reason(), d.detail());
-      }
-
-      final AgentHealth health =
-          switch (status) {
-            case CapabilityStatus.EpistemicallyWeak ew -> AgentHealth.EPISTEMICALLY_WEAK;
-            case CapabilityStatus.Degraded d -> AgentHealth.DEGRADED;
-            default -> AgentHealth.READY;
-          };
-
-      final Set<String> capabilities =
-          w.getCapabilities().stream()
-              .map(Capability::getName)
-              .collect(Collectors.toUnmodifiableSet());
-
-      candidates.add(
-          new AgentCandidate(
-              w.getName(), capabilities, executionManager.getActiveWorkCount(w.getName()), health));
-    }
-    return candidates;
   }
 
   private Capability findCapability(final CaseDefinition definition, final String capabilityName) {

--- a/runtime/src/main/java/io/casehub/engine/internal/routing/AgentCandidateFactory.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/routing/AgentCandidateFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.routing;
+
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.Worker;
+import io.casehub.api.spi.routing.AgentCandidate;
+import io.casehub.api.spi.routing.AgentHealth;
+import io.casehub.eidos.api.CapabilityHealth;
+import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
+import io.casehub.eidos.api.CapabilityHealth.ProbeContext;
+import io.casehub.engine.common.internal.model.CaseInstance;
+import io.casehub.engine.common.spi.scheduler.WorkerExecutionManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
+
+/**
+ * Shared static utility for building {@link AgentCandidate} lists from a set of workers and a
+ * capability.
+ *
+ * <p>Previously duplicated in {@code CaseContextChangedEventHandler} and {@code WorkOrchestrator}.
+ * Both now delegate here so candidate construction logic (capability matching, health probing,
+ * {@code agentDescriptor} passthrough) is maintained in one place.
+ */
+public final class AgentCandidateFactory {
+
+  private static final Logger LOG = Logger.getLogger(AgentCandidateFactory.class);
+
+  private AgentCandidateFactory() {}
+
+  /**
+   * Build a pre-filtered, health-probed candidate list for the given capability.
+   *
+   * <p>Workers without the target capability are excluded. Workers that are {@code Unavailable} are
+   * excluded with a warning log. All other workers are included with their mapped {@link
+   * AgentHealth} status and their {@link io.casehub.eidos.api.AgentDescriptor} (null if no
+   * descriptor is registered).
+   *
+   * @param caseInstance the case instance — provides the UUID for health probe context
+   * @param workers the full list of workers from the case definition; null is treated as empty
+   * @param capability the capability being routed
+   * @param executionManager source of Quartz job counts for workload scoring
+   * @param capabilityHealth health prober; called only when the worker has a descriptor
+   * @return mutable list of eligible candidates; empty if none qualify
+   */
+  public static List<AgentCandidate> buildCandidates(
+      final CaseInstance caseInstance,
+      final List<Worker> workers,
+      final Capability capability,
+      final WorkerExecutionManager executionManager,
+      final CapabilityHealth capabilityHealth) {
+
+    if (workers == null) {
+      return List.of();
+    }
+
+    final List<AgentCandidate> candidates = new ArrayList<>();
+    final String capabilityName = capability.getName();
+    final String probeContextId = caseInstance.getUuid().toString();
+
+    for (final Worker w : workers) {
+      if (w.getCapabilities() == null) {
+        continue;
+      }
+      final boolean hasCapability =
+          w.getCapabilities().stream().anyMatch(c -> c.getName().equals(capabilityName));
+      if (!hasCapability) {
+        continue;
+      }
+
+      final CapabilityStatus status =
+          w.hasDescriptor()
+              ? capabilityHealth.probe(
+                  w.agentDescriptor(), capabilityName, ProbeContext.of(probeContextId))
+              : new CapabilityHealth.CapabilityStatus.Ready();
+
+      if (status instanceof CapabilityStatus.Unavailable u) {
+        LOG.warnf(
+            "Worker '%s' unavailable for capability '%s': %s — excluded",
+            w.getName(), capabilityName, u.reason());
+        continue;
+      }
+
+      final AgentHealth health =
+          switch (status) {
+            case CapabilityStatus.EpistemicallyWeak ew -> AgentHealth.EPISTEMICALLY_WEAK;
+            case CapabilityStatus.Degraded d -> AgentHealth.DEGRADED;
+            default -> AgentHealth.READY;
+          };
+
+      final Set<String> capabilities =
+          w.getCapabilities().stream()
+              .map(Capability::getName)
+              .collect(Collectors.toUnmodifiableSet());
+
+      candidates.add(
+          new AgentCandidate(
+              w.getName(),
+              capabilities,
+              executionManager.getActiveWorkCount(w.getName()),
+              health,
+              w.hasDescriptor() ? w.agentDescriptor() : null));
+    }
+    return candidates;
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/routing/LeastLoadedAgentStrategy.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/routing/LeastLoadedAgentStrategy.java
@@ -20,6 +20,7 @@ import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
 import io.quarkus.arc.DefaultBean;
+import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Comparator;
 import java.util.List;
@@ -37,11 +38,13 @@ import java.util.List;
 public class LeastLoadedAgentStrategy implements AgentRoutingStrategy {
 
   @Override
-  public AgentAssignment select(
+  public Uni<AgentAssignment> select(
       final AgentRoutingContext context, final List<AgentCandidate> candidates) {
-    return candidates.stream()
-        .min(Comparator.comparingInt(AgentCandidate::runningJobs))
-        .map(c -> new AgentAssignment(c.workerId()))
-        .orElse(AgentAssignment.noOp());
+    final AgentAssignment result =
+        candidates.stream()
+            .min(Comparator.comparingInt(AgentCandidate::runningJobs))
+            .map(c -> AgentAssignment.assign(c.workerId()))
+            .orElse(AgentAssignment.unresolvable());
+    return Uni.createFrom().item(result);
   }
 }

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandlerTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.casehub.api.model.CaseChannel;
+import io.casehub.api.spi.CaseChannelProvider;
+import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
+import io.casehub.qhorus.api.message.MessageType;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AgentRoutingEscalationHandlerTest {
+
+  private CaseChannelProvider channelProvider;
+  private AgentRoutingEscalationHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    channelProvider = mock(CaseChannelProvider.class);
+    handler = new AgentRoutingEscalationHandler(channelProvider);
+  }
+
+  @Test
+  void oversightChannelFound_postsQuery() {
+    final UUID caseId = UUID.randomUUID();
+    final String oversightName = CaseChannel.oversightChannelName(caseId);
+    final CaseChannel channel = channel(oversightName);
+    when(channelProvider.listChannels(caseId)).thenReturn(List.of(channel));
+
+    handler.handle(new AgentRoutingEscalationEvent(caseId, "research", "research-binding"));
+
+    verify(channelProvider)
+        .postToChannel(
+            eq(channel),
+            eq("casehub-engine"),
+            any(String.class),
+            eq(MessageType.QUERY),
+            eq(null),
+            eq(null));
+  }
+
+  @Test
+  void oversightChannelNotFound_logsWarningAndDoesNotPost() {
+    final UUID caseId = UUID.randomUUID();
+    final CaseChannel unrelatedChannel = channel(CaseChannel.channelName(caseId, "work"));
+    when(channelProvider.listChannels(caseId)).thenReturn(List.of(unrelatedChannel));
+
+    handler.handle(new AgentRoutingEscalationEvent(caseId, "research", "research-binding"));
+
+    verify(channelProvider, never()).postToChannel(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void noChannelsAtAll_logsWarningAndDoesNotPost() {
+    final UUID caseId = UUID.randomUUID();
+    when(channelProvider.listChannels(caseId)).thenReturn(List.of());
+
+    handler.handle(new AgentRoutingEscalationEvent(caseId, "research", "research-binding"));
+
+    verify(channelProvider, never()).postToChannel(any(), any(), any(), any(), any(), any());
+  }
+
+  private static CaseChannel channel(final String name) {
+    return new CaseChannel("ch-" + name.hashCode(), name, "oversight", "qhorus", null);
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.engine.LoopControl;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CapabilityTarget;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Worker;
+import io.casehub.api.spi.ReactiveWorkerContextProvider;
+import io.casehub.api.spi.ReactiveWorkerProvisioner;
+import io.casehub.api.spi.routing.AgentAssignment;
+import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.casehub.eidos.api.CapabilityHealth;
+import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
+import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.engine.common.internal.event.WorkerScheduleEvent;
+import io.casehub.engine.common.internal.jq.JQEvaluator;
+import io.casehub.engine.common.internal.model.CaseInstance;
+import io.casehub.engine.common.internal.model.CaseMetaModel;
+import io.casehub.engine.common.spi.CaseDefinitionRegistry;
+import io.casehub.engine.common.spi.ExpressionEngineRegistry;
+import io.casehub.engine.common.spi.scheduler.WorkerExecutionManager;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Unit tests for the sealed AgentAssignment pattern-match in
+ * CaseContextChangedEventHandler.publishWorkerSchedule. Exercises all three branches: Assigned,
+ * Unresolvable, and EscalateToOversight.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CaseContextChangedEventHandlerRoutingTest {
+
+  @Mock EventBus eventBus;
+  @Mock JQEvaluator jqEvaluator;
+  @Mock CaseDefinitionRegistry caseDefinitionRegistry;
+  @Mock ExpressionEngineRegistry expressionEngineRegistry;
+  @Mock LoopControl loopControl;
+  @Mock AgentRoutingStrategy agentRoutingStrategy;
+  @Mock WorkerExecutionManager executionManager;
+  @Mock CapabilityHealth capabilityHealth;
+  @Mock ReactiveWorkerContextProvider reactiveWorkerContextProvider;
+  @Mock ReactiveWorkerProvisioner reactiveWorkerProvisioner;
+
+  @InjectMocks CaseContextChangedEventHandler handler;
+
+  private CaseInstance caseInstance;
+  private CaseDefinition definition;
+
+  @BeforeEach
+  void setUp() {
+    final Capability capability =
+        Capability.builder()
+            .name("research")
+            .inputSchema("{ q: .q }")
+            .outputSchema("{ r: .r }")
+            .build();
+    final ContextChangeTrigger trigger = new ContextChangeTrigger(".");
+    final Binding binding =
+        Binding.builder()
+            .name("research-binding")
+            .on(trigger)
+            .target(new CapabilityTarget(capability))
+            .build();
+    final Worker worker =
+        Worker.builder()
+            .name("analyst-worker")
+            .capabilities(capability)
+            .function(input -> java.util.Map.of())
+            .build();
+
+    final CaseMetaModel metaModel = mock(CaseMetaModel.class);
+    definition =
+        CaseDefinition.builder()
+            .namespace("test")
+            .name("Test")
+            .version("1.0")
+            .capabilities(capability)
+            .workers(worker)
+            .bindings(binding)
+            .build();
+
+    when(caseDefinitionRegistry.getCaseDefinition(metaModel)).thenReturn(definition);
+    when(expressionEngineRegistry.evaluate(
+            any(io.casehub.api.model.evaluator.ExpressionEvaluator.class),
+            any(com.fasterxml.jackson.databind.JsonNode.class)))
+        .thenReturn(true);
+    when(executionManager.getActiveWorkCount(any())).thenReturn(0);
+    when(capabilityHealth.probe(any(), any(), any()))
+        .thenReturn(new CapabilityHealth.CapabilityStatus.Ready());
+
+    final CaseContext ctx = mock(CaseContext.class);
+    when(ctx.asJsonNode()).thenReturn(NullNode.instance);
+
+    caseInstance = new CaseInstance();
+    caseInstance.setUuid(UUID.randomUUID());
+    caseInstance.setState(CaseStatus.RUNNING);
+    caseInstance.setCaseMetaModel(metaModel);
+    caseInstance.setCaseContext(ctx);
+
+    when(loopControl.select(any(), any())).thenReturn(Uni.createFrom().item(List.of(binding)));
+  }
+
+  @Test
+  void routing_assigned_publishesWorkerScheduleEvent() {
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.assign("analyst-worker")));
+
+    handler
+        .onCaseStateContextChangedEventHandler(
+            new CaseContextChangedEvent(caseInstance, NullNode.instance))
+        .await()
+        .indefinitely();
+
+    verify(eventBus).publish(eq(EventBusAddresses.WORKER_SCHEDULE), any(WorkerScheduleEvent.class));
+    verify(eventBus, never()).publish(eq(EventBusAddresses.AGENT_ROUTING_ESCALATION), any());
+  }
+
+  @Test
+  void routing_unresolvable_triesToProvision_doesNotScheduleWorker() {
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.unresolvable()));
+    // tryProvision requires a provisioner that has the capability — no-op provisioner won't trigger
+    when(reactiveWorkerProvisioner.getCapabilities())
+        .thenReturn(Uni.createFrom().item(java.util.Set.of()));
+
+    handler
+        .onCaseStateContextChangedEventHandler(
+            new CaseContextChangedEvent(caseInstance, NullNode.instance))
+        .await()
+        .indefinitely();
+
+    verify(eventBus, never())
+        .publish(eq(EventBusAddresses.WORKER_SCHEDULE), any(WorkerScheduleEvent.class));
+    verify(eventBus, never()).publish(eq(EventBusAddresses.AGENT_ROUTING_ESCALATION), any());
+  }
+
+  @Test
+  void routing_escalateToOversight_publishesEscalationEvent() {
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.escalate("research")));
+
+    handler
+        .onCaseStateContextChangedEventHandler(
+            new CaseContextChangedEvent(caseInstance, NullNode.instance))
+        .await()
+        .indefinitely();
+
+    verify(eventBus, never())
+        .publish(eq(EventBusAddresses.WORKER_SCHEDULE), any(WorkerScheduleEvent.class));
+    verify(eventBus)
+        .publish(
+            eq(EventBusAddresses.AGENT_ROUTING_ESCALATION), any(AgentRoutingEscalationEvent.class));
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/orchestration/WorkOrchestratorTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/orchestration/WorkOrchestratorTest.java
@@ -111,7 +111,7 @@ class WorkOrchestratorTest {
   void submit_workerSelected_publishesScheduleEvent() {
     final CaseInstance instance = runningInstance("analyse");
     when(agentRoutingStrategy.select(any(), any()))
-        .thenReturn(new AgentAssignment("analyst-worker"));
+        .thenReturn(Uni.createFrom().item(AgentAssignment.assign("analyst-worker")));
 
     orchestrator.submit(instance, WorkRequest.of("analyse", Map.of("doc", "x")));
 
@@ -122,7 +122,7 @@ class WorkOrchestratorTest {
   void submit_workerSelected_returnsPendingFuture() {
     final CaseInstance instance = runningInstance("analyse");
     when(agentRoutingStrategy.select(any(), any()))
-        .thenReturn(new AgentAssignment("analyst-worker"));
+        .thenReturn(Uni.createFrom().item(AgentAssignment.assign("analyst-worker")));
 
     final CompletableFuture<WorkResult> future =
         orchestrator.submit(instance, WorkRequest.of("analyse", Map.of())).toCompletableFuture();
@@ -134,7 +134,7 @@ class WorkOrchestratorTest {
   void submitAndWait_transitionsCaseToWaiting() {
     final CaseInstance instance = runningInstance("analyse");
     when(agentRoutingStrategy.select(any(), any()))
-        .thenReturn(new AgentAssignment("analyst-worker"));
+        .thenReturn(Uni.createFrom().item(AgentAssignment.assign("analyst-worker")));
 
     orchestrator.submitAndWait(instance, WorkRequest.of("analyse", Map.of("doc", "x")));
 
@@ -145,15 +145,34 @@ class WorkOrchestratorTest {
   // ---- robustness -----------------------------------------------------------
 
   @Test
-  void submit_strategyReturnsNoOp_failsFuture() {
+  void submit_strategyReturnsUnresolvable_failsFuture() {
     final CaseInstance instance = runningInstance("analyse");
-    when(agentRoutingStrategy.select(any(), any())).thenReturn(AgentAssignment.noOp());
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.unresolvable()));
 
     final var future =
         orchestrator.submit(instance, WorkRequest.of("analyse", Map.of())).toCompletableFuture();
 
     assertThat(future.isCompletedExceptionally()).isTrue();
-    verify(eventBus, never()).publish(any(), any());
+    verify(eventBus, never()).publish(any(), any(WorkerScheduleEvent.class));
+  }
+
+  @Test
+  void submit_strategyReturnsEscalate_failsFutureAndPublishesEscalation() {
+    final CaseInstance instance = runningInstance("analyse");
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.escalate("analyse")));
+
+    final var future =
+        orchestrator.submit(instance, WorkRequest.of("analyse", Map.of())).toCompletableFuture();
+
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    verify(eventBus, never()).publish(any(), any(WorkerScheduleEvent.class));
+    verify(eventBus)
+        .publish(
+            org.mockito.ArgumentMatchers.eq(
+                io.casehub.engine.common.internal.event.EventBusAddresses.AGENT_ROUTING_ESCALATION),
+            any(io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent.class));
   }
 
   @Test
@@ -194,7 +213,8 @@ class WorkOrchestratorTest {
   void probe_unavailable_workerExcludedFromCandidates() {
     when(capabilityHealth.probe(any(), any(), any()))
         .thenReturn(new CapabilityStatus.Unavailable("model offline"));
-    when(agentRoutingStrategy.select(any(), any())).thenReturn(AgentAssignment.noOp());
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.unresolvable()));
 
     final CaseInstance instance = runningInstanceWithAgentWorker("analyse");
     orchestrator.submit(instance, WorkRequest.of("analyse", Map.of())).toCompletableFuture();
@@ -210,7 +230,8 @@ class WorkOrchestratorTest {
   void probe_epistemicallyWeak_workerKeptWithWeakHealth() {
     when(capabilityHealth.probe(any(), any(), any()))
         .thenReturn(new CapabilityStatus.EpistemicallyWeak("rust", 0.25));
-    when(agentRoutingStrategy.select(any(), any())).thenReturn(new AgentAssignment("agent-worker"));
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.assign("agent-worker")));
 
     final CaseInstance instance = runningInstanceWithAgentWorker("analyse");
     orchestrator.submit(instance, WorkRequest.of("analyse", Map.of()));
@@ -229,7 +250,8 @@ class WorkOrchestratorTest {
   void probe_allUnavailable_emptyCandidateListPassedToStrategy() {
     when(capabilityHealth.probe(any(), any(), any()))
         .thenReturn(new CapabilityStatus.Unavailable("all offline"));
-    when(agentRoutingStrategy.select(any(), any())).thenReturn(AgentAssignment.noOp());
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.unresolvable()));
 
     final CaseInstance instance = runningInstanceWithAgentWorker("analyse");
     orchestrator.submit(instance, WorkRequest.of("analyse", Map.of())).toCompletableFuture();
@@ -243,7 +265,7 @@ class WorkOrchestratorTest {
   @Test
   void probe_noDescriptor_probeSkipped_workerUsesReadyHealth() {
     when(agentRoutingStrategy.select(any(), any()))
-        .thenReturn(new AgentAssignment("analyst-worker"));
+        .thenReturn(Uni.createFrom().item(AgentAssignment.assign("analyst-worker")));
 
     final CaseInstance instance = runningInstance("analyse");
     orchestrator.submit(instance, WorkRequest.of("analyse", Map.of()));

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/AgentCandidateFactoryTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/AgentCandidateFactoryTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.Worker;
+import io.casehub.api.spi.routing.AgentCandidate;
+import io.casehub.api.spi.routing.AgentHealth;
+import io.casehub.eidos.api.AgentDescriptor;
+import io.casehub.eidos.api.CapabilityHealth;
+import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
+import io.casehub.eidos.api.CapabilityHealth.ProbeContext;
+import io.casehub.engine.common.internal.model.CaseInstance;
+import io.casehub.engine.common.spi.scheduler.WorkerExecutionManager;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AgentCandidateFactoryTest {
+
+  private CapabilityHealth capabilityHealth;
+  private WorkerExecutionManager executionManager;
+  private CaseInstance caseInstance;
+  private Capability capability;
+
+  @BeforeEach
+  void setUp() {
+    capabilityHealth = mock(CapabilityHealth.class);
+    executionManager = mock(WorkerExecutionManager.class);
+    caseInstance = mock(CaseInstance.class);
+    capability = mock(Capability.class);
+
+    when(caseInstance.getUuid()).thenReturn(UUID.randomUUID());
+    when(capability.getName()).thenReturn("research");
+    when(executionManager.getActiveWorkCount("agent-1")).thenReturn(2);
+  }
+
+  @Test
+  void workerWithMatchingCapability_isIncluded() {
+    final Worker worker = workerWithCapability("agent-1", "research", false, null);
+    when(executionManager.getActiveWorkCount("agent-1")).thenReturn(2);
+
+    final List<AgentCandidate> result =
+        AgentCandidateFactory.buildCandidates(
+            caseInstance, List.of(worker), capability, executionManager, capabilityHealth);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).workerId()).isEqualTo("agent-1");
+    assertThat(result.get(0).runningJobs()).isEqualTo(2);
+    assertThat(result.get(0).health()).isEqualTo(AgentHealth.READY);
+    assertThat(result.get(0).agentDescriptor()).isNull();
+  }
+
+  @Test
+  void workerWithDifferentCapability_isExcluded() {
+    final Worker worker = workerWithCapability("agent-1", "other-capability", false, null);
+
+    final List<AgentCandidate> result =
+        AgentCandidateFactory.buildCandidates(
+            caseInstance, List.of(worker), capability, executionManager, capabilityHealth);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void unavailableWorker_isExcluded() {
+    final AgentDescriptor descriptor = mock(AgentDescriptor.class);
+    final Worker worker = workerWithCapability("agent-1", "research", true, descriptor);
+    when(capabilityHealth.probe(
+            descriptor, "research", ProbeContext.of(caseInstance.getUuid().toString())))
+        .thenReturn(new CapabilityStatus.Unavailable("down"));
+
+    final List<AgentCandidate> result =
+        AgentCandidateFactory.buildCandidates(
+            caseInstance, List.of(worker), capability, executionManager, capabilityHealth);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void workerWithDescriptor_descriptorPassedThrough() {
+    final AgentDescriptor descriptor = mock(AgentDescriptor.class);
+    final Worker worker = workerWithCapability("agent-1", "research", true, descriptor);
+    when(capabilityHealth.probe(
+            descriptor, "research", ProbeContext.of(caseInstance.getUuid().toString())))
+        .thenReturn(new CapabilityStatus.Ready());
+
+    final List<AgentCandidate> result =
+        AgentCandidateFactory.buildCandidates(
+            caseInstance, List.of(worker), capability, executionManager, capabilityHealth);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).agentDescriptor()).isSameAs(descriptor);
+  }
+
+  @Test
+  void epistemicallyWeakWorker_includedWithCorrectHealth() {
+    final AgentDescriptor descriptor = mock(AgentDescriptor.class);
+    final Worker worker = workerWithCapability("agent-1", "research", true, descriptor);
+    when(capabilityHealth.probe(
+            descriptor, "research", ProbeContext.of(caseInstance.getUuid().toString())))
+        .thenReturn(new CapabilityStatus.EpistemicallyWeak("domain", 0.3));
+
+    final List<AgentCandidate> result =
+        AgentCandidateFactory.buildCandidates(
+            caseInstance, List.of(worker), capability, executionManager, capabilityHealth);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).health()).isEqualTo(AgentHealth.EPISTEMICALLY_WEAK);
+  }
+
+  @Test
+  void nullWorkers_returnsEmpty() {
+    final List<AgentCandidate> result =
+        AgentCandidateFactory.buildCandidates(
+            caseInstance, null, capability, executionManager, capabilityHealth);
+
+    assertThat(result).isEmpty();
+  }
+
+  // ---- Helpers ---------------------------------------------------------------
+
+  private Worker workerWithCapability(
+      final String name,
+      final String capabilityName,
+      final boolean hasDescriptor,
+      final AgentDescriptor descriptor) {
+    final Worker worker = mock(Worker.class);
+    when(worker.getName()).thenReturn(name);
+    when(worker.hasDescriptor()).thenReturn(hasDescriptor);
+    if (hasDescriptor) {
+      when(worker.agentDescriptor()).thenReturn(descriptor);
+    }
+
+    final Capability cap = mock(Capability.class);
+    when(cap.getName()).thenReturn(capabilityName);
+    when(worker.getCapabilities()).thenReturn(List.of(cap));
+    return worker;
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/LeastLoadedAgentStrategyTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/LeastLoadedAgentStrategyTest.java
@@ -17,6 +17,7 @@ package io.casehub.engine.internal.routing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.node.NullNode;
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentHealth;
@@ -35,57 +36,63 @@ class LeastLoadedAgentStrategyTest {
   @BeforeEach
   void setUp() {
     strategy = new LeastLoadedAgentStrategy();
-    ctx = new AgentRoutingContext(UUID.randomUUID(), "data-analysis");
+    ctx = new AgentRoutingContext(UUID.randomUUID(), "data-analysis", NullNode.instance);
   }
 
   @Test
-  void emptyCandidates_returnsNoOp() {
-    assertThat(strategy.select(ctx, List.of()).isNoOp()).isTrue();
+  void emptyCandidates_returnsUnresolvable() {
+    assertThat(strategy.select(ctx, List.of()).await().indefinitely())
+        .isInstanceOf(AgentAssignment.Unresolvable.class);
   }
 
   @Test
   void singleCandidate_isSelected() {
-    final AgentCandidate only = candidate("agent-1", 3);
-    final AgentAssignment result = strategy.select(ctx, List.of(only));
-    assertThat(result.workerId()).isEqualTo("agent-1");
+    final AgentAssignment result =
+        strategy.select(ctx, List.of(candidate("agent-1", 3))).await().indefinitely();
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-1");
   }
 
   @Test
   void selectsLeastLoaded_byRunningJobs() {
-    final AgentCandidate busy = candidate("agent-busy", 5);
-    final AgentCandidate idle = candidate("agent-idle", 0);
-    final AgentCandidate mid = candidate("agent-mid", 2);
-
-    final AgentAssignment result = strategy.select(ctx, List.of(busy, mid, idle));
-    assertThat(result.workerId()).isEqualTo("agent-idle");
+    final AgentAssignment result =
+        strategy
+            .select(
+                ctx,
+                List.of(
+                    candidate("agent-busy", 5),
+                    candidate("agent-mid", 2),
+                    candidate("agent-idle", 0)))
+            .await()
+            .indefinitely();
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-idle");
   }
 
   @Test
   void tie_firstInListWins() {
-    // deterministic tiebreaker: list order
-    final AgentCandidate first = candidate("agent-a", 2);
-    final AgentCandidate second = candidate("agent-b", 2);
-
-    final AgentAssignment result = strategy.select(ctx, List.of(first, second));
-    assertThat(result.workerId()).isEqualTo("agent-a");
+    final AgentAssignment result =
+        strategy
+            .select(ctx, List.of(candidate("agent-a", 2), candidate("agent-b", 2)))
+            .await()
+            .indefinitely();
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-a");
   }
 
   @Test
   void healthDoesNotAffectSelection_leastLoadedWinsRegardlessOfHealth() {
-    // LeastLoadedAgentStrategy ignores health — TrustWeightedAgentStrategy handles demotion
-    final AgentCandidate readyBusy = candidate("ready-busy", 5, AgentHealth.READY);
-    final AgentCandidate weakIdle = candidate("weak-idle", 0, AgentHealth.EPISTEMICALLY_WEAK);
-
-    final AgentAssignment result = strategy.select(ctx, List.of(readyBusy, weakIdle));
-    assertThat(result.workerId()).isEqualTo("weak-idle");
-  }
-
-  @Test
-  void zeroJobs_idle_isPreferred() {
-    final AgentCandidate oneJob = candidate("one", 1);
-    final AgentCandidate zeroJobs = candidate("zero", 0);
-
-    assertThat(strategy.select(ctx, List.of(oneJob, zeroJobs)).workerId()).isEqualTo("zero");
+    final AgentAssignment result =
+        strategy
+            .select(
+                ctx,
+                List.of(
+                    candidate("ready-busy", 5, AgentHealth.READY),
+                    candidate("weak-idle", 0, AgentHealth.EPISTEMICALLY_WEAK)))
+            .await()
+            .indefinitely();
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("weak-idle");
   }
 
   private static AgentCandidate candidate(final String workerId, final int jobs) {
@@ -94,6 +101,6 @@ class LeastLoadedAgentStrategyTest {
 
   private static AgentCandidate candidate(
       final String workerId, final int jobs, final AgentHealth health) {
-    return new AgentCandidate(workerId, Set.of("data-analysis"), jobs, health);
+    return new AgentCandidate(workerId, Set.of("data-analysis"), jobs, health, null);
   }
 }


### PR DESCRIPTION
## Summary

- **engine#377 (borderline escalation):** `AgentAssignment` becomes a sealed type (`Assigned` / `Unresolvable` / `EscalateToOversight`). `TrustWeightedAgentStrategy` returns `EscalateToOversight` when all trust-eligible candidates are borderline, per trust-maturity-model.md Phase 2. Engine posts a QUERY to the case oversight channel via `AgentRoutingEscalationHandler`.
- **engine#376 (semantic routing):** New optional `casehub-engine-ai` module with `AgentEmbeddingProvider` SPI and `SemanticAgentRoutingStrategy` (@Priority(2)). Trust filtering runs first; semantic embedding re-ranks QUALIFIED candidates. Embeddings run on a worker pool thread — not the Vert.x IO thread.
- **Reactive SPI:** `AgentRoutingStrategy.select()` returns `Uni<AgentAssignment>` — correct for strategies that make blocking embedding calls.
- **`TrustCandidateClassifier`** — new `@ApplicationScoped` CDI bean shared by both trust strategies; eliminates duplication of the 4-phase classification loop.
- **`AgentCandidateFactory`** — shared static utility replacing duplicated `buildCandidates()` in `CaseContextChangedEventHandler` and `WorkOrchestrator`.
- **`AgentRoutingContext` / `AgentCandidate`** — extended with `caseContext` (JsonNode) and `agentDescriptor` (nullable) respectively.

## Deferred

- engine#383 — oversight response loop (COMMAND → re-trigger routing)
- engine#384 — PlanItem state during escalation
- engine#385 — embedding vector cache
- engine#386 — LangChain4j `AgentEmbeddingProvider` implementation
- engine#388 — minor code quality items (TrustCandidateClassifier.decide() instance method, etc.)

## Test plan

- [x] `AgentAssignmentTest` — sealed variants, factory methods, pattern switch exhaustiveness
- [x] `AgentRoutingStrategyContractTest` — Uni return type, all three variants
- [x] `TrustRoutingPolicyTest` — isBootstrap/isBorderline/passesThresholdCheck boundary cases
- [x] `TrustCandidateClassifierTest` — all 5 Phase enum values, decide() outcomes
- [x] `TrustWeightedAgentStrategyTest` — 17 tests including new escalation cases
- [x] `SemanticAgentRoutingStrategyTest` — mock embedding provider, semantic re-ranking, escalation path
- [x] `AgentCandidateFactoryTest`, `AgentRoutingEscalationHandlerTest`, `CaseContextChangedEventHandlerRoutingTest`, `WorkOrchestratorTest`
- [x] Full build green (`mvn install`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)