### PR TITLE
feat: add bootstrapEscalationRequired guard to trust routing strategies (engine#415)

### DIFF
--- a/api/src/main/java/io/casehub/api/spi/routing/AgentAssignment.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/AgentAssignment.java
@@ -21,8 +21,12 @@ package io.casehub.api.spi.routing;
  * <ul>
  *   <li>{@link Assigned} — a specific worker was selected
  *   <li>{@link Unresolvable} — no candidate passed trust filters (none were borderline)
- *   <li>{@link EscalateToOversight} — all trust-eligible candidates are borderline; human oversight
- *       is required per trust-maturity-model.md Phase 2
+ *   <li>{@link EscalateToOversight} — all trust-eligible candidates are borderline, or the
+ *       bootstrap fallback threshold was breached; human oversight is required per
+ *       trust-maturity-model.md Phase 2. The {@code reason} field identifies why escalation was
+ *       triggered — callers use it to populate {@link
+ *       io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent} and to select the
+ *       appropriate oversight handler.
  * </ul>
  *
  * <p>Callers must switch exhaustively on the sealed type. The previous {@code isNoOp()} pattern is
@@ -44,9 +48,12 @@ public sealed interface AgentAssignment
 
   /**
    * All trust-eligible candidates are borderline (score within {@code borderlineMargin} of {@code
-   * threshold}). Engine must route to human oversight per trust-maturity-model.md Phase 2.
+   * threshold}), or the bootstrap fallback threshold was breached. Engine must route to human
+   * oversight per trust-maturity-model.md Phase 2. The {@code reason} field identifies the specific
+   * trigger condition.
    */
-  record EscalateToOversight(String capabilityName) implements AgentAssignment {}
+  record EscalateToOversight(String capabilityName, EscalationReason reason)
+      implements AgentAssignment {}
 
   static AgentAssignment assign(final String workerId) {
     return new Assigned(workerId);
@@ -56,7 +63,7 @@ public sealed interface AgentAssignment
     return new Unresolvable();
   }
 
-  static AgentAssignment escalate(final String capabilityName) {
-    return new EscalateToOversight(capabilityName);
+  static AgentAssignment escalate(final String capabilityName, final EscalationReason reason) {
+    return new EscalateToOversight(capabilityName, reason);
   }
 }

--- a/api/src/main/java/io/casehub/api/spi/routing/AgentAssignment.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/AgentAssignment.java
@@ -21,10 +21,9 @@ package io.casehub.api.spi.routing;
  * <ul>
  *   <li>{@link Assigned} — a specific worker was selected
  *   <li>{@link Unresolvable} — no candidate passed trust filters (none were borderline)
- *   <li>{@link EscalateToOversight} — all trust-eligible candidates are borderline, or the
- *       bootstrap fallback threshold was breached; human oversight is required per
- *       trust-maturity-model.md Phase 2. The {@code reason} field identifies why escalation was
- *       triggered — callers use it to populate {@link
+ *   <li>{@link EscalateToOversight} — routing cannot proceed automatically; see {@link
+ *       EscalationReason} for the specific trigger. The {@code reason} field identifies why
+ *       escalation was triggered — callers use it to populate {@link
  *       io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent} and to select the
  *       appropriate oversight handler.
  * </ul>
@@ -47,10 +46,8 @@ public sealed interface AgentAssignment
   record Unresolvable() implements AgentAssignment {}
 
   /**
-   * All trust-eligible candidates are borderline (score within {@code borderlineMargin} of {@code
-   * threshold}), or the bootstrap fallback threshold was breached. Engine must route to human
-   * oversight per trust-maturity-model.md Phase 2. The {@code reason} field identifies the specific
-   * trigger condition.
+   * Routing cannot proceed automatically. See {@link EscalationReason} for why. Engine must route
+   * to human oversight via the oversight channel.
    */
   record EscalateToOversight(String capabilityName, EscalationReason reason)
       implements AgentAssignment {}

--- a/api/src/main/java/io/casehub/api/spi/routing/EscalationReason.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/EscalationReason.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi.routing;
+
+/** Why agent routing escalated to human oversight. */
+public enum EscalationReason {
+
+  /**
+   * All candidates scored 0.0 and at least one was BORDERLINE (score within {@code
+   * borderlineMargin} of {@code threshold}). The pool has agents but none are clearly qualified.
+   */
+  BORDERLINE_STALEMATE,
+
+  /**
+   * No QUALIFIED agent is available; only BOOTSTRAP-phase agents could be assigned. Pre-screen
+   * fires before scoring — no scoring has occurred. Requires human routing.
+   */
+  NO_QUALIFIED_AGENT
+}

--- a/api/src/main/java/io/casehub/api/spi/routing/TrustRoutingPolicy.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/TrustRoutingPolicy.java
@@ -28,8 +28,10 @@ import java.util.Map;
  *     trust)
  * @param qualityFloors Phase 3: dimension name → minimum acceptable quality score; candidates
  *     failing any floor are excluded; no penalty if dimension data is absent
- * @param bootstrapEscalationRequired true to escalate bootstrap context changes; false to handle
- *     via routing fallback
+ * @param bootstrapEscalationRequired when true, BOOTSTRAP candidates are stripped from the scoring
+ *     pool; if no QUALIFIED agent exists, escalates to {@link
+ *     io.casehub.api.spi.routing.EscalationReason#NO_QUALIFIED_AGENT} instead of assigning an
+ *     unproven agent. Set to true for high-stakes, irreversible capabilities. Default: false.
  */
 public record TrustRoutingPolicy(
     double threshold,

--- a/api/src/main/java/io/casehub/api/spi/routing/TrustRoutingPolicy.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/TrustRoutingPolicy.java
@@ -28,17 +28,20 @@ import java.util.Map;
  *     trust)
  * @param qualityFloors Phase 3: dimension name → minimum acceptable quality score; candidates
  *     failing any floor are excluded; no penalty if dimension data is absent
+ * @param bootstrapEscalationRequired true to escalate bootstrap context changes; false to handle
+ *     via routing fallback
  */
 public record TrustRoutingPolicy(
     double threshold,
     int minimumObservations,
     double borderlineMargin,
     double blendFactor,
-    Map<String, Double> qualityFloors) {
+    Map<String, Double> qualityFloors,
+    boolean bootstrapEscalationRequired) {
 
   /** Conservative defaults: 0.7 threshold, 10 observations, 0.1 margin, 60% trust blend. */
   public static final TrustRoutingPolicy DEFAULT =
-      new TrustRoutingPolicy(0.7, 10, 0.1, 0.6, Map.of());
+      new TrustRoutingPolicy(0.7, 10, 0.1, 0.6, Map.of(), false);
 
   /** True when an agent lacks sufficient decision history for trust-based routing (Phase 0/1). */
   public boolean isBootstrap(final int decisionCount) {

--- a/api/src/test/java/io/casehub/api/spi/AgentAssignmentTest.java
+++ b/api/src/test/java/io/casehub/api/spi/AgentAssignmentTest.java
@@ -18,6 +18,7 @@ package io.casehub.api.spi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.casehub.api.spi.routing.AgentAssignment;
+import io.casehub.api.spi.routing.EscalationReason;
 import org.junit.jupiter.api.Test;
 
 class AgentAssignmentTest {
@@ -38,12 +39,15 @@ class AgentAssignmentTest {
   }
 
   @Test
-  void escalate_createsEscalateToOversight_withCapabilityName() {
-    final AgentAssignment assignment = AgentAssignment.escalate("data-analysis");
+  void escalate_createsEscalateToOversight_withCapabilityNameAndReason() {
+    final AgentAssignment assignment =
+        AgentAssignment.escalate("data-analysis", EscalationReason.BORDERLINE_STALEMATE);
 
     assertThat(assignment).isInstanceOf(AgentAssignment.EscalateToOversight.class);
-    assertThat(((AgentAssignment.EscalateToOversight) assignment).capabilityName())
-        .isEqualTo("data-analysis");
+    final AgentAssignment.EscalateToOversight escalation =
+        (AgentAssignment.EscalateToOversight) assignment;
+    assertThat(escalation.capabilityName()).isEqualTo("data-analysis");
+    assertThat(escalation.reason()).isEqualTo(EscalationReason.BORDERLINE_STALEMATE);
   }
 
   @Test
@@ -76,7 +80,8 @@ class AgentAssignmentTest {
 
   @Test
   void patternSwitch_EscalateToOversight_branchesCorrectly() {
-    final AgentAssignment assignment = AgentAssignment.escalate("review");
+    final AgentAssignment assignment =
+        AgentAssignment.escalate("review", EscalationReason.BORDERLINE_STALEMATE);
 
     final String result =
         switch (assignment) {

--- a/api/src/test/java/io/casehub/api/spi/AgentRoutingStrategyContractTest.java
+++ b/api/src/test/java/io/casehub/api/spi/AgentRoutingStrategyContractTest.java
@@ -23,6 +23,7 @@ import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentHealth;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.smallrye.mutiny.Uni;
 import java.util.List;
 import java.util.Set;
@@ -108,7 +109,11 @@ class AgentRoutingStrategyContractTest {
   @Test
   void implementation_canReturnEscalateToOversight() {
     final AgentRoutingStrategy strategy =
-        (ctx, candidates) -> Uni.createFrom().item(AgentAssignment.escalate(ctx.capabilityName()));
+        (ctx, candidates) ->
+            Uni.createFrom()
+                .item(
+                    AgentAssignment.escalate(
+                        ctx.capabilityName(), EscalationReason.BORDERLINE_STALEMATE));
     final AgentRoutingContext ctx =
         new AgentRoutingContext(UUID.randomUUID(), "sensitive-review", NullNode.instance);
 

--- a/api/src/test/java/io/casehub/api/spi/routing/TrustRoutingPolicyTest.java
+++ b/api/src/test/java/io/casehub/api/spi/routing/TrustRoutingPolicyTest.java
@@ -24,7 +24,7 @@ class TrustRoutingPolicyTest {
 
   // threshold=0.7, minimumObservations=5, borderlineMargin=0.1
   private static final io.casehub.api.spi.routing.TrustRoutingPolicy POLICY =
-      new io.casehub.api.spi.routing.TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of());
+      new io.casehub.api.spi.routing.TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of(), false);
 
   // ---- isBootstrap --------------------------------------------------------
 

--- a/common/src/main/java/io/casehub/engine/common/internal/event/AgentRoutingEscalationEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/AgentRoutingEscalationEvent.java
@@ -15,18 +15,13 @@
  */
 package io.casehub.engine.common.internal.event;
 
+import io.casehub.api.spi.routing.EscalationReason;
 import java.util.UUID;
 
 /**
- * Published to {@link EventBusAddresses#AGENT_ROUTING_ESCALATION} when all trust-eligible agent
- * candidates for a capability are borderline (trust score within {@code borderlineMargin} of {@code
- * threshold}). Signals that human oversight is required to decide which agent should handle the
- * capability for this case.
- *
- * <p>Handler: {@code AgentRoutingEscalationHandler} posts a QUERY to the case's oversight channel
- * so a human supervisor can make the routing decision.
- *
- * <p>PlanItem state during escalation: stays PENDING. Response handling (COMMAND → re-trigger
- * routing) tracked in engine#383.
+ * Published when agent routing cannot proceed automatically and human oversight is required. The
+ * {@link EscalationReason} indicates whether the trigger was a borderline stalemate or a pool with
+ * no trust-qualified agents.
  */
-public record AgentRoutingEscalationEvent(UUID caseId, String capabilityName, String bindingName) {}
+public record AgentRoutingEscalationEvent(
+    UUID caseId, String capabilityName, String bindingName, EscalationReason reason) {}

--- a/docs/specs/2026-06-05-bootstrap-fallback-type-design.md
+++ b/docs/specs/2026-06-05-bootstrap-fallback-type-design.md
@@ -1,0 +1,280 @@
+# Bootstrap Escalation Required — Design Spec
+
+**Issue:** casehubio/engine#415
+**Branch:** `issue-415-bootstrap-fallback-type`
+**Date:** 2026-06-05
+**Status:** approved (revised)
+
+---
+
+## Problem
+
+`TrustWeightedAgentStrategy` and `SemanticAgentRoutingStrategy` both score BOOTSTRAP candidates
+by workload (`1/(1+runningJobs)`). When the available agent pool for a high-stakes capability
+contains no QUALIFIED agents (e.g. all BOOTSTRAP, or BOOTSTRAP + BORDERLINE), the BOOTSTRAP
+candidate wins by workload score. For `merge-executor`, `security-review`, and `architecture-review`,
+assigning an unproven agent is irreversible if wrong.
+
+The mixed-pool gap makes this worse: a pool of [BOOTSTRAP (0 jobs, score=1.0), BORDERLINE (score=0.0)]
+assigns the BOOTSTRAP agent — the borderline path in `decide()` requires all candidates to score
+0.0 before firing, and BOOTSTRAP's positive workload score prevents that.
+
+`DevtownCapabilityRegistry` already declares a `fallbackType` per capability but `TrustRoutingPolicy`
+carries no corresponding guard field, so enforcement is structurally impossible.
+
+The Qhorus trust gate (`DevtownObligorTrustPolicy`) cannot fix this: it correctly exempts BOOTSTRAP
+agents (no observations → permit), and `ObligorTrustContext` carries no capability tag.
+
+---
+
+## Design
+
+### 1. `TrustRoutingPolicy` — add `bootstrapEscalationRequired`
+
+```java
+public record TrustRoutingPolicy(
+    double threshold,
+    int minimumObservations,
+    double borderlineMargin,
+    double blendFactor,
+    Map<String, Double> qualityFloors,
+    boolean bootstrapEscalationRequired   // NEW
+) {
+    public static final TrustRoutingPolicy DEFAULT =
+        new TrustRoutingPolicy(0.7, 10, 0.1, 0.6, Map.of(), false);
+    // isBootstrap/isBorderline/passesThresholdCheck unchanged
+}
+```
+
+`bootstrapEscalationRequired = true` means: "this capability must never be handled by an agent
+in BOOTSTRAP phase; require human oversight if no QUALIFIED agent is available."
+
+`false` (the default) preserves the current behaviour: BOOTSTRAP candidates compete by workload
+and can be assigned. Most capabilities are unaffected.
+
+Following `trust-maturity-model.md`, this field belongs in code (a domain design decision), not
+YAML config (operational tuning).
+
+### 2. `EscalationReason` — new top-level type
+
+A top-level enum in `api/spi/routing/` (not nested inside `AgentAssignment`), used by both
+`AgentAssignment` and `AgentRoutingEscalationEvent` without coupling the event to the assignment.
+
+```java
+package io.casehub.api.spi.routing;
+
+public enum EscalationReason {
+    /** All candidates scored 0.0 and at least one was BORDERLINE. */
+    BORDERLINE_STALEMATE,
+
+    /** No QUALIFIED agent is available; only BOOTSTRAP-phase agents could be assigned.
+     *  Requires human routing. Pre-screen fires before scoring, so no scoring has occurred. */
+    NO_QUALIFIED_AGENT
+}
+```
+
+`BORDERLINE_STALEMATE` replaces `ALL_BORDERLINE` — the existing condition is "any borderline in
+an all-zero-scored pool," not "all candidates are borderline." The old name was misleading.
+
+`NO_QUALIFIED_AGENT` names the bootstrap condition by what it actually means for the pool: there
+is no trust-qualified agent available for this capability.
+
+### 3. `AgentAssignment` — add reason to `EscalateToOversight`
+
+```java
+record EscalateToOversight(String capabilityName, EscalationReason reason)
+    implements AgentAssignment {}
+
+// Factory (replaces single-arg form — all callers updated):
+static AgentAssignment escalate(String capabilityName, EscalationReason reason) {
+    return new EscalateToOversight(capabilityName, reason);
+}
+```
+
+`capabilityName` remains the actual capability name for both reasons.
+
+`TrustCandidateClassifier.decide()` updated — only change is the reason label:
+```java
+return anyBorderline
+    ? AgentAssignment.escalate(capabilityName, EscalationReason.BORDERLINE_STALEMATE)
+    : AgentAssignment.unresolvable();
+```
+
+No other changes to `TrustCandidateClassifier`. No `applyBootstrapGuard()` method — the
+bootstrap guard is the strategies' responsibility, not the classifier's.
+
+### 4. Bootstrap guard in both strategies — pre-screen + stripping
+
+Both `TrustWeightedAgentStrategy` and `SemanticAgentRoutingStrategy` get identical two-part
+bootstrap logic inserted after `classify()`.
+
+**Part 1 — pre-screen (fires before `emitOn(workerPool)` in semantic strategy):**
+
+```java
+if (policy.bootstrapEscalationRequired()) {
+    boolean hasQualified = classified.stream().anyMatch(c -> c.phase() == Phase.QUALIFIED);
+    boolean hasBootstrap = classified.stream().anyMatch(c -> c.phase() == Phase.BOOTSTRAP);
+    if (!hasQualified && hasBootstrap) {
+        return Uni.createFrom().item(
+            AgentAssignment.escalate(context.capabilityName(), EscalationReason.NO_QUALIFIED_AGENT));
+    }
+}
+```
+
+**Part 2 — strip BOOTSTRAP from scoring (only reached if QUALIFIED exists):**
+
+```java
+final List<ClassifiedCandidate> eligible = policy.bootstrapEscalationRequired()
+    ? classified.stream().filter(c -> c.phase() != Phase.BOOTSTRAP).toList()
+    : classified;
+// use eligible (not classified) in the scoring loop
+```
+
+The stripping approach means:
+- BOOTSTRAP candidates are invisible to scoring when the flag is set
+- QUALIFIED agents compete among themselves — workload comparison is only between QUALIFIED
+- A busy QUALIFIED agent is preferred over an idle BOOTSTRAP agent, which is the intent of the flag
+- `decide()` is called with `eligible` (not `classified`). The `anyBorderline` check inside `decide()` then only inspects candidates that were actually eligible, which is semantically correct — a BOOTSTRAP candidate that was stripped is not contributing to a borderline stalemate.
+
+**In `SemanticAgentRoutingStrategy`:** `eligible` is computed before `emitOn(workerPool)`. The
+lambda captures `eligible` and only pays embedding cost for agents that can actually win. If the
+pre-screen fires, `emitOn()` is never entered.
+
+**Pool coverage (with `bootstrapEscalationRequired = true`):**
+
+| Pool | Pre-screen fires? | Outcome |
+|------|-------------------|---------|
+| [BOOTSTRAP, BOOTSTRAP] | Yes — no QUALIFIED | `NO_QUALIFIED_AGENT` |
+| [BOOTSTRAP, BORDERLINE] | Yes — no QUALIFIED | `NO_QUALIFIED_AGENT` |
+| [BOOTSTRAP, EXCLUDED_*] | Yes — no QUALIFIED | `NO_QUALIFIED_AGENT` |
+| [BOOTSTRAP, QUALIFIED] | No — QUALIFIED exists | Strip BOOTSTRAP; QUALIFIED wins |
+| [BOOTSTRAP, QUALIFIED, BORDERLINE] | No — QUALIFIED exists | Strip BOOTSTRAP; QUALIFIED wins |
+| [BORDERLINE only] | No — no BOOTSTRAP | `BORDERLINE_STALEMATE` (existing path via `decide()`) |
+| [QUALIFIED only] | No — no BOOTSTRAP | Existing behaviour unchanged |
+| Flag = false | Pre-screen skipped | All existing behaviour unchanged |
+
+### 5. `AgentRoutingEscalationEvent` — carry reason
+
+```java
+public record AgentRoutingEscalationEvent(
+    UUID caseId, String capabilityName, String bindingName, EscalationReason reason) {}
+```
+
+Updated Javadoc: describes both escalation conditions (BORDERLINE_STALEMATE and NO_QUALIFIED_AGENT).
+All three construction sites updated.
+
+### 6. `AgentRoutingEscalationHandler` — message per reason + metric log
+
+The `[METRIC:escalation.no-qualified-agent]` log fires unconditionally at the top of `handle()`,
+before the channel lookup. This ensures the metric fires even when no oversight channel is open
+(the scenario where the alert is most critical — bootstrap guard fired AND no channel to route to).
+
+```java
+@ConsumeEvent(value = EventBusAddresses.AGENT_ROUTING_ESCALATION, blocking = true)
+public void handle(final AgentRoutingEscalationEvent event) {
+    // Metric log fires unconditionally — before channel search
+    if (event.reason() == EscalationReason.NO_QUALIFIED_AGENT) {
+        LOG.warnf(
+            "[METRIC:escalation.no-qualified-agent] caseId=%s capability=%s binding=%s"
+                + " — bootstrap guard fired; no trust-qualified agent available.",
+            event.caseId(), event.capabilityName(), event.bindingName());
+    }
+
+    final String oversightName = CaseChannel.oversightChannelName(event.caseId());
+    final List<CaseChannel> channels = channelProvider.listChannels(event.caseId());
+    channels.stream()
+        .filter(c -> oversightName.equals(c.name()))
+        .findFirst()
+        .ifPresentOrElse(
+            channel -> postQuery(channel, event),
+            () -> LOG.warnf("[METRIC:escalation.no-oversight-channel] ..."));
+}
+
+private void postQuery(final CaseChannel channel, final AgentRoutingEscalationEvent event) {
+    final String message = switch (event.reason()) {
+        case BORDERLINE_STALEMATE ->
+            String.format(
+                "All agent candidates for capability '%s' (binding: '%s') are borderline."
+                    + " Human oversight required: please select an agent or approve the next"
+                    + " best available agent.",
+                event.capabilityName(), event.bindingName());
+        case NO_QUALIFIED_AGENT ->
+            String.format(
+                "No trust-qualified agent is available for capability '%s' (binding: '%s')."
+                    + " Routing policy requires an agent with established trust history."
+                    + " Human routing required.",
+                event.capabilityName(), event.bindingName());
+    };
+    channelProvider.postToChannel(channel, "casehub-engine", message, MessageType.QUERY, null, null);
+}
+```
+
+Existing `[METRIC:escalation.no-oversight-channel]` log unchanged.
+
+### 7. Response path (engine#383)
+
+`NO_QUALIFIED_AGENT` and `BORDERLINE_STALEMATE` follow identical response handling: human posts
+via the oversight channel, re-triggering routing. No differentiation by reason is needed in
+the response path. Engine#383 covers both.
+
+---
+
+## Test Plan
+
+### `TrustWeightedAgentStrategyTest` — new cases + updates to existing
+
+New tests:
+- `bootstrap_noQualified_allBootstrap_escalatesNoQualifiedAgent()` — pool all-BOOTSTRAP, flag on → `NO_QUALIFIED_AGENT`
+- `bootstrap_noQualified_bootstrapPlusBorderline_escalatesNoQualifiedAgent()` — pre-screen closes mixed-pool gap
+- `bootstrap_noQualified_bootstrapPlusExcluded_escalatesNoQualifiedAgent()` — same gap, EXCLUDED variant
+- `bootstrap_qualifiedExists_bootstrapStripped_qualifiedAssigned()` — BOOTSTRAP idle, QUALIFIED busy → QUALIFIED wins
+- `bootstrap_qualifiedExists_bootstrapStripped_busyQualifiedWinsOverIdleBootstrap()` — explicit: flag overrides workload comparison
+- `bootstrap_qualifiedExists_bootstrapPlusBorderline_qualifiedWins_noBorderlineStalemate()` — [BOOTSTRAP, QUALIFIED, BORDERLINE] with flag on → BOOTSTRAP stripped, BORDERLINE remains in eligible but QUALIFIED wins; verifies `BORDERLINE_STALEMATE` does not fire when QUALIFIED exists in stripped pool
+- `bootstrap_flagFalse_allBootstrap_assignsByWorkload()` — flag off → existing behaviour preserved
+
+Updates to existing:
+- All `EscalateToOversight` assertions add `.reason() == EscalationReason.BORDERLINE_STALEMATE`
+- All `new TrustRoutingPolicy(...)` constructions add `false` as 6th arg (or named test policy)
+
+### `SemanticAgentRoutingStrategyTest` — same set of new cases
+
+Mirror of the `TrustWeightedAgentStrategyTest` bootstrap cases.
+
+### `TrustCandidateClassifierTest`
+
+- Update existing `EscalateToOversight` assertion to check `reason == BORDERLINE_STALEMATE`
+- All `new TrustRoutingPolicy(...)` constructions updated
+
+### Runtime tests
+
+- `AgentRoutingEscalationHandlerTest` — update event construction to include reason; add two
+  `NO_QUALIFIED_AGENT` sub-cases:
+  - Channel open: metric log fires AND QUERY is posted (message matches `NO_QUALIFIED_AGENT` text)
+  - No channel open: metric log fires AND QUERY is NOT posted (this is the regression test for the metric placement decision — the log must fire even when the channel is absent)
+  - Also add message assertion for `BORDERLINE_STALEMATE`
+- `DefaultWorkOrchestratorTest` — `AgentAssignment.escalate("analyse", EscalationReason.BORDERLINE_STALEMATE)`
+- `CaseContextChangedEventHandlerRoutingTest` — same update
+
+### Devtown side (devtown#62)
+
+Engine-side tests verify the mechanism in isolation. Devtown#62 must include two end-to-end tests:
+- **Escalation path:** `merge-executor` with `bootstrapEscalationRequired = true`, all-BOOTSTRAP pool → `NO_QUALIFIED_AGENT` escalation fires
+- **Stripping path:** `merge-executor` with `bootstrapEscalationRequired = true`, [BOOTSTRAP + QUALIFIED] pool → QUALIFIED wins, no escalation (covers the more common production scenario where a trusted agent exists)
+
+---
+
+## Files Changed
+
+| File | Module | Change |
+|------|--------|--------|
+| `EscalationReason.java` | api | New top-level enum: `BORDERLINE_STALEMATE`, `NO_QUALIFIED_AGENT` |
+| `TrustRoutingPolicy.java` | api | Add `boolean bootstrapEscalationRequired`, update DEFAULT |
+| `AgentAssignment.java` | api | Add reason to `EscalateToOversight`, update factory to 2-arg |
+| `AgentRoutingEscalationEvent.java` | common | Add `EscalationReason reason` field, update Javadoc |
+| `TrustCandidateClassifier.java` | ledger | Update `decide()` escalate call to use `BORDERLINE_STALEMATE` |
+| `TrustWeightedAgentStrategy.java` | ledger | Add pre-screen + BOOTSTRAP stripping |
+| `SemanticAgentRoutingStrategy.java` | engine-ai | Add pre-screen + BOOTSTRAP stripping (before `emitOn`) |
+| `CaseContextChangedEventHandler.java` | runtime | Update `AgentRoutingEscalationEvent` construction (add reason) |
+| `DefaultWorkOrchestrator.java` | runtime | Update `AgentRoutingEscalationEvent` construction (add reason) |
+| `AgentRoutingEscalationHandler.java` | runtime | Switch message per reason, add metric log |
+| Test files (×6) | ledger, engine-ai, runtime | New bootstrap tests + reason assertion updates |

--- a/engine-ai/src/main/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategy.java
+++ b/engine-ai/src/main/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategy.java
@@ -20,6 +20,7 @@ import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.api.spi.routing.TrustRoutingPolicy;
 import io.casehub.api.spi.routing.TrustRoutingPolicyProvider;
 import io.casehub.eidos.api.AgentCapability;
@@ -119,6 +120,24 @@ public class SemanticAgentRoutingStrategy implements AgentRoutingStrategy {
     final List<ClassifiedCandidate> classified =
         classifier.classify(candidates, context.capabilityName(), policy, cache);
 
+    // Bootstrap guard: pre-screen before entering worker pool — avoids embedding cost
+    if (policy.bootstrapEscalationRequired()) {
+      final boolean hasQualified = classified.stream().anyMatch(c -> c.phase() == Phase.QUALIFIED);
+      final boolean hasBootstrap = classified.stream().anyMatch(c -> c.phase() == Phase.BOOTSTRAP);
+      if (!hasQualified && hasBootstrap) {
+        return Uni.createFrom()
+            .item(
+                AgentAssignment.escalate(
+                    context.capabilityName(), EscalationReason.NO_QUALIFIED_AGENT));
+      }
+    }
+
+    // Compute eligible before entering worker pool; lambda captures eligible (not classified)
+    final List<ClassifiedCandidate> eligible =
+        policy.bootstrapEscalationRequired()
+            ? classified.stream().filter(c -> c.phase() != Phase.BOOTSTRAP).toList()
+            : classified;
+
     return Uni.createFrom()
         .voidItem()
         .emitOn(Infrastructure.getDefaultWorkerPool())
@@ -128,12 +147,12 @@ public class SemanticAgentRoutingStrategy implements AgentRoutingStrategy {
                   extractQueryText(context.caseContext(), context.capabilityName());
               final float[] queryVector = embeddingCache.getOrCompute(queryText, embeddingProvider);
 
-              final List<ScoredCandidate> scored = new ArrayList<>(classified.size());
-              for (final ClassifiedCandidate cc : classified) {
+              final List<ScoredCandidate> scored = new ArrayList<>(eligible.size());
+              for (final ClassifiedCandidate cc : eligible) {
                 scored.add(new ScoredCandidate(cc, score(cc, queryVector, policy)));
               }
 
-              return classifier.decide(classified, scored, context.capabilityName());
+              return classifier.decide(eligible, scored, context.capabilityName());
             });
   }
 

--- a/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
+++ b/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
@@ -27,6 +27,7 @@ import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentHealth;
 import io.casehub.api.spi.routing.AgentRoutingContext;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.api.spi.routing.TrustRoutingPolicy;
 import io.casehub.api.spi.routing.TrustRoutingPolicyProvider;
 import io.casehub.eidos.api.AgentCapability;
@@ -54,6 +55,8 @@ class SemanticAgentRoutingStrategyTest {
 
   private static final TrustRoutingPolicy POLICY =
       new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of(), false);
+  private static final TrustRoutingPolicy BOOTSTRAP_GUARD_POLICY =
+      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of(), true);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @BeforeEach
@@ -148,6 +151,8 @@ class SemanticAgentRoutingStrategyTest {
     final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
 
     assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.BORDERLINE_STALEMATE);
   }
 
   @Test
@@ -186,6 +191,160 @@ class SemanticAgentRoutingStrategyTest {
   void emptyCandidates_returnsUnresolvable() {
     assertThat(strategy.select(ctx(), List.of()).await().indefinitely())
         .isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  // ---- Bootstrap guard (bootstrapEscalationRequired = true) -----------------------
+
+  @Test
+  void bootstrap_noQualified_allBootstrap_escalatesNoQualifiedAgent() {
+    // Pre-screen fires BEFORE emitOn(workerPool) — no embedding cost
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    // Both candidates: no trust score → BOOTSTRAP phase
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            new AgentCandidate("agent-1", Set.of("research"), 0, AgentHealth.READY, null),
+            new AgentCandidate("agent-2", Set.of("research"), 1, AgentHealth.READY, null));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.NO_QUALIFIED_AGENT);
+    assertThat(((AgentAssignment.EscalateToOversight) result).capabilityName())
+        .isEqualTo("research");
+  }
+
+  @Test
+  void bootstrap_noQualified_bootstrapPlusBorderline_escalatesNoQualifiedAgent() {
+    // Mixed-pool gap: BOOTSTRAP + BORDERLINE → pre-screen fires, no embedding cost
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-border", "research")).thenReturn(OptionalDouble.of(0.65));
+    when(cache.getDecisionCount("agent-border", "research")).thenReturn(10);
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            candidateWithDescriptor("agent-border", 0, "agent-b"),
+            new AgentCandidate("agent-new", Set.of("research"), 0, AgentHealth.READY, null));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.NO_QUALIFIED_AGENT);
+  }
+
+  @Test
+  void bootstrap_noQualified_bootstrapPlusExcluded_escalatesNoQualifiedAgent() {
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-low", "research")).thenReturn(OptionalDouble.of(0.5));
+    when(cache.getDecisionCount("agent-low", "research")).thenReturn(10);
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            candidateWithDescriptor("agent-low", 0, "agent-l"),
+            new AgentCandidate("agent-new", Set.of("research"), 0, AgentHealth.READY, null));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.NO_QUALIFIED_AGENT);
+  }
+
+  @Test
+  void bootstrap_qualifiedExists_bootstrapStripped_qualifiedAssigned() {
+    // QUALIFIED exists → pre-screen skips, enters worker pool; BOOTSTRAP stripped from eligible
+    // Embedding mocks needed because QUALIFIED candidate triggers semantic scoring
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-qualified", "research"))
+        .thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("agent-qualified", "research")).thenReturn(10);
+    when(jqEvaluator.eval(anyString(), any()))
+        .thenReturn(ValidationResult.ok(List.of(MAPPER.createObjectNode().textNode("research"))));
+    when(embeddingProvider.embed(any()))
+        .thenReturn(new float[] {1.0f, 0.0f}) // query vector
+        .thenReturn(new float[] {0.9f, 0.1f}); // agent-qualified descriptor
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            candidateWithDescriptor("agent-qualified", 2, "agent-q"),
+            new AgentCandidate("agent-new", Set.of("research"), 0, AgentHealth.READY, null));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-qualified");
+  }
+
+  @Test
+  void bootstrap_qualifiedExists_bootstrapStripped_busyQualifiedWinsOverIdleBootstrap() {
+    // Explicit: flag overrides workload comparison. Busy QUALIFIED beats idle BOOTSTRAP.
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-qualified", "research"))
+        .thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("agent-qualified", "research")).thenReturn(10);
+    when(jqEvaluator.eval(anyString(), any()))
+        .thenReturn(ValidationResult.ok(List.of(MAPPER.createObjectNode().textNode("research"))));
+    when(embeddingProvider.embed(any()))
+        .thenReturn(new float[] {1.0f, 0.0f})
+        .thenReturn(new float[] {0.9f, 0.1f});
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            candidateWithDescriptor("agent-qualified", 5, "agent-q"),
+            new AgentCandidate("agent-new", Set.of("research"), 0, AgentHealth.READY, null));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-qualified");
+  }
+
+  @Test
+  void bootstrap_qualifiedExists_bootstrapPlusBorderline_qualifiedWins_noBorderlineStalemate() {
+    // [BOOTSTRAP, QUALIFIED, BORDERLINE]: BOOTSTRAP stripped; eligible=[QUALIFIED, BORDERLINE]
+    // QUALIFIED wins positive score; BORDERLINE_STALEMATE must NOT fire
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-qualified", "research"))
+        .thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("agent-qualified", "research")).thenReturn(10);
+    when(cache.getCapabilityScore("agent-border", "research")).thenReturn(OptionalDouble.of(0.65));
+    when(cache.getDecisionCount("agent-border", "research")).thenReturn(10);
+    when(jqEvaluator.eval(anyString(), any()))
+        .thenReturn(ValidationResult.ok(List.of(MAPPER.createObjectNode().textNode("research"))));
+    when(embeddingProvider.embed(any()))
+        .thenReturn(new float[] {1.0f, 0.0f})
+        .thenReturn(new float[] {0.9f, 0.1f}); // QUALIFIED descriptor only; BORDERLINE scores 0.0
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            candidateWithDescriptor("agent-qualified", 0, "agent-q"),
+            candidateWithDescriptor("agent-border", 0, "agent-b"),
+            new AgentCandidate("agent-new", Set.of("research"), 0, AgentHealth.READY, null));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-qualified");
+  }
+
+  @Test
+  void bootstrap_flagFalse_allBootstrap_assignsByWorkload() {
+    // POLICY has bootstrapEscalationRequired = false; pre-screen skipped; existing behaviour
+    when(jqEvaluator.eval(anyString(), any()))
+        .thenReturn(ValidationResult.ok(List.of(MAPPER.createObjectNode().textNode("research"))));
+    when(embeddingProvider.embed(any())).thenReturn(new float[] {1.0f, 0.0f});
+
+    final List<AgentCandidate> candidates =
+        List.of(
+            new AgentCandidate("agent-busy", Set.of("research"), 5, AgentHealth.READY, null),
+            new AgentCandidate("agent-idle", Set.of("research"), 0, AgentHealth.READY, null));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-idle");
   }
 
   // ---- Helpers ---------------------------------------------------------------

