### PR TITLE
 feat(schema): add Milestone SLA fields to YAML DSL — entryCriteria, slaDuration, slaStartFrom

### DIFF
--- a/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
+++ b/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.HumanTaskTarget;
 import io.casehub.api.model.Milestone;
+import io.casehub.api.model.SlaStartFrom;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import java.io.IOException;
@@ -136,11 +137,55 @@ public final class CaseDefinitionYamlMapper {
     // Convert milestones
     if (schema.getSpec().getMilestones() != null) {
       for (io.casehub.model.Milestone sm : schema.getSpec().getMilestones()) {
-        Milestone milestone =
+        Milestone.Builder milestoneBuilder =
             Milestone.builder()
                 .name(sm.getName())
-                .completionCriteria(new JQExpressionEvaluator(sm.getCondition()))
-                .build();
+                .completionCriteria(new JQExpressionEvaluator(sm.getCondition()));
+
+        if (sm.getEntryCriteria() != null) {
+          milestoneBuilder.entryCriteria(new JQExpressionEvaluator(sm.getEntryCriteria()));
+        }
+
+        if (sm.getSlaDuration() != null) {
+          Duration duration;
+          try {
+            duration = Duration.parse(sm.getSlaDuration());
+          } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(
+                "Milestone '"
+                    + sm.getName()
+                    + "' has invalid slaDuration '"
+                    + sm.getSlaDuration()
+                    + "' — must be ISO-8601 duration (e.g. PT2H)",
+                e);
+          }
+          if (duration.isNegative() || duration.isZero()) {
+            throw new IllegalArgumentException(
+                "Milestone '"
+                    + sm.getName()
+                    + "' slaDuration must be positive, got '"
+                    + sm.getSlaDuration()
+                    + "'");
+          }
+          milestoneBuilder.slaDuration(duration);
+        }
+
+        if (sm.getSlaStartFrom() != null) {
+          SlaStartFrom startFrom = SlaStartFrom.valueOf(sm.getSlaStartFrom().value());
+          if (startFrom == SlaStartFrom.PREVIOUS_MILESTONE_COMPLETED
+              || startFrom == SlaStartFrom.EVENT_OCCURRED) {
+            throw new UnsupportedOperationException(
+                "Milestone '"
+                    + sm.getName()
+                    + "' uses slaStartFrom="
+                    + startFrom
+                    + " which is not yet implemented."
+                    + " Use CASE_CREATED or MILESTONE_ACTIVATED.");
+          }
+          milestoneBuilder.slaStartFrom(startFrom);
+        }
+
+        Milestone milestone = milestoneBuilder.build();
         milestone.setDescription(sm.getDescription());
         def.getMilestones().add(milestone);
       }

--- a/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
+++ b/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
@@ -752,4 +752,29 @@ class CaseDefinitionYamlMapperTest {
         .hasMessageContaining("PREVIOUS_MILESTONE_COMPLETED")
         .hasMessageContaining("not yet implemented");
   }
+
+  @Test
+  void milestone_withEventOccurredSlaStartFrom_throwsUnsupportedOperation() {
+    String yaml =
+        """
+        namespace: test
+        name: Event StartFrom
+        version: 1.0.0
+        spec:
+          milestones:
+            - name: event-sla
+              condition: '.done == true'
+              slaDuration: PT1H
+              slaStartFrom: EVENT_OCCURRED
+        """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("event-sla")
+        .hasMessageContaining("EVENT_OCCURRED")
+        .hasMessageContaining("not yet implemented");
+  }
 }

--- a/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
+++ b/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
@@ -27,6 +27,7 @@ import io.casehub.api.model.GoalBasedCompletion;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.HumanTaskTarget;
 import io.casehub.api.model.Milestone;