--- a/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
+++ b/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
@@ -330,6 +330,24 @@ class SemanticAgentRoutingStrategyTest {
   }
 
   @Test
+  void bootstrap_allExcluded_noBootstrap_returnsUnresolvable() {
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-low", "research")).thenReturn(OptionalDouble.of(0.5));
+    when(cache.getDecisionCount("agent-low", "research")).thenReturn(10);
+    // EXCLUDED_PHASE2B: scores 0.0 — still enters worker pool, query text gets embedded
+    when(jqEvaluator.eval(anyString(), any()))
+        .thenReturn(ValidationResult.ok(List.of(MAPPER.createObjectNode().textNode("research"))));
+    when(embeddingProvider.embed(any())).thenReturn(new float[] {1.0f, 0.0f});
+
+    final List<AgentCandidate> candidates =
+        List.of(candidateWithDescriptor("agent-low", 0, "agent-l"));
+
+    final AgentAssignment result = strategy.select(ctx(), candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  @Test
   void bootstrap_flagFalse_allBootstrap_assignsByWorkload() {
     // POLICY has bootstrapEscalationRequired = false; pre-screen skipped; existing behaviour
     when(jqEvaluator.eval(anyString(), any()))

--- a/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
+++ b/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
@@ -53,7 +53,7 @@ class SemanticAgentRoutingStrategyTest {
   private SemanticAgentRoutingStrategy strategy;
 
   private static final TrustRoutingPolicy POLICY =
-      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of());
+      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of(), false);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @BeforeEach

--- a/ledger/src/main/java/io/casehub/ledger/routing/TrustCandidateClassifier.java
+++ b/ledger/src/main/java/io/casehub/ledger/routing/TrustCandidateClassifier.java
@@ -17,6 +17,7 @@ package io.casehub.ledger.routing;
 
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.api.spi.routing.TrustRoutingPolicy;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
@@ -173,7 +174,7 @@ public class TrustCandidateClassifier {
     final boolean anyBorderline = classified.stream().anyMatch(c -> c.phase() == Phase.BORDERLINE);
 
     return anyBorderline
-        ? AgentAssignment.escalate(capabilityName)
+        ? AgentAssignment.escalate(capabilityName, EscalationReason.BORDERLINE_STALEMATE)
         : AgentAssignment.unresolvable();
   }
 }

--- a/ledger/src/main/java/io/casehub/ledger/routing/TrustWeightedAgentStrategy.java
+++ b/ledger/src/main/java/io/casehub/ledger/routing/TrustWeightedAgentStrategy.java
@@ -19,6 +19,7 @@ import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.api.spi.routing.TrustRoutingPolicy;
 import io.casehub.api.spi.routing.TrustRoutingPolicyProvider;
 import io.casehub.ledger.routing.TrustCandidateClassifier.ClassifiedCandidate;
@@ -86,12 +87,30 @@ public class TrustWeightedAgentStrategy implements AgentRoutingStrategy {
     final List<ClassifiedCandidate> classified =
         classifier.classify(candidates, context.capabilityName(), policy, cache);
 
-    final List<ScoredCandidate> scored = new ArrayList<>(classified.size());
-    for (final ClassifiedCandidate cc : classified) {
+    // Bootstrap guard: pre-screen before scoring
+    if (policy.bootstrapEscalationRequired()) {
+      final boolean hasQualified = classified.stream().anyMatch(c -> c.phase() == Phase.QUALIFIED);
+      final boolean hasBootstrap = classified.stream().anyMatch(c -> c.phase() == Phase.BOOTSTRAP);
+      if (!hasQualified && hasBootstrap) {
+        return Uni.createFrom()
+            .item(
+                AgentAssignment.escalate(
+                    context.capabilityName(), EscalationReason.NO_QUALIFIED_AGENT));
+      }
+    }
+
+    // Strip BOOTSTRAP from scoring when guard is active (only reached if QUALIFIED exists)
+    final List<ClassifiedCandidate> eligible =
+        policy.bootstrapEscalationRequired()
+            ? classified.stream().filter(c -> c.phase() != Phase.BOOTSTRAP).toList()
+            : classified;
+
+    final List<ScoredCandidate> scored = new ArrayList<>(eligible.size());
+    for (final ClassifiedCandidate cc : eligible) {
       scored.add(new ScoredCandidate(cc, score(cc, policy)));
     }
 
-    return Uni.createFrom().item(classifier.decide(classified, scored, context.capabilityName()));
+    return Uni.createFrom().item(classifier.decide(eligible, scored, context.capabilityName()));
   }
 
   private double score(final ClassifiedCandidate cc, final TrustRoutingPolicy policy) {

--- a/ledger/src/test/java/io/casehub/ledger/routing/TrustCandidateClassifierTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/routing/TrustCandidateClassifierTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentHealth;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.ledger.routing.TrustCandidateClassifier.ClassifiedCandidate;
 import io.casehub.ledger.routing.TrustCandidateClassifier.Phase;
 import io.casehub.ledger.routing.TrustCandidateClassifier.ScoredCandidate;
@@ -173,6 +174,8 @@ class TrustCandidateClassifierTest {
 
     assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
     assertThat(((AgentAssignment.EscalateToOversight) result).capabilityName()).isEqualTo(CAP);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.BORDERLINE_STALEMATE);
   }
 
   @Test
@@ -195,6 +198,8 @@ class TrustCandidateClassifierTest {
     final AgentAssignment result = classifier.decide(List.of(border, excluded), scored, CAP);
 
     assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.BORDERLINE_STALEMATE);
   }
 
   @Test

--- a/ledger/src/test/java/io/casehub/ledger/routing/TrustCandidateClassifierTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/routing/TrustCandidateClassifierTest.java
@@ -40,7 +40,7 @@ class TrustCandidateClassifierTest {
 
   // threshold=0.7, minimumObservations=5, borderlineMargin=0.1
   private static final io.casehub.api.spi.routing.TrustRoutingPolicy POLICY =
-      new io.casehub.api.spi.routing.TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of());
+      new io.casehub.api.spi.routing.TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of(), false);
   private static final String CAP = "research";
 
   @BeforeEach
@@ -109,7 +109,7 @@ class TrustCandidateClassifierTest {
   void classify_qualityFloorFailed_isExcludedPhase3() {
     final io.casehub.api.spi.routing.TrustRoutingPolicy policyWithFloor =
         new io.casehub.api.spi.routing.TrustRoutingPolicy(
-            0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75));
+            0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75), false);
 
     when(cache.getCapabilityScore("a", CAP)).thenReturn(OptionalDouble.of(0.85));
     when(cache.getDecisionCount("a", CAP)).thenReturn(10);
@@ -140,7 +140,7 @@ class TrustCandidateClassifierTest {
   void classify_qualityFloorMissing_isQualified() {
     final io.casehub.api.spi.routing.TrustRoutingPolicy policyWithFloor =
         new io.casehub.api.spi.routing.TrustRoutingPolicy(
-            0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75));
+            0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75), false);
     when(cache.getCapabilityScore("a", CAP)).thenReturn(OptionalDouble.of(0.85));
     when(cache.getDecisionCount("a", CAP)).thenReturn(10);
     // no dimension data → graceful; not penalised

--- a/ledger/src/test/java/io/casehub/ledger/routing/TrustWeightedAgentStrategyTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/routing/TrustWeightedAgentStrategyTest.java
@@ -25,6 +25,7 @@ import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentHealth;
 import io.casehub.api.spi.routing.AgentRoutingContext;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.api.spi.routing.TrustRoutingPolicy;
 import io.casehub.api.spi.routing.TrustRoutingPolicyProvider;
 import java.util.List;