+import io.casehub.api.model.SlaStartFrom;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.ai.Agent;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
@@ -572,5 +573,183 @@ class CaseDefinitionYamlMapperTest {
     GoalBasedCompletion completion = (GoalBasedCompletion) def.getCompletion();
     assertThat(completion.getSuccess()).isNotNull();
     assertThat(completion.getFailure()).isNotNull();
+  }
+
+  @Test
+  void milestone_withSlaFields_allFieldsParsed() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: SLA Test
+        version: 1.0.0
+        spec:
+          milestones:
+            - name: approval
+              condition: '.approved == true'
+              entryCriteria: '.submitted == true'
+              slaDuration: PT2H
+              slaStartFrom: CASE_CREATED
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(def.getMilestones()).hasSize(1);
+    Milestone m = def.getMilestones().get(0);
+    assertThat(m.getName()).isEqualTo("approval");
+    assertThat(m.getCompletionCriteria()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) m.getCompletionCriteria()).expression())
+        .isEqualTo(".approved == true");
+    assertThat(m.getEntryCriteria()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) m.getEntryCriteria()).expression())
+        .isEqualTo(".submitted == true");
+    assertThat(m.getSlaDuration()).isEqualTo(Duration.ofHours(2));
+    assertThat(m.getSlaStartFrom()).isEqualTo(SlaStartFrom.CASE_CREATED);
+  }
+
+  @Test
+  void milestone_withoutSlaFields_usesDefaults() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Defaults Test
+        version: 1.0.0
+        spec:
+          milestones:
+            - name: simple
+              condition: '.done == true'
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    Milestone m = def.getMilestones().get(0);
+    assertThat(m.getName()).isEqualTo("simple");
+    assertThat(m.getSlaDuration()).isNull();
+    assertThat(m.getSlaStartFrom()).isEqualTo(SlaStartFrom.MILESTONE_ACTIVATED);
+    assertThat(m.getEntryCriteria()).isNotNull();
+    assertThat(m.getEntryCriteria()).isNotInstanceOf(JQExpressionEvaluator.class);
+  }
+
+  @Test
+  void milestone_withEntryCriteriaOnly_slaFieldsDefault() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Entry Test
+        version: 1.0.0
+        spec:
+          milestones:
+            - name: gated
+              condition: '.reviewed == true'
+              entryCriteria: '.assignee != null'
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    Milestone m = def.getMilestones().get(0);
+    assertThat(m.getEntryCriteria()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) m.getEntryCriteria()).expression())
+        .isEqualTo(".assignee != null");
+    assertThat(m.getSlaDuration()).isNull();
+    assertThat(m.getSlaStartFrom()).isEqualTo(SlaStartFrom.MILESTONE_ACTIVATED);
+  }
+
+  @Test
+  void milestone_withInvalidSlaDurationFormat_throwsIllegalArgument() {
+    String yaml =
+        """
+        namespace: test
+        name: Bad Duration
+        version: 1.0.0
+        spec:
+          milestones:
+            - name: bad-sla
+              condition: '.done == true'
+              slaDuration: "1h"
+        """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bad-sla")
+        .hasMessageContaining("1h");
+  }
+
+  @Test
+  void milestone_withZeroSlaDuration_throwsIllegalArgument() {
+    String yaml =
+        """
+        namespace: test
+        name: Zero Duration
+        version: 1.0.0
+        spec:
+          milestones:
+            - name: zero-sla
+              condition: '.done == true'
+              slaDuration: "PT0S"
+        """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("zero-sla")
+        .hasMessageContaining("must be positive");
+  }
+
+  @Test
+  void milestone_withNegativeSlaDuration_throwsIllegalArgument() {
+    String yaml =
+        """
+        namespace: test
+        name: Neg Duration
+        version: 1.0.0
+        spec:
+          milestones:
+            - name: neg-sla
+              condition: '.done == true'
+              slaDuration: "PT-1H"
+        """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("neg-sla")
+        .hasMessageContaining("must be positive");
+  }
+
+  @Test
+  void milestone_withUnimplementedSlaStartFrom_throwsUnsupportedOperation() {
+    String yaml =
+        """
+        namespace: test
+        name: Unimplemented StartFrom
+        version: 1.0.0
+        spec:
+          milestones:
+            - name: future-sla
+              condition: '.done == true'
+              slaDuration: PT1H
+              slaStartFrom: PREVIOUS_MILESTONE_COMPLETED
+        """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("future-sla")
+        .hasMessageContaining("PREVIOUS_MILESTONE_COMPLETED")
+        .hasMessageContaining("not yet implemented");
   }
 }