@@ -45,6 +46,9 @@ class TrustWeightedAgentStrategyTest {
   // Default policy: threshold=0.7, minimumObservations=5, borderlineMargin=0.1, blendFactor=0.6
   private static final TrustRoutingPolicy DEFAULT_POLICY =
       new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of(), false);
+
+  private static final TrustRoutingPolicy BOOTSTRAP_GUARD_POLICY =
+      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of(), true);
 
   @BeforeEach
   void setUp() {
@@ -110,6 +114,8 @@ class TrustWeightedAgentStrategyTest {
     assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
     assertThat(((AgentAssignment.EscalateToOversight) result).capabilityName())
         .isEqualTo("research");
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.BORDERLINE_STALEMATE);
   }
 
   @Test
@@ -119,8 +125,10 @@ class TrustWeightedAgentStrategyTest {
         .thenReturn(OptionalDouble.of(0.75));
     when(cache.getDecisionCount("agent-above-border", "research")).thenReturn(10);
 
-    assertThat(select(List.of(candidate("agent-above-border", 0))))
-        .isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    final AgentAssignment result = select(List.of(candidate("agent-above-border", 0)));
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.BORDERLINE_STALEMATE);
   }
 
   @Test
@@ -134,6 +142,8 @@ class TrustWeightedAgentStrategyTest {
         select(List.of(candidate("agent-1", 0), candidate("agent-2", 0)));
 
     assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.BORDERLINE_STALEMATE);
   }
 
   @Test
@@ -144,8 +154,11 @@ class TrustWeightedAgentStrategyTest {
     when(cache.getCapabilityScore("agent-low", "research")).thenReturn(OptionalDouble.of(0.3));
     when(cache.getDecisionCount("agent-low", "research")).thenReturn(10);
 
-    assertThat(select(List.of(candidate("agent-border", 0), candidate("agent-low", 0))))
-        .isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    final AgentAssignment result =
+        select(List.of(candidate("agent-border", 0), candidate("agent-low", 0)));
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.BORDERLINE_STALEMATE);
   }
 
   @Test
@@ -302,6 +315,123 @@ class TrustWeightedAgentStrategyTest {
         List.of(candidate("agent-1", 0), candidate("agent-2", 0));
 
     assertThat(select(candidates)).isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  // ---- Bootstrap guard (bootstrapEscalationRequired = true) -----------------------
+
+  @Test
+  void bootstrap_noQualified_allBootstrap_escalatesNoQualifiedAgent() {
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    // All candidates: no trust score → BOOTSTRAP phase
+
+    final AgentAssignment result =
+        select(List.of(candidate("agent-1", 0), candidate("agent-2", 1)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.NO_QUALIFIED_AGENT);
+    assertThat(((AgentAssignment.EscalateToOversight) result).capabilityName())
+        .isEqualTo("research");
+  }
+
+  @Test
+  void bootstrap_noQualified_bootstrapPlusBorderline_escalatesNoQualifiedAgent() {
+    // Closes mixed-pool gap: without guard, BOOTSTRAP (workload>0) beats BORDERLINE (score=0)
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-border", "research")).thenReturn(OptionalDouble.of(0.65));
+    when(cache.getDecisionCount("agent-border", "research")).thenReturn(10);
+    // agent-new: BOOTSTRAP (no score in cache)
+
+    final AgentAssignment result =
+        select(List.of(candidate("agent-border", 0), candidate("agent-new", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.NO_QUALIFIED_AGENT);
+  }
+
+  @Test
+  void bootstrap_noQualified_bootstrapPlusExcluded_escalatesNoQualifiedAgent() {
+    // EXCLUDED_PHASE2B (score<threshold) + BOOTSTRAP: BOOTSTRAP would win by workload without guard
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-low", "research")).thenReturn(OptionalDouble.of(0.5));
+    when(cache.getDecisionCount("agent-low", "research")).thenReturn(10);
+    // agent-new: BOOTSTRAP
+
+    final AgentAssignment result =
+        select(List.of(candidate("agent-low", 0), candidate("agent-new", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.EscalateToOversight.class);
+    assertThat(((AgentAssignment.EscalateToOversight) result).reason())
+        .isEqualTo(EscalationReason.NO_QUALIFIED_AGENT);
+  }
+
+  @Test
+  void bootstrap_qualifiedExists_bootstrapStripped_qualifiedAssigned() {
+    // QUALIFIED exists → pre-screen skips; BOOTSTRAP stripped from scoring pool
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-qualified", "research"))
+        .thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("agent-qualified", "research")).thenReturn(10);
+    // agent-new: BOOTSTRAP, 0 jobs (would outscore QUALIFIED by workload without stripping)
+
+    final AgentAssignment result =
+        select(List.of(candidate("agent-qualified", 2), candidate("agent-new", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-qualified");
+  }
+
+  @Test
+  void bootstrap_qualifiedExists_bootstrapStripped_busyQualifiedWinsOverIdleBootstrap() {
+    // Explicit: flag overrides workload comparison. Busy QUALIFIED beats idle BOOTSTRAP.
+    // Without flag: BOOTSTRAP workload=1.0 > QUALIFIED blended~0.55 (5 jobs) → BOOTSTRAP wins.
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-qualified", "research"))
+        .thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("agent-qualified", "research")).thenReturn(10);
+
+    final AgentAssignment result =
+        select(List.of(candidate("agent-qualified", 5), candidate("agent-new", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-qualified");
+  }
+
+  @Test
+  void bootstrap_qualifiedExists_bootstrapPlusBorderline_qualifiedWins_noBorderlineStalemate() {
+    // [BOOTSTRAP, QUALIFIED, BORDERLINE] with flag:
+    // BOOTSTRAP stripped → eligible=[QUALIFIED, BORDERLINE]
+    // QUALIFIED wins positive score; BORDERLINE_STALEMATE must NOT fire
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-qualified", "research"))
+        .thenReturn(OptionalDouble.of(0.85));
+    when(cache.getDecisionCount("agent-qualified", "research")).thenReturn(10);
+    when(cache.getCapabilityScore("agent-border", "research")).thenReturn(OptionalDouble.of(0.65));
+    when(cache.getDecisionCount("agent-border", "research")).thenReturn(10);
+    // agent-new: BOOTSTRAP
+
+    final AgentAssignment result =
+        select(
+            List.of(
+                candidate("agent-qualified", 0),
+                candidate("agent-border", 0),
+                candidate("agent-new", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-qualified");
+  }
+
+  @Test
+  void bootstrap_flagFalse_allBootstrap_assignsByWorkload() {
+    // bootstrapEscalationRequired = false: pre-screen skipped; existing behaviour preserved
+    when(policyProvider.forCapability("research")).thenReturn(DEFAULT_POLICY);
+
+    final AgentAssignment result =
+        select(List.of(candidate("agent-busy", 5), candidate("agent-idle", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.Assigned.class);
+    assertThat(((AgentAssignment.Assigned) result).workerId()).isEqualTo("agent-idle");
   }
 
   // ---- Helpers ------------------------------------------------------------

--- a/ledger/src/test/java/io/casehub/ledger/routing/TrustWeightedAgentStrategyTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/routing/TrustWeightedAgentStrategyTest.java
@@ -44,7 +44,7 @@ class TrustWeightedAgentStrategyTest {
 
   // Default policy: threshold=0.7, minimumObservations=5, borderlineMargin=0.1, blendFactor=0.6
   private static final TrustRoutingPolicy DEFAULT_POLICY =
-      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of());
+      new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of(), false);
 
   @BeforeEach
   void setUp() {
@@ -192,7 +192,7 @@ class TrustWeightedAgentStrategyTest {
   @Test
   void phase3_qualityFloorMet_candidateSelected() {
     final TrustRoutingPolicy policyWithFloor =
-        new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75));
+        new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75), false);
     when(policyProvider.forCapability("research")).thenReturn(policyWithFloor);
 
     when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.85));
@@ -209,7 +209,7 @@ class TrustWeightedAgentStrategyTest {
   @Test
   void phase3_qualityFloorFailed_returnsUnresolvable() {
     final TrustRoutingPolicy policyWithFloor =
-        new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75));
+        new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75), false);
     when(policyProvider.forCapability("research")).thenReturn(policyWithFloor);
 
     when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.85));
@@ -224,7 +224,7 @@ class TrustWeightedAgentStrategyTest {
   @Test
   void phase3_noDimensionData_candidateNotPenalised() {
     final TrustRoutingPolicy policyWithFloor =
-        new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75));
+        new TrustRoutingPolicy(0.7, 5, 0.1, 0.6, Map.of("thoroughness", 0.75), false);
     when(policyProvider.forCapability("research")).thenReturn(policyWithFloor);
 
     when(cache.getCapabilityScore("agent-1", "research")).thenReturn(OptionalDouble.of(0.85));
@@ -258,7 +258,7 @@ class TrustWeightedAgentStrategyTest {
 
   @Test
   void blendScoring_purelyTrustBased_whenBlendFactorIsOne() {
-    final TrustRoutingPolicy pureTrust = new TrustRoutingPolicy(0.7, 5, 0.1, 1.0, Map.of());
+    final TrustRoutingPolicy pureTrust = new TrustRoutingPolicy(0.7, 5, 0.1, 1.0, Map.of(), false);
     when(policyProvider.forCapability("research")).thenReturn(pureTrust);
 
     when(cache.getCapabilityScore("agent-a", "research")).thenReturn(OptionalDouble.of(0.90));
@@ -274,7 +274,8 @@ class TrustWeightedAgentStrategyTest {
 
   @Test
   void blendScoring_purelyWorkloadBased_whenBlendFactorIsZero() {
-    final TrustRoutingPolicy pureWorkload = new TrustRoutingPolicy(0.7, 5, 0.1, 0.0, Map.of());
+    final TrustRoutingPolicy pureWorkload =
+        new TrustRoutingPolicy(0.7, 5, 0.1, 0.0, Map.of(), false);
     when(policyProvider.forCapability("research")).thenReturn(pureWorkload);
 
     when(cache.getCapabilityScore("agent-a", "research")).thenReturn(OptionalDouble.of(0.95));

--- a/ledger/src/test/java/io/casehub/ledger/routing/TrustWeightedAgentStrategyTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/routing/TrustWeightedAgentStrategyTest.java
@@ -423,6 +423,21 @@ class TrustWeightedAgentStrategyTest {
   }
 
   @Test
+  void bootstrap_allExcluded_noBootstrap_returnsUnresolvable() {
+    // Guard requires hasBootstrap=true; all-EXCLUDED pool has no BOOTSTRAP → guard must not fire
+    when(policyProvider.forCapability("research")).thenReturn(BOOTSTRAP_GUARD_POLICY);
+    when(cache.getCapabilityScore("agent-low", "research")).thenReturn(OptionalDouble.of(0.5));
+    when(cache.getDecisionCount("agent-low", "research")).thenReturn(10);
+    when(cache.getCapabilityScore("agent-lower", "research")).thenReturn(OptionalDouble.of(0.3));
+    when(cache.getDecisionCount("agent-lower", "research")).thenReturn(10);
+
+    final AgentAssignment result =
+        select(List.of(candidate("agent-low", 0), candidate("agent-lower", 0)));
+
+    assertThat(result).isInstanceOf(AgentAssignment.Unresolvable.class);
+  }
+
+  @Test
   void bootstrap_flagFalse_allBootstrap_assignsByWorkload() {
     // bootstrapEscalationRequired = false: pre-screen skipped; existing behaviour preserved
     when(policyProvider.forCapability("research")).thenReturn(DEFAULT_POLICY);

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandler.java
@@ -17,6 +17,7 @@ package io.casehub.engine.internal.engine.handler;
 
 import io.casehub.api.model.CaseChannel;
 import io.casehub.api.spi.CaseChannelProvider;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
 import io.casehub.qhorus.api.message.MessageType;
@@ -52,6 +53,15 @@ public class AgentRoutingEscalationHandler {
 
   @ConsumeEvent(value = EventBusAddresses.AGENT_ROUTING_ESCALATION, blocking = true)
   public void handle(final AgentRoutingEscalationEvent event) {
+    // Metric log fires unconditionally — before channel search
+    // Fires even when no oversight channel is open (that scenario is the most critical to alert on)
+    if (event.reason() == EscalationReason.NO_QUALIFIED_AGENT) {
+      LOG.warnf(
+          "[METRIC:escalation.no-qualified-agent] caseId=%s capability=%s binding=%s"
+              + " — bootstrap guard fired; no trust-qualified agent available.",
+          event.caseId(), event.capabilityName(), event.bindingName());
+    }
+
     final String oversightName = CaseChannel.oversightChannelName(event.caseId());
     final List<CaseChannel> channels = channelProvider.listChannels(event.caseId());
 
@@ -70,18 +80,27 @@ public class AgentRoutingEscalationHandler {
 
   private void postQuery(final CaseChannel channel, final AgentRoutingEscalationEvent event) {
     final String message =
-        String.format(
-            "All agent candidates for capability '%s' (binding: '%s') are borderline."
-                + " Human oversight required: please select an agent or approve the next"
-                + " best available agent.",
-            event.capabilityName(), event.bindingName());
+        switch (event.reason()) {
+          case BORDERLINE_STALEMATE ->
+              String.format(
+                  "All agent candidates for capability '%s' (binding: '%s') are borderline."
+                      + " Human oversight required: please select an agent or approve the next"
+                      + " best available agent.",
+                  event.capabilityName(), event.bindingName());
+          case NO_QUALIFIED_AGENT ->
+              String.format(
+                  "No trust-qualified agent is available for capability '%s' (binding: '%s')."
+                      + " Routing policy requires an agent with established trust history."
+                      + " Human routing required.",
+                  event.capabilityName(), event.bindingName());
+        };
 
     channelProvider.postToChannel(
         channel, "casehub-engine", message, MessageType.QUERY, null, null);
 
     LOG.infof(
         "Agent routing escalation: QUERY posted to oversight channel '%s' for"
-            + " caseId=%s capability=%s",
-        channel.name(), event.caseId(), event.capabilityName());
+            + " caseId=%s capability=%s reason=%s",
+        channel.name(), event.caseId(), event.capabilityName(), event.reason());
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -337,7 +337,10 @@ public class CaseContextChangedEventHandler {
     eventBus.publish(
         EventBusAddresses.AGENT_ROUTING_ESCALATION,
         new AgentRoutingEscalationEvent(
-            caseInstance.getUuid(), escalation.capabilityName(), binding.getName()));
+            caseInstance.getUuid(),
+            escalation.capabilityName(),
+            binding.getName(),
+            escalation.reason()));
 
     return Uni.createFrom().voidItem();
   }

--- a/runtime/src/main/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestrator.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestrator.java
@@ -162,7 +162,7 @@ public class DefaultWorkOrchestrator implements WorkOrchestrator {
         eventBus.publish(
             EventBusAddresses.AGENT_ROUTING_ESCALATION,
             new AgentRoutingEscalationEvent(
-                instance.getUuid(), e.capabilityName(), "(direct-orchestration)"));
+                instance.getUuid(), e.capabilityName(), "(direct-orchestration)", e.reason()));
         final CompletableFuture<WorkResult> failed = new CompletableFuture<>();
         failed.completeExceptionally(
             new IllegalStateException(

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandlerTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandlerTest.java
@@ -16,6 +16,7 @@
 package io.casehub.engine.internal.engine.handler;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -85,6 +86,41 @@ class AgentRoutingEscalationHandlerTest {
     handler.handle(
         new AgentRoutingEscalationEvent(
             caseId, "research", "research-binding", EscalationReason.BORDERLINE_STALEMATE));
+
+    verify(channelProvider, never()).postToChannel(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void noQualifiedAgent_channelFound_postsQueryWithNoQualifiedMessage() {
+    final UUID caseId = UUID.randomUUID();
+    final String oversightName = CaseChannel.oversightChannelName(caseId);
+    final CaseChannel oversight = channel(oversightName);
+    when(channelProvider.listChannels(caseId)).thenReturn(List.of(oversight));
+
+    handler.handle(
+        new AgentRoutingEscalationEvent(
+            caseId, "merge-executor", "merge-binding", EscalationReason.NO_QUALIFIED_AGENT));
+
+    verify(channelProvider)
+        .postToChannel(
+            eq(oversight),
+            eq("casehub-engine"),
+            contains("No trust-qualified agent"),
+            eq(MessageType.QUERY),
+            eq(null),
+            eq(null));
+  }
+
+  @Test
+  void noQualifiedAgent_noChannel_doesNotPostQueryButHandlesGracefully() {
+    // Regression test: metric log fires unconditionally before channel search.
+    // Even with no channel, handle() completes without error and posts nothing.
+    final UUID caseId = UUID.randomUUID();
+    when(channelProvider.listChannels(caseId)).thenReturn(List.of());
+
+    handler.handle(
+        new AgentRoutingEscalationEvent(
+            caseId, "merge-executor", "merge-binding", EscalationReason.NO_QUALIFIED_AGENT));
 
     verify(channelProvider, never()).postToChannel(any(), any(), any(), any(), any(), any());
   }

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandlerTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandlerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.casehub.api.model.CaseChannel;
 import io.casehub.api.spi.CaseChannelProvider;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
 import io.casehub.qhorus.api.message.MessageType;
 import java.util.List;
@@ -49,7 +50,9 @@ class AgentRoutingEscalationHandlerTest {
     final CaseChannel channel = channel(oversightName);
     when(channelProvider.listChannels(caseId)).thenReturn(List.of(channel));
 
-    handler.handle(new AgentRoutingEscalationEvent(caseId, "research", "research-binding"));
+    handler.handle(
+        new AgentRoutingEscalationEvent(
+            caseId, "research", "research-binding", EscalationReason.BORDERLINE_STALEMATE));
 
     verify(channelProvider)
         .postToChannel(
@@ -67,7 +70,9 @@ class AgentRoutingEscalationHandlerTest {
     final CaseChannel unrelatedChannel = channel(CaseChannel.channelName(caseId, "work"));
     when(channelProvider.listChannels(caseId)).thenReturn(List.of(unrelatedChannel));
 
-    handler.handle(new AgentRoutingEscalationEvent(caseId, "research", "research-binding"));
+    handler.handle(
+        new AgentRoutingEscalationEvent(
+            caseId, "research", "research-binding", EscalationReason.BORDERLINE_STALEMATE));
 
     verify(channelProvider, never()).postToChannel(any(), any(), any(), any(), any(), any());
   }
@@ -77,7 +82,9 @@ class AgentRoutingEscalationHandlerTest {
     final UUID caseId = UUID.randomUUID();
     when(channelProvider.listChannels(caseId)).thenReturn(List.of());
 
-    handler.handle(new AgentRoutingEscalationEvent(caseId, "research", "research-binding"));
+    handler.handle(
+        new AgentRoutingEscalationEvent(
+            caseId, "research", "research-binding", EscalationReason.BORDERLINE_STALEMATE));
 
     verify(channelProvider, never()).postToChannel(any(), any(), any(), any(), any(), any());
   }

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandlerTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/AgentRoutingEscalationHandlerTest.java
@@ -59,7 +59,7 @@ class AgentRoutingEscalationHandlerTest {
         .postToChannel(
             eq(channel),
             eq("casehub-engine"),
-            any(String.class),
+            contains("borderline"),
             eq(MessageType.QUERY),
             eq(null),
             eq(null));

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
@@ -37,6 +37,7 @@ import io.casehub.api.spi.ReactiveWorkerContextProvider;
 import io.casehub.api.spi.ReactiveWorkerProvisioner;
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.eidos.api.CapabilityHealth;
 import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
 import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
@@ -184,7 +185,9 @@ class CaseContextChangedEventHandlerRoutingTest {
   @Test
   void routing_escalateToOversight_publishesEscalationEvent() {
     when(agentRoutingStrategy.select(any(), any()))
-        .thenReturn(Uni.createFrom().item(AgentAssignment.escalate("research")));
+        .thenReturn(
+            Uni.createFrom()
+                .item(AgentAssignment.escalate("research", EscalationReason.BORDERLINE_STALEMATE)));
 
     handler
         .onCaseStateContextChangedEventHandler(

--- a/runtime/src/test/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestratorTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestratorTest.java
@@ -32,6 +32,7 @@ import io.casehub.api.model.Worker;
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
+import io.casehub.api.spi.routing.EscalationReason;
 import io.casehub.eidos.api.AgentDescriptor;
 import io.casehub.eidos.api.CapabilityHealth;
 import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
@@ -161,7 +162,9 @@ class DefaultWorkOrchestratorTest {
   void submit_strategyReturnsEscalate_failsFutureAndPublishesEscalation() {
     final CaseInstance instance = runningInstance("analyse");
     when(agentRoutingStrategy.select(any(), any()))
-        .thenReturn(Uni.createFrom().item(AgentAssignment.escalate("analyse")));
+        .thenReturn(
+            Uni.createFrom()
+                .item(AgentAssignment.escalate("analyse", EscalationReason.BORDERLINE_STALEMATE)));
 
     final var future =
         orchestrator.submit(instance, WorkRequest.of("analyse", Map.of())).toCompletableFuture();


### PR DESCRIPTION
## Summary

- Adds `boolean bootstrapEscalationRequired` to `TrustRoutingPolicy` — when true, BOOTSTRAP-phase agents are never assigned to the capability
- Introduces `EscalationReason` top-level enum (`BORDERLINE_STALEMATE`, `NO_QUALIFIED_AGENT`) carried by `AgentAssignment.EscalateToOversight` and `AgentRoutingEscalationEvent`
- Closes the **mixed-pool gap**: a `[BOOTSTRAP, BORDERLINE]` pool previously assigned the BOOTSTRAP agent (workload > 0 beats borderline's 0.0); the guard now escalates instead
- Both routing strategies (`TrustWeightedAgentStrategy`, `SemanticAgentRoutingStrategy`) get identical two-part guard: pre-screen fires before scoring (before `emitOn(workerPool)` in the semantic strategy), then BOOTSTRAP candidates are stripped from the eligible scoring pool
- `[METRIC:escalation.no-qualified-agent]` structured log fires unconditionally before the channel lookup — fires even when no oversight channel is open
- Handler message text is accurate per reason; `BORDERLINE_STALEMATE` retains existing text

## Design

The guard uses a pre-screen + stripping approach:

1. **Pre-screen** (before scoring): if `bootstrapEscalationRequired && !hasQualified && hasBootstrap` → `EscalateToOversight(capabilityName, NO_QUALIFIED_AGENT)` immediately
2. **Stripping**: if QUALIFIED exists, `eligible = classified without BOOTSTRAP` — busy QUALIFIED beats idle BOOTSTRAP

Pool coverage with `bootstrapEscalationRequired = true`:

| Pool | Outcome |
|------|---------|
| All-BOOTSTRAP | `NO_QUALIFIED_AGENT` |
| BOOTSTRAP + BORDERLINE | `NO_QUALIFIED_AGENT` (mixed-pool gap closed) |
| BOOTSTRAP + EXCLUDED | `NO_QUALIFIED_AGENT` |
| BOOTSTRAP + QUALIFIED | Strip BOOTSTRAP; QUALIFIED wins |
| BORDERLINE only | `BORDERLINE_STALEMATE` (existing path) |
| Flag = false | All existing behaviour unchanged |

## Test plan

- 7 new bootstrap guard tests in `TrustWeightedAgentStrategyTest` (all pools covered including mixed-pool gap)
- 7 mirror tests in `SemanticAgentRoutingStrategyTest`
- 2 `NO_QUALIFIED_AGENT` handler sub-cases: channel open (QUERY posted) and no channel (metric fires, no QUERY)
- `BORDERLINE_STALEMATE` reason asserted in all existing escalation tests
- All 83 changed-class tests pass; 651 total ledger+ai+runtime unit tests green

## Devtown follow-up

`DevtownTrustRoutingPolicyProvider.forCapability()` should pass `bootstrapEscalationRequired = true` for `merge-executor`, `security-review`, and `architecture-review`. Tracked in devtown#62.

Closes #415