--- a/schema/src/main/resources/schema/CaseDefinition.yaml
+++ b/schema/src/main/resources/schema/CaseDefinition.yaml
@@ -431,6 +431,17 @@ $defs:
         type: string
         title: MilestoneCondition
         description: "JQ expression — true means milestone is reached"
+      entryCriteria:
+        type: string
+        description: "JQ predicate — milestone becomes ACTIVE when true (default: always true)"
+      slaDuration:
+        type: string
+        description: "ISO-8601 duration for SLA deadline (e.g. PT2H, PT24H). Must be positive if present."
+      slaStartFrom:
+        type: string
+        enum: [CASE_CREATED, MILESTONE_ACTIVATED, PREVIOUS_MILESTONE_COMPLETED, EVENT_OCCURRED]
+        default: MILESTONE_ACTIVATED
+        description: "When SLA clock starts. Only CASE_CREATED and MILESTONE_ACTIVATED are currently implemented."
 
   RetryPolicy:
     type: object


### PR DESCRIPTION
  ## Summary

  - Add `entryCriteria`, `slaDuration`, `slaStartFrom` to the Milestone YAML schema definition and wire them through `CaseDefinitionYamlMapper`
  - YAML-defined cases can now use milestone SLA tracking and entry criteria gating — previously only available via the Java DSL (`Milestone.builder()`)
  - All four `SlaStartFrom` enum values are in the schema; `PREVIOUS_MILESTONE_COMPLETED` and `EVENT_OCCURRED` throw `UnsupportedOperationException` at load time (fail-fast)

  ## Changes

  **Schema** (`CaseDefinition.yaml`):
  - `entryCriteria` — optional JQ predicate, milestone becomes ACTIVE when true
  - `slaDuration` — optional ISO-8601 duration (e.g. `PT2H`), must be positive
  - `slaStartFrom` — enum (`CASE_CREATED`, `MILESTONE_ACTIVATED`, `PREVIOUS_MILESTONE_COMPLETED`, `EVENT_OCCURRED`), default `MILESTONE_ACTIVATED`

  **Mapper** (`CaseDefinitionYamlMapper.java`):
  - Wire all 3 fields with validation matching the `HumanTask.expiresIn` pattern
  - Invalid duration format, zero/negative duration, and unimplemented `slaStartFrom` values produce descriptive errors with milestone name

  **No API changes** — `Milestone.java` already supported all fields via builder.

  ## Example YAML
  
  ```yaml
  milestones:
    - name: approval
      condition: '.approved == true'
      entryCriteria: '.submitted == true'
      slaDuration: PT2H
      slaStartFrom: CASE_CREATED

  Test plan
  
  - [x] Happy path: milestone with all 3 new fields parsed correctly
  - [x] Defaults: milestone without new fields — entryCriteria always-true, slaDuration null, slaStartFrom MILESTONE_ACTIVATED
  - [x] entryCriteria only — SLA fields default
  - [x] Invalid slaDuration format ("1h") → IllegalArgumentException
  - [x] Zero slaDuration ("PT0S") → IllegalArgumentException
  - [x] Negative slaDuration ("PT-1H") → IllegalArgumentException
  - [x] Unimplemented slaStartFrom PREVIOUS_MILESTONE_COMPLETED → UnsupportedOperationException
  - [x] Unimplemented slaStartFrom EVENT_OCCURRED → UnsupportedOperationException
  - [x] All existing tests pass (25 total in CaseDefinitionYamlMapperTest)
  - [x] Full build: 1,211 tests pass across schema, api, common, runtime, blackboard

  Closes #420