### PR TITLE
feat: ActionRiskClassifier SPI — platform-level oversight gate for consequential worker actions (engine#402)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,11 +208,61 @@ To add a new operational SPI: define the interface in `api/spi/`, add a `@Defaul
 
 **To test SPI wiring:** use `@Alternative @Priority(1) @ApplicationScoped` static inner classes in `@QuarkusTest` with `static` recording fields reset in `@BeforeEach`. This activates the recording bean globally across the test suite without Mockito. See `SpiWiringIntegrationTest` for the pattern. To test provisioner wiring, define a `CaseHub` subclass with a capability binding and no workers — the engine will fall through to `tryProvision()`.
 
+## ActionRiskClassifier SPI
+
+Platform-level oversight gate for consequential worker actions. Workers declare what they are about to do; the engine classifies the risk before applying output and advancing the case. Implemented in engine#402.
+
+**Worker return type — `WorkerResult` (breaking change):** All worker functions now return `WorkerResult` instead of `Map<String, Object>`. `Agent.execute()` also returns `WorkerResult`.
+```java
+// No consequential action — unchanged behaviour
+.function(input -> WorkerResult.of(Map.of("result", "done")))
+
+// Declares a consequential action
+.function(input -> WorkerResult.of(
+    Map.of("output", "value"),
+    PlannedAction.of("File SAR report", "sar.file", Map.of("accountId", "ACC-123"))))
+```
+
+**SPI interfaces** in `api/src/main/java/io/casehub/api/spi/`:
+- `ActionRiskClassifier` — blocking; consumer implementations use this
+- `ReactiveActionRiskClassifier` — primary (called by engine); `ChainedReactiveActionRiskClassifier` bridges blocking → reactive
+- `RiskDecision` — sealed: `Autonomous` | `GateRequired(reason, reversible, candidateGroups, expiresIn, scope)`
+- `PlannedAction` — what the worker declares; enriched by engine with `workerId` and `caseId` before classify()
+- `@RiskClassifier` — CDI qualifier; consumer implementations must use this to avoid CDI conflict with the chain
+
+**Composition pattern:** Multiple consumer classifiers are supported via `@RiskClassifier @ApplicationScoped`:
+```java
+@RiskClassifier @ApplicationScoped
+public class AmlActionRiskClassifier implements ActionRiskClassifier {
+    @Override public RiskDecision classify(PlannedAction action) { ... }
+}
+```
+`ChainedReactiveActionRiskClassifier` (`@ApplicationScoped`, NOT `@DefaultBean`) discovers all `@RiskClassifier` beans and applies "most restrictive wins" (fewest candidateGroups beats more; GateRequired beats Autonomous). Classifier failure → fail-safe `GateRequired`. Blocking classifiers offloaded to worker pool via `runSubscriptionOn(workerPool)`.
+
+**Gate mechanism:** When `GateRequired` fires:
+1. `WorkflowExecutionCompletedHandler` stores `PendingActionGate` in-memory on `CaseInstance` (**not persisted by JPA in v1 — restart loses the gate**; tracked as engine#433)
+2. Publishes `ActionGateScheduleEvent` → `ActionGateWorkItemHandler` (work-adapter) creates a WorkItem
+3. Human approves/rejects via work inbox
+4. `ActionGateCompletionApplier` (work-adapter) publishes `ActionGateApprovedEvent` or `ActionGateRejectedEvent`
+5. `ActionGateApprovedHandler` (runtime) re-fires `WorkflowExecutionCompleted(plannedAction=null)` — normal completion path applies deferred output
+6. `ActionGateRejectedHandler`/`ActionGateExpiredHandler` write context signals (`actionGateRejected`, `actionGateExpired`), fire `CONTEXT_CHANGED`, publish `ACTION_GATE_WORKER_FAULTED` for blackboard PlanItem fault
+
+**Binding guard requirement:** Case definitions with consequential workers MUST include rejection handler bindings. The binding trigger condition must also exclude gate signal paths to prevent re-scheduling while a gate is pending:
+```java
+.on(new ContextChangeTrigger(".result == null and .actionGateRejected == null and .actionGateApproved == null"))
+```
+
+**Startup warning:** `ActionGateDeploymentHealthCheck` warns if `@RiskClassifier` classifiers are registered but `casehub-engine-work-adapter` is absent (gate WorkItem would never be created).
+
+**New event bus addresses** (in `EventBusAddresses`): `ACTION_GATE_SCHEDULE`, `ACTION_GATE_APPROVED`, `ACTION_GATE_REJECTED`, `ACTION_GATE_EXPIRED`, `ACTION_GATE_CANCELLED`, `ACTION_GATE_WORKER_FAULTED` (distinct from `WORKER_RETRIES_EXHAUSTED` — gate faults must not fault the CaseInstance).
+
+See design spec: `docs/specs/2026-06-05-action-risk-classifier-design.md`. Consumer exploration issues: life#20, devtown#56, aml#42, clinical#47, openclaw#6.
+
 ## Agent Worker AI Model
 
 AI agent workers live in `api/src/main/java/io/casehub/api/model/ai/`:
 
-- `Agent` — immutable execution unit; holds systemPrompt, transformers, ChatModel, optional responseSchema
+- `Agent` — immutable execution unit; holds systemPrompt, transformers, ChatModel, optional responseSchema. **`execute()` returns `WorkerResult`** (not `Map<String,Object>`) — engine#402 breaking change. Agent workers that want to declare a consequential action return `WorkerResult.of(output, PlannedAction.of(...))`.
 - `AgentBuilder` — fluent builder; JQ string mode (`inputSchema(String)`) or lambda mode (`inputTransformer(UnaryOperator<JsonNode>)`) for transformers; mutually exclusive per direction
 - `ChatModelProvider` — SPI interface; implementations use reflection (`Class.forName`) to avoid compile-time LLM SDK dependencies
 - `ModelType` — enum: OPENAI, OLLAMA, ANTHROPIC, MISTRAL, GOOGLE_AI_GEMINI

--- a/api/src/main/java/io/casehub/api/model/Worker.java
+++ b/api/src/main/java/io/casehub/api/model/Worker.java
@@ -138,7 +138,7 @@ public class Worker implements PlanElement {
       return this;
     }
 
-    public Builder function(Function<Map<String, Object>, Map<String, Object>> function) {
+    public Builder function(Function<Map<String, Object>, WorkerResult> function) {
       this.functionHolder = new WorkerFunctionHolder<>(function);
       return this;
     }

--- a/api/src/main/java/io/casehub/api/model/WorkerResult.java
+++ b/api/src/main/java/io/casehub/api/model/WorkerResult.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+import io.casehub.api.spi.PlannedAction;
+import java.util.Map;
+
+/**
+ * The return type for all worker functions.
+ *
+ * <p>Replaces {@code Map<String, Object>} as the function/agent return type. Workers without
+ * consequential actions use {@link #of(Map)} — behaviour is unchanged. Workers proposing a
+ * consequential action include a {@link PlannedAction} via {@link #of(Map, PlannedAction)}.
+ *
+ * <p>{@link PlannedAction} is optional. If present, the engine calls {@link
+ * io.casehub.api.spi.ReactiveActionRiskClassifier#classify(PlannedAction)} before applying output
+ * to the case context. {@code WorkerResult} is unpacked at the {@code QuartzWorkerExecutionJob}
+ * boundary; it does not propagate as a type beyond the job.
+ */
+public record WorkerResult(Map<String, Object> output, PlannedAction plannedAction) {
+
+  public static WorkerResult of(final Map<String, Object> output) {
+    return new WorkerResult(output, null);
+  }
+
+  public static WorkerResult of(final Map<String, Object> output, final PlannedAction action) {
+    return new WorkerResult(output, action);
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/ai/Agent.java
+++ b/api/src/main/java/io/casehub/api/model/ai/Agent.java
@@ -27,6 +27,7 @@ import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.input.PromptTemplate;
+import io.casehub.api.model.WorkerResult;
 import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -62,7 +63,15 @@ public final class Agent {
     return new AgentBuilder();
   }
 
-  public Map<String, Object> execute(Map<String, Object> input) {
+  /**
+   * Executes this agent with the given input and returns a {@link WorkerResult}.
+   *
+   * <p>The output map is the LLM response after applying the output transformer. Workers that
+   * declare a consequential action should use {@link WorkerResult#of(Map,
+   * io.casehub.api.spi.PlannedAction)} — agents that don't declare actions use {@link
+   * WorkerResult#of(Map)}.
+   */
+  public WorkerResult execute(Map<String, Object> input) {
     JsonNode inputNode = MAPPER.convertValue(input, JsonNode.class);
     JsonNode transformed = inputTransformer.apply(inputNode);
 
@@ -98,7 +107,7 @@ public final class Agent {
       throw new AgentException("LLM returned invalid JSON: " + responseText, e);
     }
 
-    return MAPPER.convertValue(outputTransformer.apply(responseJson), MAP_TYPE);
+    return WorkerResult.of(MAPPER.convertValue(outputTransformer.apply(responseJson), MAP_TYPE));
   }
 
   private ResponseFormat buildResponseFormat() {

--- a/api/src/main/java/io/casehub/api/model/event/CaseHubEventType.java
+++ b/api/src/main/java/io/casehub/api/model/event/CaseHubEventType.java
@@ -49,6 +49,12 @@ public enum CaseHubEventType {
 
   WORKFLOW_STEP_DISPATCHED, // workflow step dispatched a casehub capability via WorkOrchestrator
   WORKFLOW_STEP_COMPLETED, // workflow step dispatch completed successfully
-  WORKFLOW_STEP_FAILED // workflow step dispatch failed (capability not found, routing error,
+  WORKFLOW_STEP_FAILED, // workflow step dispatch failed (capability not found, routing error,
   // exhaustion)
+
+  ACTION_GATE_PENDING, // worker declared a PlannedAction; gate pending human approval
+  ACTION_GATE_APPROVED, // human approved the gate; deferred worker output applied
+  ACTION_GATE_REJECTED, // human rejected the gate; worker treated as faulted
+  ACTION_GATE_EXPIRED, // gate WorkItem expired before approval; worker treated as faulted
+  ACTION_GATE_CANCELLED, // gate cancelled because the case reached a terminal state
 }

--- a/api/src/main/java/io/casehub/api/spi/ActionRiskClassifier.java
+++ b/api/src/main/java/io/casehub/api/spi/ActionRiskClassifier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+/**
+ * Classifies a worker's planned action to determine whether it may proceed autonomously or must be
+ * gated for human approval.
+ *
+ * <p>Implementations must be annotated {@link RiskClassifier} and {@code @ApplicationScoped}. The
+ * engine chains all registered implementations — the most restrictive result wins. Multiple
+ * consumer repos can provide classifiers simultaneously without conflict.
+ *
+ * <p>The engine calls this interface via {@link ReactiveActionRiskClassifier} (the reactive
+ * primary). Blocking implementations are bridged to reactive automatically by {@code
+ * ChainedReactiveActionRiskClassifier}, which offloads them to the worker thread pool.
+ *
+ * <p>If {@code classify} throws, the engine applies a fail-safe {@link RiskDecision.GateRequired}
+ * requiring manual review. Do not throw to bypass the gate — the fail-safe will catch it.
+ *
+ * <p>The {@link PlannedAction} passed to {@code classify} is always fully enriched: {@code
+ * workerId} and {@code caseId} are non-null.
+ */
+public interface ActionRiskClassifier {
+
+  RiskDecision classify(PlannedAction action);
+}

--- a/api/src/main/java/io/casehub/api/spi/PlannedAction.java
+++ b/api/src/main/java/io/casehub/api/spi/PlannedAction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A consequential action a worker intends to take before the engine advances the case.
+ *
+ * <p>Workers create instances via {@link #of(String, String, Map)} and include them in {@link
+ * io.casehub.api.model.WorkerResult}. The engine enriches the instance with {@code workerId} and
+ * {@code caseId} via {@link #withIdentity(String, UUID)} before passing it to {@link
+ * ActionRiskClassifier#classify(PlannedAction)}.
+ *
+ * <p>Classifiers always receive a fully populated instance — {@code workerId} and {@code caseId}
+ * are non-null at classify time.
+ */
+public record PlannedAction(
+    String workerId,
+    UUID caseId,
+    String description,
+    String actionType,
+    Map<String, Object> context) {
+
+  /** Worker-facing factory — workerId and caseId populated by engine before classify(). */
+  public static PlannedAction of(
+      final String description, final String actionType, final Map<String, Object> context) {
+    return new PlannedAction(null, null, description, actionType, context);
+  }
+
+  /** Engine enrichment — called just before passing to the classifier. */
+  public PlannedAction withIdentity(final String workerId, final UUID caseId) {
+    return new PlannedAction(workerId, caseId, description, actionType, context);
+  }
+}

--- a/api/src/main/java/io/casehub/api/spi/ReactiveActionRiskClassifier.java
+++ b/api/src/main/java/io/casehub/api/spi/ReactiveActionRiskClassifier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Reactive variant of {@link ActionRiskClassifier} — the primary interface called by the engine.
+ *
+ * <p>The engine's {@code WorkflowExecutionCompletedHandler} injects and calls this interface. The
+ * engine ships {@code ChainedReactiveActionRiskClassifier} as the sole non-default implementation;
+ * it discovers all {@link RiskClassifier}-qualified {@link ActionRiskClassifier} beans and chains
+ * them.
+ *
+ * <p>Consumer implementations should implement the blocking {@link ActionRiskClassifier} with the
+ * {@link RiskClassifier} qualifier rather than this interface directly. The chain bridges blocking
+ * classifiers to reactive and offloads them to the worker thread pool to avoid blocking the Vert.x
+ * IO thread.
+ */
+public interface ReactiveActionRiskClassifier {
+
+  Uni<RiskDecision> classify(PlannedAction action);
+}

--- a/api/src/main/java/io/casehub/api/spi/RiskClassifier.java
+++ b/api/src/main/java/io/casehub/api/spi/RiskClassifier.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * CDI qualifier for {@link ActionRiskClassifier} implementations.
+ *
+ * <p>Consumer implementations must be annotated {@code @RiskClassifier @ApplicationScoped} so the
+ * engine's {@code ChainedReactiveActionRiskClassifier} can discover and chain them without circular
+ * dependency. The chain implements {@link ReactiveActionRiskClassifier}, not {@code
+ * ActionRiskClassifier}, which prevents self-injection.
+ *
+ * <p>Multiple classifiers from different repos (casehub-aml, casehub-clinical) are automatically
+ * chained — the most restrictive {@link RiskDecision.GateRequired} wins.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+public @interface RiskClassifier {}

--- a/api/src/main/java/io/casehub/api/spi/RiskDecision.java
+++ b/api/src/main/java/io/casehub/api/spi/RiskDecision.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * The outcome of {@link ActionRiskClassifier#classify(PlannedAction)}.
+ *
+ * <p>{@link Autonomous} — proceed immediately; case advances as if no PlannedAction was declared.
+ *
+ * <p>{@link GateRequired} — pause the case and route to a human approver via a WorkItem. The engine
+ * fires an {@code ActionGateScheduleEvent}; {@code casehub-engine-work-adapter} creates the
+ * WorkItem. If work-adapter is absent the case stalls — see {@code
+ * ActionGateDeploymentHealthCheck}.
+ */
+public sealed interface RiskDecision permits RiskDecision.Autonomous, RiskDecision.GateRequired {
+
+  record Autonomous() implements RiskDecision {}
+
+  /**
+   * Gate the action pending human approval.
+   *
+   * <p>{@code candidateGroups} — null means no group restriction on the WorkItem. When multiple
+   * classifiers both return {@code GateRequired}, the one with the fewest groups wins entirely —
+   * union semantics are wrong for compliance (an MLRO and a physician are not interchangeable
+   * approvers).
+   *
+   * <p>{@code reversible} — purely presentational. Shown to the approver as "This action cannot be
+   * undone" when false. Does not affect engine routing or WorkItem creation.
+   *
+   * <p>If {@link ActionRiskClassifier#classify(PlannedAction)} throws, the engine uses {@code new
+   * GateRequired("Classifier error — manual review required", true, null, null, null)} as the
+   * fail-safe default.
+   */
+  record GateRequired(
+      String reason,
+      boolean reversible,
+      List<String> candidateGroups,
+      Duration expiresIn,
+      String scope)
+      implements RiskDecision {}
+}

--- a/api/src/test/java/io/casehub/api/model/AgentWorkerTest.java
+++ b/api/src/test/java/io/casehub/api/model/AgentWorkerTest.java
@@ -101,7 +101,7 @@ class AgentWorkerTest {
             .build();
 
     Agent extractedAgent = (Agent) worker.getFunction().getValue();
-    Map<String, Object> result = extractedAgent.execute(Map.of("text", "hello world"));
+    Map<String, Object> result = extractedAgent.execute(Map.of("text", "hello world")).output();
 
     assertEquals("HELLO WORLD", result.get("result"));
   }

--- a/api/src/test/java/io/casehub/api/model/WorkerTest.java
+++ b/api/src/test/java/io/casehub/api/model/WorkerTest.java
@@ -51,7 +51,7 @@ class WorkerTest {
             .capabilities(
                 Capability.builder().name("review").inputSchema(".x").outputSchema(".y").build())
             .agentDescriptor(DESCRIPTOR)
-            .function(input -> Map.of())
+            .function(input -> WorkerResult.of(Map.of()))
             .build();
 
     assertThat(worker.hasDescriptor()).isTrue();
@@ -64,7 +64,7 @@ class WorkerTest {
             .name("plain-worker")
             .capabilities(
                 Capability.builder().name("review").inputSchema(".x").outputSchema(".y").build())
-            .function(input -> Map.of())
+            .function(input -> WorkerResult.of(Map.of()))
             .build();
 
     assertThat(worker.hasDescriptor()).isFalse();
@@ -78,7 +78,7 @@ class WorkerTest {
             .capabilities(
                 Capability.builder().name("review").inputSchema(".x").outputSchema(".y").build())
             .agentDescriptor(DESCRIPTOR)
-            .function(input -> Map.of())
+            .function(input -> WorkerResult.of(Map.of()))
             .build();
 
     assertThat(worker.agentDescriptor()).isSameAs(DESCRIPTOR);
@@ -91,7 +91,7 @@ class WorkerTest {
             .name("plain-worker")
             .capabilities(
                 Capability.builder().name("review").inputSchema(".x").outputSchema(".y").build())
-            .function(input -> Map.of())
+            .function(input -> WorkerResult.of(Map.of()))
             .build();
 
     assertThat(worker.agentDescriptor()).isNull();

--- a/api/src/test/java/io/casehub/api/model/ai/AgentBuilderTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/AgentBuilderTest.java
@@ -134,7 +134,7 @@ class AgentBuilderTest {
             .build();
 
     // Should not throw — just runs with identity transformers
-    final Map<String, Object> result = agent.execute(Map.of("status", "pending"));
+    final Map<String, Object> result = agent.execute(Map.of("status", "pending")).output();
     assertThat(result).containsKey("answer");
   }
 

--- a/api/src/test/java/io/casehub/api/model/ai/AgentTest.java
+++ b/api/src/test/java/io/casehub/api/model/ai/AgentTest.java
@@ -56,7 +56,7 @@ class AgentTest {
             .model(model)
             .build();
 
-    Map<String, Object> result = agent.execute(Map.of("question", "what?"));
+    Map<String, Object> result = agent.execute(Map.of("question", "what?")).output();
 
     assertThat(result.get("value")).isEqualTo(42);
     assertThat(result).doesNotContainKey("extra");

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/ActionGateExpiredPlanItemHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/ActionGateExpiredPlanItemHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import io.casehub.blackboard.event.PlanItemFaultedEvent;
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.common.internal.event.ActionGateWorkerFaultedEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.engine.common.internal.model.PlanItemStatus;
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import java.util.EnumSet;
+import java.util.Set;
+import org.jboss.logging.Logger;
+
+/**
+ * Marks the associated {@link PlanItem} FAULTED when a gate expires, enabling {@link
+ * io.casehub.blackboard.stage.StageAutocompleteEvaluator} to proceed.
+ *
+ * <p>Consumes {@link ActionGateWorkerFaultedEvent} on {@link
+ * EventBusAddresses#ACTION_GATE_WORKER_FAULTED}, published by {@code ActionGateRejectedHandler} and
+ * {@code ActionGateExpiredHandler} in the engine runtime. Uses a dedicated event address (not
+ * WORKER_RETRIES_EXHAUSTED) because gate faults must NOT cause a CaseInstance state transition to
+ * FAULTED — only the PlanItem should be faulted. Refs engine#402.
+ */
+@ApplicationScoped
+public class ActionGateExpiredPlanItemHandler {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateExpiredPlanItemHandler.class);
+
+  private static final Set<PlanItemStatus> FAULTABLE =
+      EnumSet.of(PlanItemStatus.RUNNING, PlanItemStatus.DELEGATED);
+
+  @Inject BlackboardRegistry registry;
+  @Inject Event<PlanItemFaultedEvent> planItemFaultedEvents;
+
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_WORKER_FAULTED, blocking = true)
+  public void onActionGateWorkerFaulted(final ActionGateWorkerFaultedEvent event) {
+    final String planItemId = registry.getPlanItemId(event.caseId(), event.workerId()).orElse(null);
+    if (planItemId == null) {
+      LOG.debugf(
+          "No PlanItem indexed for worker '%s' in case %s — blackboard not active or already evicted",
+          event.workerId(), event.caseId());
+      return;
+    }
+
+    registry
+        .get(event.caseId())
+        .flatMap(plan -> plan.getPlanItem(planItemId))
+        .ifPresent(
+            item -> {
+              if (!FAULTABLE.contains(item.getStatus())) {
+                LOG.debugf(
+                    "PlanItem %s for worker '%s' in case %s has status %s — not faultable,"
+                        + " skipping",
+                    planItemId, event.workerId(), event.caseId(), item.getStatus());
+                return;
+              }
+              item.markFaulted();
+              planItemFaultedEvents.fireAsync(
+                  new PlanItemFaultedEvent(event.caseId(), planItemId, event.workerId()));
+              LOG.infof(
+                  "PlanItem %s faulted (gate worker faulted): caseId=%s workerId=%s",
+                  planItemId, event.caseId(), event.workerId());
+            });
+  }
+}

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/ActionGateRejectedPlanItemHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/ActionGateRejectedPlanItemHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.handler;
+
+import io.casehub.blackboard.event.PlanItemFaultedEvent;
+import io.casehub.blackboard.plan.PlanItem;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.engine.common.internal.event.ActionGateWorkerFaultedEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.engine.common.internal.model.PlanItemStatus;
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import java.util.EnumSet;
+import java.util.Set;
+import org.jboss.logging.Logger;
+
+/**
+ * Marks the associated {@link PlanItem} FAULTED when a gate is rejected, enabling {@link
+ * io.casehub.blackboard.stage.StageAutocompleteEvaluator} to proceed.
+ *
+ * <p>Consumes {@link ActionGateWorkerFaultedEvent} on {@link
+ * EventBusAddresses#ACTION_GATE_WORKER_FAULTED}, published by {@code ActionGateRejectedHandler} and
+ * {@code ActionGateExpiredHandler} in the engine runtime. Uses a dedicated event address (not
+ * WORKER_RETRIES_EXHAUSTED) because gate faults must NOT cause a CaseInstance state transition to
+ * FAULTED — only the PlanItem should be faulted. Refs engine#402.
+ */
+@ApplicationScoped
+public class ActionGateRejectedPlanItemHandler {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateRejectedPlanItemHandler.class);
+
+  private static final Set<PlanItemStatus> FAULTABLE =
+      EnumSet.of(PlanItemStatus.RUNNING, PlanItemStatus.DELEGATED);
+
+  @Inject BlackboardRegistry registry;
+  @Inject Event<PlanItemFaultedEvent> planItemFaultedEvents;
+
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_WORKER_FAULTED, blocking = true)
+  public void onActionGateWorkerFaulted(final ActionGateWorkerFaultedEvent event) {
+    final String planItemId = registry.getPlanItemId(event.caseId(), event.workerId()).orElse(null);
+    if (planItemId == null) {
+      LOG.debugf(
+          "No PlanItem indexed for worker '%s' in case %s — blackboard not active or already evicted",
+          event.workerId(), event.caseId());
+      return;
+    }
+
+    registry
+        .get(event.caseId())
+        .flatMap(plan -> plan.getPlanItem(planItemId))
+        .ifPresent(
+            item -> {
+              if (!FAULTABLE.contains(item.getStatus())) {
+                LOG.debugf(
+                    "PlanItem %s for worker '%s' in case %s has status %s — not faultable,"
+                        + " skipping",
+                    planItemId, event.workerId(), event.caseId(), item.getStatus());
+                return;
+              }
+              item.markFaulted();
+              planItemFaultedEvents.fireAsync(
+                  new PlanItemFaultedEvent(event.caseId(), planItemId, event.workerId()));
+              LOG.infof(
+                  "PlanItem %s faulted (gate worker faulted): caseId=%s workerId=%s",
+                  planItemId, event.caseId(), event.workerId());
+            });
+  }
+}

--- a/blackboard/src/test/java/io/casehub/blackboard/NoOpLedgerEntryRepository.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/NoOpLedgerEntryRepository.java
@@ -79,6 +79,11 @@ class NoOpLedgerEntryRepository implements LedgerEntryRepository {
   }
 
   @Override
+  public List<LedgerEntry> findEventsByActorId(String actorId) {
+    return List.of();
+  }
+
+  @Override
   public Map<UUID, List<LedgerAttestation>> findAttestationsForEntries(Set<UUID> entryIds) {
     return Map.of();
   }

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
@@ -70,7 +70,7 @@ class PlanItemCompletionHandlerTest {
     when(instance.getUuid()).thenReturn(caseId);
     Worker worker = mock(Worker.class);
     when(worker.getName()).thenReturn(workerName);
-    return new WorkflowExecutionCompleted(instance, worker, "idempotency-key", Map.of());
+    return WorkflowExecutionCompleted.approved(instance, worker, "idempotency-key", Map.of());
   }
 
   @Test

--- a/blackboard/src/test/java/io/casehub/blackboard/it/BasicBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/BasicBlackboardTest.java
@@ -29,6 +29,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.blackboard.registry.BlackboardRegistry;
 import io.casehub.engine.common.internal.model.PlanItemStatus;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
@@ -252,7 +253,7 @@ class BasicBlackboardTest {
                   .name("once-worker")
                   .capabilities(cap)
                   // Write phase=done — trigger (.phase == "start") won't match again
-                  .function(input -> Map.of("phase", "done"))
+                  .function(input -> WorkerResult.of(Map.of("phase", "done")))
                   .build())
           .bindings(
               Binding.builder()
@@ -290,7 +291,7 @@ class BasicBlackboardTest {
               Worker.builder()
                   .name("never-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of())
+                  .function(input -> WorkerResult.of(Map.of()))
                   .build())
           .bindings(
               Binding.builder()
@@ -336,7 +337,7 @@ class BasicBlackboardTest {
               Worker.builder()
                   .name("completing-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("phase", "done"))
+                  .function(input -> WorkerResult.of(Map.of("phase", "done")))
                   .build())
           .bindings(
               Binding.builder()
@@ -382,7 +383,7 @@ class BasicBlackboardTest {
               Worker.builder()
                   .name("milestone-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("go", false, "docsUploaded", true))
+                  .function(input -> WorkerResult.of(Map.of("go", false, "docsUploaded", true)))
                   .build())
           .bindings(
               Binding.builder()

--- a/blackboard/src/test/java/io/casehub/blackboard/it/ExitConditionBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/ExitConditionBlackboardTest.java
@@ -24,6 +24,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.blackboard.registry.BlackboardRegistry;
 import io.casehub.blackboard.stage.Stage;
 import io.casehub.blackboard.stage.StageStatus;
@@ -110,7 +111,7 @@ class ExitConditionBlackboardTest {
               Worker.builder()
                   .name("exit-writer-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("phase", "exited"))
+                  .function(input -> WorkerResult.of(Map.of("phase", "exited")))
                   .build())
           .bindings(
               Binding.builder()

--- a/blackboard/src/test/java/io/casehub/blackboard/it/LambdaEntryConditionBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/LambdaEntryConditionBlackboardTest.java
@@ -24,6 +24,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.blackboard.registry.BlackboardRegistry;
 import io.casehub.blackboard.stage.Stage;
 import io.casehub.blackboard.stage.StageStatus;
@@ -125,7 +126,7 @@ class LambdaEntryConditionBlackboardTest {
               Worker.builder()
                   .name("lambda-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("done", true))
+                  .function(input -> WorkerResult.of(Map.of("done", true)))
                   .build())
           .bindings(
               Binding.builder()

--- a/blackboard/src/test/java/io/casehub/blackboard/it/MixedWorkersBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/MixedWorkersBlackboardTest.java
@@ -23,6 +23,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.blackboard.event.PlanItemCompletedEvent;
 import io.casehub.blackboard.registry.BlackboardRegistry;
 import io.casehub.engine.common.internal.model.PlanItemStatus;
@@ -154,12 +155,12 @@ class MixedWorkersBlackboardTest {
               Worker.builder()
                   .name("worker-a")
                   .capabilities(capA)
-                  .function(input -> Map.of("phaseA", "done"))
+                  .function(input -> WorkerResult.of(Map.of("phaseA", "done")))
                   .build(),
               Worker.builder()
                   .name("worker-b")
                   .capabilities(capB)
-                  .function(input -> Map.of("phaseB", "done"))
+                  .function(input -> WorkerResult.of(Map.of("phaseB", "done")))
                   .build())
           .bindings(
               Binding.builder()

--- a/blackboard/src/test/java/io/casehub/blackboard/it/PlanConfigurerBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/PlanConfigurerBlackboardTest.java
@@ -25,6 +25,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.blackboard.control.BlackboardPlanConfigurer;
 import io.casehub.blackboard.plan.CasePlanModel;
 import io.casehub.blackboard.registry.BlackboardRegistry;
@@ -211,7 +212,7 @@ class PlanConfigurerBlackboardTest {
               Worker.builder()
                   .name("configured-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("probe", "done"))
+                  .function(input -> WorkerResult.of(Map.of("probe", "done")))
                   .build())
           .bindings(
               Binding.builder()

--- a/blackboard/src/test/java/io/casehub/blackboard/it/SequentialStagesBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/SequentialStagesBlackboardTest.java
@@ -24,6 +24,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.blackboard.registry.BlackboardRegistry;
 import io.casehub.blackboard.stage.Stage;
 import io.casehub.blackboard.stage.StageStatus;
@@ -118,7 +119,7 @@ class SequentialStagesBlackboardTest {
               Worker.builder()
                   .name("phase-writer-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("phase", "two"))
+                  .function(input -> WorkerResult.of(Map.of("phase", "two")))
                   .build())
           .bindings(
               Binding.builder()

--- a/blackboard/src/test/java/io/casehub/blackboard/it/StageBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/StageBlackboardTest.java
@@ -24,6 +24,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.blackboard.plan.CasePlanModel;
 import io.casehub.blackboard.plan.PlanItem;
 import io.casehub.blackboard.registry.BlackboardRegistry;
@@ -421,7 +422,7 @@ class StageBlackboardTest {
               Worker.builder()
                   .name("signal-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("probe", "done"))
+                  .function(input -> WorkerResult.of(Map.of("probe", "done")))
                   .build())
           .bindings(
               Binding.builder()
@@ -460,7 +461,9 @@ class StageBlackboardTest {
               Worker.builder()
                   .name("once-signal-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("go", false)) // falsifies trigger, no re-fire
+                  .function(
+                      input ->
+                          WorkerResult.of(Map.of("go", false))) // falsifies trigger, no re-fire
                   .build())
           .bindings(
               Binding.builder()

--- a/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateApprovedEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateApprovedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.common.internal.event;
+
+import java.util.UUID;
+
+/**
+ * Published on {@link EventBusAddresses#ACTION_GATE_APPROVED} by {@code
+ * ActionGateCompletionApplier} (work-adapter) when a gate WorkItem is COMPLETED.
+ *
+ * <p>Consumed by {@code ActionGateApprovedHandler} in the engine runtime, which re-fires {@link
+ * WorkflowExecutionCompleted} with {@code plannedAction=null} so the normal completion machinery
+ * applies the deferred output, marks the PlanItem COMPLETED, and fires CONTEXT_CHANGED.
+ *
+ * <p>{@code workItemResolution} is the raw resolution JSON from the WorkItem — typically contains
+ * approver notes. {@code approvedBy} is sourced from {@code WorkItem.assignee}; may be null if the
+ * WorkItem was completed without an explicit claim.
+ */
+public record ActionGateApprovedEvent(
+    UUID caseId, long gateId, String workItemResolution, String approvedBy) {}

--- a/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateCancelledEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateCancelledEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.common.internal.event;
+
+import java.util.UUID;
+
+/**
+ * Published on {@link EventBusAddresses#ACTION_GATE_CANCELLED} by {@code CaseStatusChangedHandler}
+ * when a case transitions to a terminal state (COMPLETED, FAULTED, CANCELLED) while a gate is
+ * pending.
+ *
+ * <p>Consumed by {@code ActionGateCancelledHandler} in work-adapter, which cancels the orphaned
+ * gate WorkItem via {@code WorkItemService}. Prevents orphaned WorkItems resolving against a dead
+ * case. Cancellation is a no-op if the WorkItem has already reached a terminal state.
+ */
+public record ActionGateCancelledEvent(UUID caseId, long gateId) {}

--- a/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateExpiredEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateExpiredEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.common.internal.event;
+
+import java.util.UUID;
+
+/**
+ * Published on {@link EventBusAddresses#ACTION_GATE_EXPIRED} by {@code ActionGateCompletionApplier}
+ * (work-adapter) when a gate WorkItem expires before approval.
+ *
+ * <p>Consumed by {@code ActionGateExpiredHandler} in the engine runtime (writes {@code
+ * actionGateExpired} signal, calls {@code workerStatusListener}, fires CONTEXT_CHANGED) and by
+ * {@code ActionGateExpiredPlanItemHandler} in the blackboard module (marks PlanItem FAULTED).
+ */
+public record ActionGateExpiredEvent(UUID caseId, long gateId) {}

--- a/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateRejectedEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateRejectedEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.common.internal.event;
+
+import java.util.UUID;
+
+/**
+ * Published on {@link EventBusAddresses#ACTION_GATE_REJECTED} by {@code
+ * ActionGateCompletionApplier} (work-adapter) when a gate WorkItem is REJECTED or CANCELLED.
+ *
+ * <p>Consumed by {@code ActionGateRejectedHandler} in the engine runtime (writes {@code
+ * actionGateRejected} signal, calls {@code workerStatusListener}, fires CONTEXT_CHANGED) and by
+ * {@code ActionGateRejectedPlanItemHandler} in the blackboard module (marks PlanItem FAULTED so
+ * stage autocomplete can proceed).
+ */
+public record ActionGateRejectedEvent(
+    UUID caseId, long gateId, String workItemResolution, String rejectedBy) {}

--- a/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateScheduleEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateScheduleEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.common.internal.event;
+
+import io.casehub.api.spi.PlannedAction;
+import io.casehub.api.spi.RiskDecision;
+import java.util.UUID;
+
+/**
+ * Published on {@link EventBusAddresses#ACTION_GATE_SCHEDULE} when the engine determines a worker's
+ * action must be gated for human approval.
+ *
+ * <p>{@code gateId} is the EventLog entry id of the {@code ACTION_GATE_PENDING} entry — it becomes
+ * the stable key linking the gate to its WorkItem via callerRef {@code
+ * "case:{caseId}/gate:{gateId}"}.
+ *
+ * <p>Consumed by {@code ActionGateWorkItemHandler} in {@code casehub-engine-work-adapter}, which
+ * creates the WorkItem. If work-adapter is absent, this event fires with no handler and the case
+ * stalls.
+ */
+public record ActionGateScheduleEvent(
+    UUID caseId,
+    String tenancyId,
+    long gateId,
+    PlannedAction plannedAction,
+    RiskDecision.GateRequired gateRequired) {}

--- a/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateWorkerFaultedEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateWorkerFaultedEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.common.internal.event;
+
+import java.util.UUID;
+
+/**
+ * Published on {@link EventBusAddresses#ACTION_GATE_WORKER_FAULTED} by {@code
+ * ActionGateRejectedHandler} and {@code ActionGateExpiredHandler} in the engine runtime after a
+ * gate is resolved negatively.
+ *
+ * <p>Consumed by the blackboard module ({@code ActionGateRejectedPlanItemHandler}, {@code
+ * ActionGateExpiredPlanItemHandler}) to mark the associated PlanItem FAULTED, enabling {@code
+ * StageAutocompleteEvaluator} to fire. This is distinct from {@link WorkerRetriesExhaustedEvent}
+ * which also faults the {@code CaseInstance} state — gate faults must leave the case RUNNING so the
+ * rejection binding can react.
+ */
+public record ActionGateWorkerFaultedEvent(UUID caseId, String workerId, String idempotency) {}

--- a/common/src/main/java/io/casehub/engine/common/internal/event/EventBusAddresses.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/EventBusAddresses.java
@@ -82,4 +82,13 @@ public final class EventBusAddresses {
    * is pending. Handled by ActionGateCancelledHandler in work-adapter to cancel the WorkItem.
    */
   public static final String ACTION_GATE_CANCELLED = "casehub.action.gate.cancelled";
+
+  /**
+   * Published by ActionGateRejectedHandler and ActionGateExpiredHandler when a gate is resolved
+   * negatively (rejected or expired). Consumed by the blackboard module to mark the associated
+   * PlanItem FAULTED — enabling StageAutocompleteEvaluator to proceed. Distinct from
+   * WORKER_RETRIES_EXHAUSTED which also faults the CaseInstance; gate faults leave the case
+   * RUNNING.
+   */
+  public static final String ACTION_GATE_WORKER_FAULTED = "casehub.action.gate.worker.faulted";
 }

--- a/common/src/main/java/io/casehub/engine/common/internal/event/EventBusAddresses.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/EventBusAddresses.java
@@ -51,4 +51,35 @@ public final class EventBusAddresses {
 
   /** Published by QuartzWorkerExecutionJob when a workflow future completes exceptionally. */
   public static final String WORKFLOW_EXECUTION_FAILED = "casehub.workflow.execution.failed";
+
+  // --- Action gate lifecycle ---
+
+  /** Published by WorkflowExecutionCompletedHandler when GateRequired fires. */
+  public static final String ACTION_GATE_SCHEDULE = "casehub.action.gate.schedule";
+
+  /**
+   * Published by ActionGateCompletionApplier (work-adapter) when a gate WorkItem is COMPLETED.
+   * Handled by ActionGateApprovedHandler in the engine runtime.
+   */
+  public static final String ACTION_GATE_APPROVED = "casehub.action.gate.approved";
+
+  /**
+   * Published by ActionGateCompletionApplier (work-adapter) when a gate WorkItem is
+   * REJECTED/CANCELLED. Handled by ActionGateRejectedHandler in the engine runtime and by
+   * ActionGateRejectedPlanItemHandler in the blackboard module.
+   */
+  public static final String ACTION_GATE_REJECTED = "casehub.action.gate.rejected";
+
+  /**
+   * Published by ActionGateCompletionApplier (work-adapter) when a gate WorkItem expires. Handled
+   * by ActionGateExpiredHandler in the engine runtime and by ActionGateExpiredPlanItemHandler in
+   * the blackboard module.
+   */
+  public static final String ACTION_GATE_EXPIRED = "casehub.action.gate.expired";
+
+  /**
+   * Published by CaseStatusChangedHandler when a case transitions to a terminal state while a gate
+   * is pending. Handled by ActionGateCancelledHandler in work-adapter to cancel the WorkItem.
+   */
+  public static final String ACTION_GATE_CANCELLED = "casehub.action.gate.cancelled";
 }

--- a/common/src/main/java/io/casehub/engine/common/internal/event/WorkflowExecutionCompleted.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/WorkflowExecutionCompleted.java
@@ -16,8 +16,35 @@
 package io.casehub.engine.common.internal.event;
 
 import io.casehub.api.model.Worker;
+import io.casehub.api.spi.PlannedAction;
 import io.casehub.engine.common.internal.model.CaseInstance;
 import java.util.Map;
 
+/**
+ * Published on {@link EventBusAddresses#WORKER_EXECUTION_FINISHED} when a worker function returns.
+ *
+ * <p>{@code plannedAction} is non-null only when the worker returned a {@link
+ * io.casehub.api.model.WorkerResult} with a declared action. The engine's completion handler forks
+ * on this field: null means the normal path; non-null triggers {@link
+ * io.casehub.api.spi.ReactiveActionRiskClassifier#classify(PlannedAction)} before applying output.
+ *
+ * <p>The gate approval path re-publishes this event with {@code plannedAction=null} so the normal
+ * completion machinery handles output application, PlanItem completion, and stage autocomplete
+ * without re-classifying.
+ */
 public record WorkflowExecutionCompleted(
-    CaseInstance caseInstance, Worker worker, String idempotency, Map<String, Object> output) {}
+    CaseInstance caseInstance,
+    Worker worker,
+    String idempotency,
+    Map<String, Object> output,
+    PlannedAction plannedAction) {
+
+  /** Convenience constructor for the gate-re-fire path — plannedAction is always null. */
+  public static WorkflowExecutionCompleted approved(
+      final CaseInstance caseInstance,
+      final Worker worker,
+      final String idempotency,
+      final Map<String, Object> output) {
+    return new WorkflowExecutionCompleted(caseInstance, worker, idempotency, output, null);
+  }
+}

--- a/common/src/main/java/io/casehub/engine/common/internal/model/CaseInstance.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/model/CaseInstance.java
@@ -115,11 +115,18 @@ public class CaseInstance {
   /**
    * Non-null while an action gate is pending human approval. Set by the engine when {@link
    * io.casehub.api.spi.RiskDecision.GateRequired} fires; cleared by the gate resolution handlers
-   * after processing. Stored as a nullable JSON blob on the JPA entity.
+   * after processing.
+   *
+   * <p><strong>In-memory only in v1 — not persisted by {@code CaseInstanceEntity}.</strong> If the
+   * engine restarts while a gate is pending, the gate is lost from memory. The WorkItem in
+   * quarkus-work survives restart, but when it resolves, the resolution handler sees null from the
+   * cache and discards the approval silently — the case stalls. When v2 adds the {@code
+   * pending_action_gate} column to {@code CaseInstanceEntity}, resolution handlers must also call
+   * {@code caseInstanceRepository.update()} to clear it.
    *
    * <p>Only one gate is supported per case in v1. If a second worker returns a PlannedAction while
    * this field is non-null, the engine proceeds as Autonomous for the second action and logs an
-   * ERROR.
+   * ERROR. The second action bypasses classification — a known v1 constraint.
    */
   private PendingActionGate pendingActionGate;
 

--- a/common/src/main/java/io/casehub/engine/common/internal/model/CaseInstance.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/model/CaseInstance.java
@@ -111,4 +111,23 @@ public class CaseInstance {
   public void setState(CaseStatus state) {
     this.state = state;
   }
+
+  /**
+   * Non-null while an action gate is pending human approval. Set by the engine when {@link
+   * io.casehub.api.spi.RiskDecision.GateRequired} fires; cleared by the gate resolution handlers
+   * after processing. Stored as a nullable JSON blob on the JPA entity.
+   *
+   * <p>Only one gate is supported per case in v1. If a second worker returns a PlannedAction while
+   * this field is non-null, the engine proceeds as Autonomous for the second action and logs an
+   * ERROR.
+   */
+  private PendingActionGate pendingActionGate;
+
+  public PendingActionGate getPendingActionGate() {
+    return pendingActionGate;
+  }
+
+  public void setPendingActionGate(final PendingActionGate pendingActionGate) {
+    this.pendingActionGate = pendingActionGate;
+  }
 }

--- a/common/src/main/java/io/casehub/engine/common/internal/model/PendingActionGate.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/model/PendingActionGate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.common.internal.model;
+
+import io.casehub.api.spi.PlannedAction;
+import java.util.Map;
+
+/**
+ * Operational state for an in-flight action gate stored on {@link CaseInstance}.
+ *
+ * <p>Set when a worker declares a {@link PlannedAction} and the engine's {@link
+ * io.casehub.api.spi.ActionRiskClassifier} returns {@link
+ * io.casehub.api.spi.RiskDecision.GateRequired}. Cleared by the gate resolution handlers ({@code
+ * ActionGateApprovedHandler}, {@code ActionGateRejectedHandler}, {@code ActionGateExpiredHandler})
+ * after they finish processing.
+ *
+ * <p>{@code gateId} is the EventLog entry id of the {@code ACTION_GATE_PENDING} entry. It is
+ * embedded in the WorkItem callerRef as {@code "case:{caseId}/gate:{gateId}"} and used to correlate
+ * the gate back to its deferred output on resolution.
+ *
+ * <p>{@link io.casehub.api.model.Worker} is intentionally absent — lambdas are not
+ * Jackson-serializable. The approved handler retrieves the {@code Worker} at resolution time via
+ * {@code CaseDefinitionRegistry}.
+ */
+public record PendingActionGate(
+    long gateId,
+    String workerId,
+    String idempotency,
+    Map<String, Object> deferredOutput,
+    PlannedAction plannedAction) {}

--- a/docs/specs/2026-06-05-action-risk-classifier-design.md
+++ b/docs/specs/2026-06-05-action-risk-classifier-design.md
@@ -1,0 +1,758 @@
+# ActionRiskClassifier SPI — Design Spec
+
+**Issue:** casehubio/engine#402  
+**Branch:** issue-402-action-risk-classifier-spi  
+**Date:** 2026-06-05 (revised after review)
+
+---
+
+## Problem
+
+Workers execute autonomously. When a worker proposes a consequential action — filing a SAR,
+freezing an account, deploying to production, cancelling a subscription, submitting a regulatory
+report — there is no platform-level mechanism to pause and route that decision to a human before
+the case advances. Every worker that needs human approval must implement bespoke approval logic
+or skip the gate entirely.
+
+`ActionRiskClassifier` fixes this at the platform layer: the worker declares intent, the engine
+classifies the risk, and if approval is required the engine pauses, routes to a human via a
+WorkItem, and resumes or rejects when the human responds. Workers write zero approval logic.
+
+---
+
+## Consumers and Requirements
+
+| Repo | Use cases | Key constraint |
+|------|-----------|----------------|
+| casehub-aml | SAR filing, account freeze, law enforcement referral | MLRO sign-off; gate audit trail is a compliance artefact |
+| casehub-clinical | SUSAR filing, dose modification, patient withdrawal, SAE reporting | Physician/clinician approval; regulatory deadlines (24h, 7-day) |
+| devtown | Production deploy, contributor access, security escalation | Project-configurable thresholds |
+| casehub-life | Spend above threshold, non-refundable bookings, contractor instruction | Household-configurable thresholds |
+| casehub-openclaw | Oversight channel gate in Epic 6 end-to-end wiring | Full round-trip: classify → gate → human decision → workflow continues |
+
+AML and clinical require specific approver roles (`candidateGroups`) and approval deadlines
+(`expiresIn`). The gate mechanism is a **WorkItem** — these fields are already first-class on
+`WorkItemCreateRequest`. Qhorus oversight channels are the right mechanism for routing escalation
+(engine#377/#383); action approval is a structured HITL concern owned by `casehub-work`.
+OpenClaw and Life can bridge WorkItems to messaging channels on their side.
+
+---
+
+## Design
+
+### 1. Worker-facing API
+
+**`WorkerResult`** replaces `Map<String, Object>` as the return type for all worker functions.
+
+```java
+// api/src/main/java/io/casehub/api/model/WorkerResult.java
+public record WorkerResult(
+    Map<String, Object> output,
+    @Nullable PlannedAction plannedAction) {
+
+  public static WorkerResult of(Map<String, Object> output) {
+    return new WorkerResult(output, null);
+  }
+
+  public static WorkerResult of(Map<String, Object> output, PlannedAction action) {
+    return new WorkerResult(output, action);
+  }
+}
+```
+
+Workers without consequential actions return `WorkerResult.of(output)` — behaviour unchanged.
+Workers proposing actions return `WorkerResult.of(output, PlannedAction.of(...))`.
+
+This is a **deliberate breaking change** to all worker function signatures:
+- `Function<Map<String,Object>, Map<String,Object>>` → `Function<Map<String,Object>, WorkerResult>`
+- `Agent.execute(Map<String,Object>)` → returns `WorkerResult`
+- Workflow workers always return `WorkerResult.of(output)` — no PlannedAction in v1 (workflow DSL
+  extension tracked as follow-up)
+
+**Worker migration** — mechanical, no behaviour change: `return map` → `return WorkerResult.of(map)`.
+No compatibility shim is provided. All consumer repos update their workers when taking the new engine
+version. The engine has no external users so a coordinated same-release migration is correct.
+
+Note: `WorkerContext.declareAction()` (thread-local side channel) was evaluated as an alternative.
+Rejected because workflow workers run on a different thread from `WorkerExecutionContext.set()` —
+thread-local values don't survive the async boundary. `WorkerResult` travels with the event; no
+thread-safety concern.
+
+**`PlannedAction`** — what the worker declares:
+
+```java
+// api/src/main/java/io/casehub/api/spi/PlannedAction.java
+public record PlannedAction(
+    @Nullable String workerId,      // null from worker; populated by engine before classify()
+    @Nullable UUID caseId,          // null from worker; populated by engine before classify()
+    String description,             // "Cancel Netflix subscription for household account"
+    String actionType,              // "subscription.cancel", "sar.file", "spend.transfer"
+    Map<String, Object> context     // {"amount": 49.99, "provider": "Netflix", ...}
+) {
+  /** Worker-facing factory — workerId and caseId populated by engine before classify(). */
+  public static PlannedAction of(
+      String description, String actionType, Map<String, Object> context) {
+    return new PlannedAction(null, null, description, actionType, context);
+  }
+
+  /** Engine enrichment — called before passing to the classifier. */
+  public PlannedAction withIdentity(String workerId, UUID caseId) {
+    return new PlannedAction(workerId, caseId, description, actionType, context);
+  }
+}
+```
+
+`workerId` and `caseId` are engine metadata populated via `withIdentity()` before `classify()` is
+called. Classifiers receive a fully populated `PlannedAction`. `context` is `Map<String, Object>`
+— AML and clinical pass structured values (nested maps, numbers), not flat strings.
+
+---
+
+### 2. SPI
+
+#### Interfaces
+
+```java
+// api/src/main/java/io/casehub/api/spi/ActionRiskClassifier.java (blocking, convenience)
+public interface ActionRiskClassifier {
+  RiskDecision classify(PlannedAction action);
+}
+
+// api/src/main/java/io/casehub/api/spi/ReactiveActionRiskClassifier.java (primary — called by engine)
+public interface ReactiveActionRiskClassifier {
+  Uni<RiskDecision> classify(PlannedAction action);
+}
+```
+
+Reactive is primary because classifiers do async work (DB queries for risk scores, config lookups,
+external API calls). The blocking interface is bridged automatically by the chained classifier.
+
+```java
+// api/src/main/java/io/casehub/api/spi/RiskDecision.java
+public sealed interface RiskDecision {
+  record Autonomous() implements RiskDecision {}
+
+  record GateRequired(
+      String reason,                          // human-readable, shown as WorkItem title context
+      boolean reversible,                     // purely presentational — no engine routing logic
+      @Nullable List<String> candidateGroups, // null = no group restriction on WorkItem
+      @Nullable Duration expiresIn,           // null = no expiry on WorkItem
+      @Nullable String scope                  // SLA preference key, null = no SLA
+  ) implements RiskDecision {}
+}
+```
+
+**`reversible` is purely presentational.** The engine serialises it into the WorkItem payload so
+the approver UI can show "This action cannot be undone." It does not affect engine routing, approval
+logic, or WorkItem creation in any way. Classifiers that want irreversible actions to require higher
+approver tiers encode that policy in `candidateGroups` — the engine does not infer it from
+`reversible`.
+
+#### Classifier composition — `@RiskClassifier` qualifier
+
+Multiple classifiers can be active simultaneously (e.g., a hospital deployment with both AML and
+clinical classifiers). CDI cannot resolve two `@ApplicationScoped ActionRiskClassifier` beans
+without a qualifier.
+
+Solution: `@RiskClassifier` qualifier in `api/spi/`. Consumer implementations use
+`@RiskClassifier @ApplicationScoped`. The engine ships `ChainedReactiveActionRiskClassifier`
+which injects `@RiskClassifier Instance<ActionRiskClassifier>` — no circular dependency because
+`ChainedReactiveActionRiskClassifier` implements `ReactiveActionRiskClassifier`, not
+`ActionRiskClassifier`.
+
+```java
+// api/src/main/java/io/casehub/api/spi/RiskClassifier.java
+@Qualifier
+@Retention(RUNTIME)
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+public @interface RiskClassifier {}
+```
+
+```java
+// engine/internal/worker/ChainedReactiveActionRiskClassifier.java
+@ApplicationScoped  // NOT @DefaultBean — displaces the autonomous default when any @RiskClassifier bean exists
+public class ChainedReactiveActionRiskClassifier implements ReactiveActionRiskClassifier {
+
+  @Inject @RiskClassifier Instance<ActionRiskClassifier> classifiers;
+
+  @Override
+  public Uni<RiskDecision> classify(PlannedAction action) {
+    if (classifiers.isUnsatisfied()) {
+      // No consumer classifiers registered — always Autonomous (safe default)
+      return Uni.createFrom().item(new Autonomous());
+    }
+    return Uni.createFrom()
+        .item(() ->
+            StreamSupport.stream(classifiers.spliterator(), false)
+                .map(c -> c.classify(action))
+                .reduce(new Autonomous(), this::mostRestrictive))
+        .runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+    // Blocking classifiers (DB queries, API calls) must run off the Vert.x IO thread.
+    // runSubscriptionOn offloads the entire chain to the worker pool.
+  }
+
+  private RiskDecision mostRestrictive(RiskDecision a, RiskDecision b) {
+    if (!(b instanceof GateRequired gb)) return a;
+    if (!(a instanceof GateRequired ga)) return b;
+    return narrower(ga, gb);
+  }
+
+  /**
+   * When two classifiers both return GateRequired, the one with the narrower candidateGroups
+   * wins entirely — its reason, reversible, expiresIn, and scope are all used as-is.
+   *
+   * Union semantics are wrong for compliance: ["mlro"] ∪ ["physician"] = ["mlro", "physician"]
+   * means either role can approve, which breaks both AML (MLRO authority) and clinical (physician
+   * authority). The stricter requirement takes precedence; the losing classifier's gate is
+   * subsumed. Case definition authors must structure multi-domain actions into sequential workers
+   * with separate gates when different approver pools are required.
+   *
+   * Tie-breaking order: fewest candidates → shortest expiresIn → CDI iteration order (first wins).
+   */
+  private GateRequired narrower(GateRequired a, GateRequired b) {
+    int sizeA = a.candidateGroups() == null ? Integer.MAX_VALUE : a.candidateGroups().size();
+    int sizeB = b.candidateGroups() == null ? Integer.MAX_VALUE : b.candidateGroups().size();
+    if (sizeA != sizeB) return sizeA < sizeB ? a : b;
+    // Equal group count: shorter expiry is more restrictive
+    if (a.expiresIn() != null && b.expiresIn() != null) {
+      return a.expiresIn().compareTo(b.expiresIn()) <= 0 ? a : b;
+    }
+    if (a.expiresIn() != null) return a; // deadline is more restrictive than no deadline
+    if (b.expiresIn() != null) return b;
+    return a; // CDI iteration order: first wins
+  }
+}
+```
+
+**Consumer pattern:**
+
+```java
+@RiskClassifier
+@ApplicationScoped
+public class AmlActionRiskClassifier implements ActionRiskClassifier {
+  @Override
+  public RiskDecision classify(PlannedAction action) {
+    if ("sar.file".equals(action.actionType())) {
+      return new GateRequired(
+          "SAR submission — MLRO sign-off required",
+          false,
+          List.of("mlro", "senior-analyst"),
+          Duration.ofHours(24),
+          "casehubio/aml/sar-submission");
+    }
+    return new Autonomous();
+  }
+}
+```
+
+**No separate `DefaultActionRiskClassifier` needed.** `ChainedReactiveActionRiskClassifier`
+returns `Autonomous` via the `isUnsatisfied()` guard when no consumer provides a `@RiskClassifier`
+classifier — adding a `@DefaultBean @RiskClassifier` fallback would cause `isUnsatisfied()` to
+always return false, breaking the startup warning and making the guard dead code. The chain IS the
+default. Add `ChainedReactiveActionRiskClassifier` to the beans table in
+PP-20260514-engine-spi-noops-defaultbean.
+
+#### Classifier failure — fail-safe
+
+If `classify()` throws or the reactive `Uni` fails, the engine treats the failure as:
+
+```java
+new GateRequired("Classifier error — manual review required before proceeding",
+    true, null, null, null)
+```
+
+This fail-safe default is the only acceptable choice for AML/clinical. A classifier failure that
+allows an action to proceed autonomously could have regulatory consequences. The error is logged at
+ERROR level with the classifier class name and full stack trace. The SPI Javadoc must specify this
+behaviour so classifier implementors know not to throw to bypass the gate.
+
+---
+
+### 3. Engine integration
+
+**`WorkflowExecutionCompleted`** event gains `@Nullable PlannedAction plannedAction`. The event
+retains its existing `Map<String,Object> output` field — `WorkerResult` is unpacked at the
+`QuartzWorkerExecutionJob` boundary and does not propagate as a type beyond it.
+
+**`QuartzWorkerExecutionJob`**: function and agent workers return `WorkerResult`. Workflow workers
+wrap output as `WorkerResult.of(output)`. The `plannedAction` field of `WorkflowExecutionCompleted`
+is set from `WorkerResult.plannedAction()`.
+
+**`WorkflowExecutionCompletedHandler`** forks before applying any output:
+
+```
+if (event.plannedAction() == null):
+    → existing path, unchanged
+
+else if (instance.getPendingActionGate() != null):
+    → ERROR log: concurrent gate unsupported in v1
+    → proceed as if plannedAction == null (existing path)
+
+else:
+    enrichedAction = event.plannedAction().withIdentity(worker.getName(), instance.getUuid())
+    classify(enrichedAction) →
+
+      Autonomous:
+          → existing path, unchanged
+
+      GateRequired:
+          → gate path (see §4)
+
+      classifier throws:
+          → fail-safe GateRequired("Classifier error — ...", true, null, null, null)
+          → gate path
+```
+
+**Concurrent gate constraint (v1):** `CaseInstance` holds one `pendingActionGate`. If a second
+worker returns a `PlannedAction` while a gate is already pending, the engine logs an ERROR and
+proceeds as `Autonomous` for the second action. The first gate takes precedence. Multi-gate support
+is deferred. Case definition authors must avoid designs where two concurrent workers may
+simultaneously propose actions requiring gates.
+
+**`WorkerOutputApplier`** — no longer needed. The gate approval path re-fires
+`WorkflowExecutionCompleted` with `plannedAction=null`, which goes through the existing completion
+path. No output application logic is duplicated or extracted.
+
+---
+
+### 4. Pending gate state and gate initiation
+
+**`PendingActionGate`** record in `common/internal/model/`:
+
+```java
+public record PendingActionGate(
+    long gateId,                       // EventLog id of ACTION_GATE_PENDING entry; embedded in callerRef
+    String workerId,
+    String idempotency,
+    Map<String, Object> deferredOutput,
+    PlannedAction plannedAction        // fully enriched (workerId + caseId populated)
+) {}
+```
+
+`Worker` is intentionally absent. `Worker.getFunction().getValue()` can be a lambda —
+not Jackson-serializable. The approved handler retrieves the `Worker` at resolution time via
+`caseDefinitionRegistry.getCaseDefinition(instance.getCaseMetaModel())` filtered by `workerId`.
+No serialization required.
+
+**`CaseInstance`** gains `private PendingActionGate pendingActionGate` with getter/setter.
+
+**`CaseInstanceEntity`** (JPA): new `pending_action_gate` column — nullable JSON blob (`@Column`,
+serialized via Jackson). No migration needed — schema is `drop-and-create`.
+
+**`InMemoryCaseInstanceRepository`**: handles the new field naturally.
+
+**Gate path in `WorkflowExecutionCompletedHandler`** when `GateRequired` fires:
+
+1. Write `ACTION_GATE_PENDING` EventLog entry (`EventStreamType.CASE`) — the compliance audit record.
+   See §7 for exact payload structure.
+2. Populate `PendingActionGate` on `CaseInstance`; save.
+3. Publish `ActionGateScheduleEvent` to event bus.
+4. **Do not** apply output to case context.
+5. **Do not** fire `CONTEXT_CHANGED`.
+6. **Do not** call `workerStatusListener` — the worker is not yet done.
+7. Fire `CaseLifecycleEvent(ACTION_GATE_PENDING)` for observability.
+
+---
+
+### 5. `CallerRef` sealed hierarchy — structural change
+
+`CallerRef` is currently `record CallerRef(UUID caseId, String planItemId)`. Adding a gate format
+requires a sealed hierarchy because a gate ref has no `planItemId` field.
+
+**New structure:**
+
+```java
+// work-adapter/src/main/java/io/casehub/workadapter/CallerRef.java
+public sealed interface CallerRef permits PlanItemCallerRef, GateCallerRef {
+
+  UUID caseId();
+
+  static @Nullable CallerRef parse(String raw) {
+    if (raw == null) return null;
+    Matcher pi = PI_PATTERN.matcher(raw);
+    if (pi.matches()) return new PlanItemCallerRef(UUID.fromString(pi.group(1)), pi.group(2));
+    Matcher gate = GATE_PATTERN.matcher(raw);
+    if (gate.matches()) return new GateCallerRef(UUID.fromString(gate.group(1)), Long.parseLong(gate.group(2)));
+    return null;
+  }
+}
+
+// case:{caseId}/pi:{planItemId}
+public record PlanItemCallerRef(UUID caseId, String planItemId) implements CallerRef {
+  public static String encode(UUID caseId, String planItemId) {
+    return "case:" + caseId + "/pi:" + planItemId;
+  }
+}
+
+// case:{caseId}/gate:{gateId}
+public record GateCallerRef(UUID caseId, long gateId) implements CallerRef {
+  public static String encode(UUID caseId, long gateId) {
+    return "case:" + caseId + "/gate:" + gateId;
+  }
+}
+```
+
+**Call site impact** — all existing usages of `ref.planItemId()` and `CallerRef.encode()` require
+pattern-matching updates. Affected files (production + test):
+
+- `WorkItemLifecycleAdapter` (3 parse call sites, each using `ref.caseId()` + `ref.planItemId()`)
+- `HumanTaskScheduleHandler` (2 `CallerRef.encode()` call sites → `PlanItemCallerRef.encode()`)
+- `HumanTaskRecoveryService` (1 `CallerRef.encode()` → `PlanItemCallerRef.encode()`)
+- `PlanItemCompletionApplier` (receives `planItemId` from caller — callers update, not this class)
+- All test call sites (~12 across `WorkItemLifecycleAdapterTest`, `HumanTaskScheduleHandlerTest`,
+  `HumanTaskRecoveryServiceTest`)
+
+This is a real structural refactoring, not a trivial extension. It is explicitly scoped as part of
+this issue.
+
+---
+
+### 6. Gate mechanism (work-adapter)
+
+**`ActionGateWorkItemHandler`** — new class in `work-adapter/`,
+`@ConsumeEvent(ACTION_GATE_SCHEDULE, blocking=true) @Transactional`:
+
+- Creates a WorkItem directly via `WorkItemService.create()`.
+- **No PlanItem. No BlackboardRegistry.** The gate is a first-class work-adapter concept.
+- callerRef: `GateCallerRef.encode(event.caseId(), event.gateId())` →
+  `"case:{caseId}/gate:{gateId}"`.
+- title: `GateRequired.reason()`.
+- candidateGroups, expiresAt (from `expiresIn`), scope: from `GateRequired`.
+- payload: full `PlannedAction` + `reversible` serialized as JSON (human sees what the agent
+  proposed, including the description and actionType — not just the context map).
+- Tenancy: `ActionGateScheduleEvent` carries `tenancyId`. The handler establishes tenant context
+  via the same `@Transactional` boundary pattern as `HumanTaskScheduleHandler`.
+
+**`WorkItemLifecycleAdapter.onWorkItemLifecycle()` restructured:**
+
+```java
+CallerRef ref = CallerRef.parse(workItem.callerRef);
+if (ref == null) return;
+
+// Gate refs bypass the blackboard guard — gates have no PlanItem
+if (ref instanceof GateCallerRef gateRef) {
+    actionGateCompletionApplier.apply(gateRef, status, workItem);
+    return;
+}
+
+// Existing PlanItemCallerRef path — blackboard guard applies
+if (registry.get(ref.caseId()).isEmpty()) { ... return; }
+PlanItemCallerRef piRef = (PlanItemCallerRef) ref;
+applier.apply(piRef.caseId(), piRef.planItemId(), status, workItem);
+```
+
+The gate check must come **before** the blackboard guard, not after. Without this ordering, gate
+WorkItem lifecycle events silently die when no active `CasePlanModel` is registered — which is
+always the case for gates (they create no PlanItem).
+
+**`ActionGateCompletionApplier`** — new class in `work-adapter/`, `@ApplicationScoped`:
+
+| WorkItemStatus | Action |
+|----------------|--------|
+| COMPLETED | publish `ActionGateApprovedEvent(caseId, gateId, workItemResolution)` |
+| REJECTED | publish `ActionGateRejectedEvent(caseId, gateId, resolution)` |
+| CANCELLED | same as REJECTED |
+| EXPIRED | publish `ActionGateExpiredEvent(caseId, gateId)` |
+
+Work-adapter publishes events back to the engine runtime — output application stays in the engine.
+
+---
+
+### 7. Gate resolution (engine runtime)
+
+**`ActionGateApprovedHandler`** — `@ConsumeEvent(ACTION_GATE_APPROVED)`:
+
+1. Load `CaseInstance`; read `pendingActionGate`. If null, log WARN and return (idempotent).
+2. **Terminal state guard:** if `instance.getState()` is COMPLETED, FAULTED, or CANCELLED: log
+   WARN ("gate resolved on terminated case — discarding deferred output"), clear gate, save, return.
+3. Write `ACTION_GATE_APPROVED` EventLog entry (`EventStreamType.CASE`). See §8 for payload.
+4. Write `actionGateApproved: {actionType, workerId, resolution}` to case context — downstream
+   workers and case definitions can observe who approved and what the resolution was.
+5. Clear `pendingActionGate`, save `CaseInstance`.
+6. Re-publish `WorkflowExecutionCompleted(instance, worker, idempotency, deferredOutput, plannedAction=null)`
+   to `WORKER_EXECUTION_FINISHED`.
+
+Step 6 re-enters the normal completion machinery with `plannedAction=null` — no re-classification,
+no re-gating. `WorkflowExecutionCompletedHandler` applies the deferred output, calls
+`workerStatusListener.onWorkerCompleted()`, calls `caseResumptionService.resumeIfWaiting()`, fires
+`CaseLifecycleEvent(WORKER_EXECUTION_COMPLETED)` and `WorkerDecisionEvent`, and publishes
+`CONTEXT_CHANGED`. `PlanItemCompletionHandler` in the blackboard (if present) handles
+`WORKER_EXECUTION_FINISHED` and marks the PlanItem COMPLETED. `StageAutocompleteEvaluator` fires
+normally. No duplication of completion logic; no new coupling to the blackboard.
+
+**`ActionGateRejectedHandler`** — `@ConsumeEvent(ACTION_GATE_REJECTED)`:
+
+1. Load `CaseInstance`. Terminal state guard (same as approved handler).
+2. Call `workerStatusListener.onWorkerCompleted(WorkResult.faulted(idempotency, workerId, caseId))`
+   — external observers (Claudony, monitoring) see a faulted completion, not a silent disappearance.
+3. Write `ACTION_GATE_REJECTED` EventLog entry (`EventStreamType.CASE`).
+4. Write `actionGateRejected: {actionType, reason, workerId, resolution}` to case context.
+5. Clear `pendingActionGate`, save.
+6. Publish `ACTION_GATE_REJECTED` on event bus (also consumed by blackboard module — see §9).
+7. Fire `CONTEXT_CHANGED`.
+
+**Case definitions react via `contextChange(".actionGateRejected")`** — same pattern as
+`workItemEscalated`. Case definitions using consequential workers **must** include a rejection
+handler binding. If no binding reacts, the case stalls — this is the same behaviour as any
+unhandled context change. There is no engine fallback in v1. Document as a required convention.
+
+**`ActionGateExpiredHandler`** — same shape as rejected: `workerStatusListener.onWorkerCompleted(faulted)`,
+write `actionGateExpired` to context, fire `ACTION_GATE_EXPIRED`, fire `CONTEXT_CHANGED`.
+
+---
+
+### 8. Case termination with pending gate
+
+`CaseStatusChangedHandler.onCaseStatusChangedHandler()` already handles terminal transitions
+(COMPLETED, FAULTED, CANCELLED). Add: if `instance.getPendingActionGate() != null` at termination
+time, publish `ActionGateCancelledEvent(caseId, gateId)`.
+
+**`ActionGateCancelledHandler`** in work-adapter: receives `ActionGateCancelledEvent`, looks up
+and cancels the gate WorkItem via `WorkItemService.cancel(callerRef)`. This prevents orphaned
+WorkItems resolving after case termination. If the WorkItem is already terminal (already approved
+or rejected before the case terminated), cancellation is a no-op.
+
+The gate approval/rejection handlers already include terminal state guards (§7) — if a WorkItem
+resolves after case termination (race condition), the handlers detect the terminal state and discard
+the deferred output.
+
+---
+
+### 9. Blackboard integration (new handlers in `casehub-engine-blackboard`)
+
+Gate rejection/expiry must mark the associated PlanItem terminal so `StageAutocompleteEvaluator`
+can complete the stage. The engine runtime does not depend on the blackboard module, so this is
+done via two new event bus handlers in `casehub-engine-blackboard`:
+
+**`ActionGateRejectedPlanItemHandler`** — `@ConsumeEvent(ACTION_GATE_REJECTED, blocking=true)`:
+- Finds the `CasePlanModel` for `caseId` in `BlackboardRegistry`.
+- Locates the PlanItem by `workerId` (the worker whose action was rejected).
+- Calls `item.markFaulted()` — gate rejection is a terminal failure for the worker.
+- Saves via `PlanItemStore`.
+- `StageAutocompleteEvaluator` fires on the next CONTEXT_CHANGED (which the engine runtime fires).
+
+**`ActionGateExpiredPlanItemHandler`** — same shape for expiry.
+
+Gate approval is handled automatically: re-publishing `WorkflowExecutionCompleted` to
+`WORKER_EXECUTION_FINISHED` triggers `PlanItemCompletionHandler` (already in the blackboard), which
+marks the PlanItem COMPLETED. No new handler needed for the approval path.
+
+---
+
+### 10. EventLog payload structures
+
+All gate events use `EventStreamType.CASE`.
+
+**`ACTION_GATE_PENDING` payload:**
+```json
+{
+  "gateId": 12345,
+  "workerId": "risk-analysis-worker",
+  "idempotency": "abc123hash",
+  "deferredOutput": { "riskScore": 0.87, "recommendation": "APPROVE" },
+  "plannedAction": {
+    "description": "File SAR for account ACC-123",
+    "actionType": "sar.file",
+    "context": { "accountId": "ACC-123", "amount": 50000, "currency": "GBP" }
+  },
+  "gateRequired": {
+    "reason": "SAR submission to regulator — MLRO sign-off required",
+    "reversible": false,
+    "candidateGroups": ["mlro", "senior-analyst"],
+    "expiresInSeconds": 86400,
+    "scope": "casehubio/aml/sar-submission"
+  }
+}
+```
+
+**`ACTION_GATE_APPROVED` payload:**
+```json
+{
+  "gateId": 12345,
+  "workerId": "risk-analysis-worker",
+  "approvedBy": "user-mlro-001",
+  "resolution": "{\"approverNote\": \"Evidence reviewed and approved for submission\"}"
+}
+```
+
+`approvedBy` is sourced from `workItem.assignee` — the user who claimed and completed the WorkItem.
+If null (completed without explicit claim), the handler falls back to parsing
+`resolution.completedBy` if present, otherwise omits the field. For AML compliance, MLROs must
+claim the WorkItem before completing it; null `assignee` on a SAR approval WorkItem should be
+logged as a data integrity warning.
+
+**`ACTION_GATE_REJECTED` payload:**
+```json
+{
+  "gateId": 12345,
+  "workerId": "risk-analysis-worker",
+  "rejectedBy": "user-mlro-001",
+  "resolution": "{\"reason\": \"Insufficient evidence — request further investigation\"}"
+}
+```
+
+`rejectedBy` follows the same sourcing rule as `approvedBy`: `workItem.assignee`, fallback to
+`resolution.completedBy`.
+
+**`ACTION_GATE_EXPIRED` payload:**
+```json
+{
+  "gateId": 12345,
+  "workerId": "risk-analysis-worker",
+  "expiresAt": "2026-06-06T10:00:00Z"
+}
+```
+
+---
+
+### 11. New event types
+
+Added to `CaseHubEventType`:
+
+```java
+ACTION_GATE_PENDING,
+ACTION_GATE_APPROVED,
+ACTION_GATE_REJECTED,
+ACTION_GATE_EXPIRED,
+ACTION_GATE_CANCELLED,
+```
+
+---
+
+### 12. New event bus addresses
+
+Added to `EventBusAddresses`:
+
+```java
+ACTION_GATE_SCHEDULE   = "action-gate.schedule"
+ACTION_GATE_APPROVED   = "action-gate.approved"
+ACTION_GATE_REJECTED   = "action-gate.rejected"
+ACTION_GATE_EXPIRED    = "action-gate.expired"
+ACTION_GATE_CANCELLED  = "action-gate.cancelled"
+```
+
+---
+
+### 13. Deployment constraint and startup warning
+
+Returning `GateRequired` requires `casehub-work-adapter` on the classpath. If absent,
+`ActionGateScheduleEvent` fires with no handler — the case stalls. The default classifier always
+returns `Autonomous`, so deployments without work-adapter are not broken by default.
+
+**Startup warning:** A `@Singleton @Startup` observer in the engine runtime checks:
+- Are any `@RiskClassifier ActionRiskClassifier` beans registered? (`!classifiers.isUnsatisfied()`)
+  This is true only when a consumer has provided at least one qualified classifier — the chain
+  itself does not carry `@RiskClassifier`, and there is no `@DefaultBean` fallback.
+- Is `WorkItemService` unavailable? (`Instance<WorkItemService>.isUnsatisfied()`)
+- If both true: log `WARN("ActionRiskClassifier beans detected but casehub-work-adapter is not " +
+  "on the classpath. GateRequired decisions will stall indefinitely.")`
+
+---
+
+### 14. Testing strategy
+
+**Unit tests (no container):**
+- `ChainedReactiveActionRiskClassifier`: empty chain → Autonomous; single classifier; two
+  classifiers — Autonomous + Autonomous → Autonomous; Autonomous + GateRequired → GateRequired;
+  GateRequired + GateRequired → merged (most restrictive candidateGroups, shorter expiresIn)
+- `WorkflowExecutionCompletedHandler`: plannedAction=null → existing path (no classify);
+  plannedAction + Autonomous → existing path; plannedAction + GateRequired → gate path
+  (verify EventLog written, pendingActionGate set, no CONTEXT_CHANGED published)
+- `ActionGateApprovedHandler`: re-fires WorkflowExecutionCompleted with plannedAction=null;
+  terminal state guard (COMPLETED/FAULTED/CANCELLED → discards); null pendingActionGate → idempotent
+- `CallerRef.parse()`: pi format → PlanItemCallerRef; gate format → GateCallerRef; invalid → null
+
+**Integration tests** (`@QuarkusTest`, pattern from `SpiWiringIntegrationTest`):
+
+Gate wiring test — inner `@Alternative @Priority(1) @ApplicationScoped` classifier that records
+`classify()` calls, returns a static `GateRequired`. Verify:
+- `classify()` was called with the enriched `PlannedAction` (workerId and caseId non-null)
+- `ActionGateScheduleEvent` was published
+- `pendingActionGate` is set on the case
+- No `CONTEXT_CHANGED` was published
+
+Gate approval path — fire `ActionGateApprovedEvent` manually; verify deferred output applied to
+case context, `WORKER_EXECUTION_FINISHED` re-fired, PlanItem COMPLETED (if blackboard active).
+
+Gate rejection path — fire `ActionGateRejectedEvent`; verify `actionGateRejected` in case context,
+`workerStatusListener` called with FAULTED, PlanItem FAULTED (if blackboard active).
+
+**Work-adapter tests** (mock `WorkItemService` — no real casehub-work deployment needed):
+- `ActionGateWorkItemHandler`: creates WorkItem with correct callerRef, title, candidateGroups,
+  expiresAt, payload (full PlannedAction + reversible)
+- `WorkItemLifecycleAdapter` gate routing: gate callerRef routes to `ActionGateCompletionApplier`
+  BEFORE the blackboard guard; pi callerRef routes normally
+
+---
+
+### 15. Files changed
+
+**`api/` module:**
+- New: `model/WorkerResult.java`
+- New: `spi/PlannedAction.java`
+- New: `spi/RiskClassifier.java` (qualifier)
+- New: `spi/ActionRiskClassifier.java`
+- New: `spi/ReactiveActionRiskClassifier.java`
+- New: `spi/RiskDecision.java`
+- Changed: `model/event/CaseHubEventType.java` — add `ACTION_GATE_*` types
+- Changed: `model/ai/Agent.java` — `execute()` returns `WorkerResult`
+- Changed: `model/ai/AgentBuilder.java`
+
+**`common/` module:**
+- New: `internal/model/PendingActionGate.java`
+- New: `internal/event/ActionGateScheduleEvent.java`
+- New: `internal/event/ActionGateApprovedEvent.java`
+- New: `internal/event/ActionGateRejectedEvent.java`
+- New: `internal/event/ActionGateExpiredEvent.java`
+- New: `internal/event/ActionGateCancelledEvent.java`
+- Changed: `internal/model/CaseInstance.java` — `pendingActionGate` field
+- Changed: `internal/event/EventBusAddresses.java` — `ACTION_GATE_*` addresses
+
+**`engine/runtime/` module:**
+- New: `internal/worker/DefaultActionRiskClassifier.java` (`@DefaultBean @RiskClassifier @ApplicationScoped`)
+- New: `internal/worker/ChainedReactiveActionRiskClassifier.java` (`@ApplicationScoped`)
+- New: `internal/engine/handler/ActionGateApprovedHandler.java`
+- New: `internal/engine/handler/ActionGateRejectedHandler.java`
+- New: `internal/engine/handler/ActionGateExpiredHandler.java`
+- New: `internal/startup/ActionGateDeploymentHealthCheck.java` (startup warning)
+- Changed: `internal/engine/handler/WorkflowExecutionCompletedHandler.java`
+- Changed: `internal/engine/handler/CaseStatusChangedHandler.java` — cancel gate on termination
+
+**`scheduler-quartz/` module:**
+- Changed: `QuartzWorkerExecutionJob.java` — handle `WorkerResult`, pass `plannedAction`
+
+**`work-adapter/` module:**
+- New: `ActionGateWorkItemHandler.java`
+- New: `ActionGateCompletionApplier.java`
+- New: `ActionGateCancelledHandler.java`
+- Changed: `CallerRef.java` → sealed `CallerRef` interface + `PlanItemCallerRef` + `GateCallerRef`
+- Changed: `WorkItemLifecycleAdapter.java` — gate routing before blackboard guard + call site updates
+- Changed: `HumanTaskScheduleHandler.java` — `CallerRef.encode()` → `PlanItemCallerRef.encode()`
+- Changed: `HumanTaskRecoveryService.java` — same
+- Changed: all test files with `CallerRef` usage (~12 test call sites)
+
+**`casehub-engine-blackboard/` module:**
+- New: `ActionGateRejectedPlanItemHandler.java`
+- New: `ActionGateExpiredPlanItemHandler.java`
+
+**`persistence-hibernate/` module:**
+- Changed: `CaseInstanceEntity.java` — `pending_action_gate` nullable JSON column
+
+**`persistence-memory/` module:**
+- Changed: `InMemoryCaseInstanceRepository.java`
+
+**Protocols and docs:**
+- Updated: PP-20260514-engine-spi-noops-defaultbean — add `DefaultActionRiskClassifier` to table
+- Updated: `docs/CLAUDE.md` — document `ActionRiskClassifier` SPI, `@RiskClassifier` pattern,
+  `GateRequired` deployment constraint, concurrent gate v1 limitation
+
+---
+
+### 16. Deferred issues
+
+| Issue | Description |
+|-------|-------------|
+| Workflow PlannedAction support | Workflow workers return `WorkerResult.of(output)` in v1. Requires workflow DSL extension to declare intent mid-execution. |
+| Lightweight gate path without work-adapter | Qhorus oversight channel as alternative gate mechanism for deployments without casehub-work. |
+| Multi-gate support | v1 supports one pending gate per case. Multiple simultaneous gated workers requires `List<PendingActionGate>` and WorkItem-to-gate correlation rework. |
+| Consumer-provided ReactiveActionRiskClassifier | `ChainedReactiveActionRiskClassifier` is `@ApplicationScoped` without `@DefaultBean`, so there is no way for a consumer to displace it. Consumers with complex reactive classifiers that can't be expressed as blocking `ActionRiskClassifier` are blocked. If this use case arises, the chain could delegate to `@RiskClassifier ReactiveActionRiskClassifier` beans alongside blocking ones. |

--- a/ledger/src/test/java/io/casehub/ledger/service/CaseLedgerEventCaptureDisabledTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/service/CaseLedgerEventCaptureDisabledTest.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.ledger.service;
 
+import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.casehub.engine.common.spi.event.CaseLifecycleEvent;
@@ -54,7 +55,7 @@ class CaseLedgerEventCaptureDisabledTest {
   public static class DisabledProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      return Map.of("casehub.ledger.enabled", "false");
+      return WorkerResult.of(Map.of("casehub.ledger.enabled", "false"));
     }
   }
 }

--- a/ledger/src/test/java/io/casehub/ledger/service/CaseLedgerEventCaptureDisabledTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/service/CaseLedgerEventCaptureDisabledTest.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.ledger.service;
 
-import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.casehub.engine.common.spi.event.CaseLifecycleEvent;
@@ -55,7 +54,7 @@ class CaseLedgerEventCaptureDisabledTest {
   public static class DisabledProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      return WorkerResult.of(Map.of("casehub.ledger.enabled", "false"));
+      return Map.of("casehub.ledger.enabled", "false");
     }
   }
 }

--- a/ledger/src/test/java/io/casehub/ledger/service/WorkerDecisionEventCaptureDisabledTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/service/WorkerDecisionEventCaptureDisabledTest.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.ledger.service;
 
+import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.casehub.engine.common.spi.event.WorkerDecisionEvent;
@@ -54,7 +55,7 @@ class WorkerDecisionEventCaptureDisabledTest {
   public static class DisabledProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      return Map.of("casehub.ledger.enabled", "false");
+      return WorkerResult.of(Map.of("casehub.ledger.enabled", "false"));
     }
   }
 }

--- a/ledger/src/test/java/io/casehub/ledger/service/WorkerDecisionEventCaptureDisabledTest.java
+++ b/ledger/src/test/java/io/casehub/ledger/service/WorkerDecisionEventCaptureDisabledTest.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.ledger.service;
 
-import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.casehub.engine.common.spi.event.WorkerDecisionEvent;
@@ -55,7 +54,7 @@ class WorkerDecisionEventCaptureDisabledTest {
   public static class DisabledProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      return WorkerResult.of(Map.of("casehub.ledger.enabled", "false"));
+      return Map.of("casehub.ledger.enabled", "false");
     }
   }
 }

--- a/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/RlsIntegrationTest.java
+++ b/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/RlsIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.persistence.jpa;
 
+import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.agroal.api.AgroalDataSource;
@@ -81,13 +82,13 @@ class RlsIntegrationTest {
   public static class RlsProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      return Map.of(
+      return WorkerResult.of(Map.of(
           "casehub.rls.enabled", "true",
           // Use Hibernate DDL (not Flyway) so tables exist before RlsPolicyApplicator fires.
           // Flyway migrations run after @Priority(100) StartupEvent observers in Quarkus
           // test mode, causing "relation does not exist" errors when RLS tries to ALTER TABLE.
           "quarkus.hibernate-orm.schema-management.strategy", "drop-and-create",
-          "quarkus.flyway.migrate-at-start", "false");
+          "quarkus.flyway.migrate-at-start", "false"));
     }
   }
 

--- a/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/RlsIntegrationTest.java
+++ b/persistence-hibernate/src/test/java/io/casehub/persistence/jpa/RlsIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.persistence.jpa;
 
-import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.agroal.api.AgroalDataSource;
@@ -82,13 +81,13 @@ class RlsIntegrationTest {
   public static class RlsProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      return WorkerResult.of(Map.of(
+      return Map.of(
           "casehub.rls.enabled", "true",
           // Use Hibernate DDL (not Flyway) so tables exist before RlsPolicyApplicator fires.
           // Flyway migrations run after @Priority(100) StartupEvent observers in Quarkus
           // test mode, causing "relation does not exist" errors when RLS tries to ALTER TABLE.
           "quarkus.hibernate-orm.schema-management.strategy", "drop-and-create",
-          "quarkus.flyway.migrate-at-start", "false"));
+          "quarkus.flyway.migrate-at-start", "false");
     }
   }
 

--- a/resilience/src/test/java/io/casehub/resilience/NoOpLedgerEntryRepository.java
+++ b/resilience/src/test/java/io/casehub/resilience/NoOpLedgerEntryRepository.java
@@ -79,6 +79,11 @@ class NoOpLedgerEntryRepository implements LedgerEntryRepository {
   }
 
   @Override
+  public List<LedgerEntry> findEventsByActorId(String actorId) {
+    return List.of();
+  }
+
+  @Override
   public Map<UUID, List<LedgerAttestation>> findAttestationsForEntries(Set<UUID> entryIds) {
     return Map.of();
   }

--- a/resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterReplayServiceTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterReplayServiceTest.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.resilience.deadletter;
 
+import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -150,7 +151,7 @@ class DeadLetterReplayServiceTest {
             .capabilities(cap)
             .function(
                 (java.util.function.Function<Map<String, Object>, Map<String, Object>>)
-                    i -> Map.of())
+                    i -> WorkerResult.of(Map.of()))
             .build();
     CaseDefinition definition =
         CaseDefinition.builder()

--- a/resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterReplayServiceTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterReplayServiceTest.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.resilience.deadletter;
 
-import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -29,6 +28,7 @@ import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
@@ -149,9 +149,7 @@ class DeadLetterReplayServiceTest {
         Worker.builder()
             .name(workerId)
             .capabilities(cap)
-            .function(
-                (java.util.function.Function<Map<String, Object>, Map<String, Object>>)
-                    i -> WorkerResult.of(Map.of()))
+            .function(i -> WorkerResult.of(Map.of()))
             .build();
     CaseDefinition definition =
         CaseDefinition.builder()

--- a/resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.resilience.poison;
 
+import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -181,7 +182,7 @@ class PoisonPillIntegrationTest {
                   .function(
                       input -> {
                         runCount.incrementAndGet();
-                        return Map.of("status", "complete");
+                        return WorkerResult.of(Map.of("status", "complete"));
                       })
                   .executionPolicy(new ExecutionPolicy(5000, new RetryPolicy(1, 100)))
                   .build())

--- a/resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.resilience.poison;
 
-import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -31,6 +30,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.RetryPolicy;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerIntegrationTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.resilience.timeout;
 
+import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -166,7 +167,7 @@ class CaseTimeoutEnforcerIntegrationTest {
                         } catch (InterruptedException e) {
                           Thread.currentThread().interrupt();
                         }
-                        return Map.of();
+                        return WorkerResult.of(Map.of());
                       })
                   .executionPolicy(
                       // 30s per-execution timeout, 1 retry — budget expires at 1s, long before

--- a/resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerIntegrationTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.resilience.timeout;
 
-import io.casehub.api.model.WorkerResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -32,6 +31,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.RetryPolicy;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.internal.model.CaseInstance;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateApprovedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateApprovedHandler.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine.handler;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import io.casehub.engine.common.internal.event.ActionGateApprovedEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.engine.common.internal.event.WorkflowExecutionCompleted;
+import io.casehub.engine.common.internal.history.EventLog;
+import io.casehub.engine.common.internal.model.CaseInstance;
+import io.casehub.engine.common.internal.model.PendingActionGate;
+import io.casehub.engine.common.spi.CaseDefinitionRegistry;
+import io.casehub.engine.common.spi.EventLogRepository;
+import io.casehub.engine.common.spi.cache.CaseInstanceCache;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * Resolves an approved action gate by re-firing {@link WorkflowExecutionCompleted} with {@code
+ * plannedAction=null}, letting the normal completion machinery apply the deferred output, mark the
+ * PlanItem COMPLETED (via blackboard), and fire CONTEXT_CHANGED.
+ *
+ * <p>Uses {@link CaseInstanceCache} to access the live in-memory {@link CaseInstance} because
+ * {@code pendingActionGate} is an in-memory field — it is not persisted in the JPA entity, which
+ * only stores structural metadata (state, caseMetaModel, waitingForWorkId, etc.).
+ *
+ * <p>Terminal state guard: if the case is already COMPLETED/FAULTED/CANCELLED when approval
+ * arrives, the gate is cleared in memory and the deferred output discarded. Refs engine#402.
+ */
+@ApplicationScoped
+public class ActionGateApprovedHandler {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateApprovedHandler.class);
+
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject CaseDefinitionRegistry caseDefinitionRegistry;
+  @Inject EventLogRepository eventLogRepository;
+  @Inject EventBus eventBus;
+
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_APPROVED)
+  public Uni<Void> onActionGateApproved(final ActionGateApprovedEvent event) {
+    final CaseInstance instance = caseInstanceCache.get(event.caseId());
+    if (instance == null) {
+      LOG.warnf(
+          "CaseInstance not in cache for gate approval: caseId=%s gateId=%d — discarding",
+          event.caseId(), event.gateId());
+      return Uni.createFrom().voidItem();
+    }
+
+    // Terminal state guard — case terminated while gate was pending
+    if (isTerminal(instance.getState())) {
+      LOG.warnf(
+          "Gate approved on terminated case (state=%s): caseId=%s gateId=%d — discarding",
+          instance.getState(), event.caseId(), event.gateId());
+      instance.setPendingActionGate(null); // clear in-memory
+      return Uni.createFrom().voidItem();
+    }
+
+    final PendingActionGate gate = instance.getPendingActionGate();
+    if (gate == null || gate.gateId() != event.gateId()) {
+      LOG.warnf(
+          "PendingActionGate mismatch or absent: caseId=%s expected gateId=%d actual=%s — discarding",
+          event.caseId(), event.gateId(), gate != null ? gate.gateId() : "null");
+      return Uni.createFrom().voidItem();
+    }
+
+    // Write actionGateApproved signal so downstream bindings can observe the approval
+    instance
+        .getCaseContext()
+        .set(
+            "actionGateApproved",
+            Map.of(
+                "actionType", gate.plannedAction().actionType(),
+                "workerId", gate.workerId(),
+                "approvedBy", event.approvedBy() != null ? event.approvedBy() : "unknown",
+                "gateId", gate.gateId()));
+
+    instance.setPendingActionGate(null);
+
+    // Write compliance EventLog entry, then re-fire the completion event
+    return writeResolutionEventLog(instance, gate).invoke(() -> refireCompletion(instance, gate));
+  }
+
+  private void refireCompletion(final CaseInstance instance, final PendingActionGate gate) {
+    final Worker worker = findWorker(instance, gate.workerId());
+    if (worker == null) {
+      LOG.errorf(
+          "Worker '%s' not found in definition for caseId=%s — deferred output discarded",
+          gate.workerId(), instance.getUuid());
+      return;
+    }
+    // Re-fire WorkflowExecutionCompleted with plannedAction=null — normal completion path runs:
+    // output applied to context, PlanItem COMPLETED (via blackboard), CONTEXT_CHANGED fired.
+    eventBus.publish(
+        EventBusAddresses.WORKER_EXECUTION_FINISHED,
+        WorkflowExecutionCompleted.approved(
+            instance, worker, gate.idempotency(), gate.deferredOutput()));
+    LOG.infof(
+        "Gate approved — re-fired WorkflowExecutionCompleted: caseId=%s worker=%s gateId=%d",
+        instance.getUuid(), gate.workerId(), gate.gateId());
+  }
+
+  private Worker findWorker(final CaseInstance instance, final String workerId) {
+    final var def = caseDefinitionRegistry.getCaseDefinition(instance.getCaseMetaModel());
+    if (def == null) return null;
+    return def.getWorkers().stream()
+        .filter(w -> w.getName().equals(workerId))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private Uni<Void> writeResolutionEventLog(
+      final CaseInstance instance, final PendingActionGate gate) {
+    final EventLog log = new EventLog();
+    log.setCaseId(instance.getUuid());
+    log.setWorkerId(gate.workerId());
+    log.setStreamType(EventStreamType.CASE);
+    log.setTimestamp(Instant.now());
+    log.setEventType(CaseHubEventType.ACTION_GATE_APPROVED);
+    return eventLogRepository.append(log, instance.tenancyId);
+  }
+
+  private static boolean isTerminal(final CaseStatus state) {
+    return state == CaseStatus.COMPLETED
+        || state == CaseStatus.FAULTED
+        || state == CaseStatus.CANCELLED;
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
@@ -21,6 +21,7 @@ import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.api.spi.WorkerStatusListener;
 import io.casehub.engine.common.internal.event.ActionGateExpiredEvent;
+import io.casehub.engine.common.internal.event.ActionGateWorkerFaultedEvent;
 import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
 import io.casehub.engine.common.internal.history.EventLog;
@@ -101,6 +102,12 @@ public class ActionGateExpiredHandler {
     eventBus.publish(
         EventBusAddresses.CONTEXT_CHANGED,
         new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+
+    // Notify the blackboard to mark the PlanItem FAULTED (gate-specific event, not
+    // WORKER_RETRIES_EXHAUSTED)
+    eventBus.publish(
+        EventBusAddresses.ACTION_GATE_WORKER_FAULTED,
+        new ActionGateWorkerFaultedEvent(instance.getUuid(), gate.workerId(), gate.idempotency()));
 
     // EventLog write is best-effort — failures are logged, not propagated
     writeResolutionEventLog(instance, gate)

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
@@ -57,7 +57,8 @@ public class ActionGateExpiredHandler {
   @Inject EventBus eventBus;
   @Inject WorkerStatusListener workerStatusListener;
 
-  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_EXPIRED)
+  // blocking=true: workerStatusListener.onWorkerCompleted() may do I/O in consumer impls
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_EXPIRED, blocking = true)
   public Uni<Void> onActionGateExpired(final ActionGateExpiredEvent event) {
     final CaseInstance instance = caseInstanceCache.get(event.caseId());
     if (instance == null) {

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine.handler;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.WorkResult;
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import io.casehub.api.spi.WorkerStatusListener;
+import io.casehub.engine.common.internal.event.ActionGateExpiredEvent;
+import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.engine.common.internal.history.EventLog;
+import io.casehub.engine.common.internal.model.CaseInstance;
+import io.casehub.engine.common.internal.model.PendingActionGate;
+import io.casehub.engine.common.spi.EventLogRepository;
+import io.casehub.engine.common.spi.cache.CaseInstanceCache;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * Handles an expired action gate: clears {@code pendingActionGate}, writes {@code
+ * actionGateExpired} signal to the case context, notifies {@link WorkerStatusListener} that the
+ * worker faulted (deadline missed), and fires CONTEXT_CHANGED.
+ *
+ * <p>Uses {@link CaseInstanceCache} — {@code pendingActionGate} is an in-memory field not persisted
+ * by the JPA entity. CONTEXT_CHANGED fires immediately; EventLog write is fire-and-forget
+ * (best-effort compliance record). Refs engine#402.
+ */
+@ApplicationScoped
+public class ActionGateExpiredHandler {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateExpiredHandler.class);
+
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject EventLogRepository eventLogRepository;
+  @Inject EventBus eventBus;
+  @Inject WorkerStatusListener workerStatusListener;
+
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_EXPIRED)
+  public Uni<Void> onActionGateExpired(final ActionGateExpiredEvent event) {
+    final CaseInstance instance = caseInstanceCache.get(event.caseId());
+    if (instance == null) {
+      LOG.warnf(
+          "CaseInstance not in cache for gate expiry: caseId=%s gateId=%d — discarding",
+          event.caseId(), event.gateId());
+      return Uni.createFrom().voidItem();
+    }
+
+    if (isTerminal(instance.getState())) {
+      LOG.warnf(
+          "Gate expired on terminated case (state=%s): caseId=%s gateId=%d — discarding",
+          instance.getState(), event.caseId(), event.gateId());
+      return Uni.createFrom().voidItem();
+    }
+
+    final PendingActionGate gate = instance.getPendingActionGate();
+    if (gate == null || gate.gateId() != event.gateId()) {
+      LOG.warnf(
+          "PendingActionGate mismatch or absent: caseId=%s expected gateId=%d actual=%s"
+              + " — discarding",
+          event.caseId(), event.gateId(), gate != null ? gate.gateId() : "null");
+      return Uni.createFrom().voidItem();
+    }
+
+    // Clear gate FIRST — before writing signal (same ordering as rejected handler)
+    instance.setPendingActionGate(null);
+
+    instance
+        .getCaseContext()
+        .set(
+            "actionGateExpired",
+            Map.of(
+                "actionType", gate.plannedAction().actionType(),
+                "workerId", gate.workerId(),
+                "gateId", gate.gateId()));
+
+    workerStatusListener.onWorkerCompleted(
+        gate.workerId(),
+        WorkResult.faulted(gate.idempotency(), gate.workerId(), instance.getUuid()));
+
+    eventBus.publish(
+        EventBusAddresses.CONTEXT_CHANGED,
+        new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+
+    // EventLog write is best-effort — failures are logged, not propagated
+    writeResolutionEventLog(instance, gate)
+        .onFailure()
+        .invoke(
+            t ->
+                LOG.warnf(
+                    t,
+                    "ACTION_GATE_EXPIRED EventLog write failed: caseId=%s gateId=%d"
+                        + " — gate resolution still applied",
+                    instance.getUuid(),
+                    gate.gateId()))
+        .onFailure()
+        .recoverWithNull()
+        .subscribe()
+        .asCompletionStage();
+
+    return Uni.createFrom().voidItem();
+  }
+
+  private Uni<Void> writeResolutionEventLog(
+      final CaseInstance instance, final PendingActionGate gate) {
+    final EventLog log = new EventLog();
+    log.setCaseId(instance.getUuid());
+    log.setWorkerId(gate.workerId());
+    log.setStreamType(EventStreamType.CASE);
+    log.setTimestamp(Instant.now());
+    log.setEventType(CaseHubEventType.ACTION_GATE_EXPIRED);
+    return eventLogRepository.append(log, instance.tenancyId);
+  }
+
+  private static boolean isTerminal(final CaseStatus state) {
+    return state == CaseStatus.COMPLETED
+        || state == CaseStatus.FAULTED
+        || state == CaseStatus.CANCELLED;
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
@@ -64,7 +64,8 @@ public class ActionGateRejectedHandler {
   @Inject EventBus eventBus;
   @Inject WorkerStatusListener workerStatusListener;
 
-  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_REJECTED)
+  // blocking=true: workerStatusListener.onWorkerCompleted() may do I/O in consumer impls
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_REJECTED, blocking = true)
   public Uni<Void> onActionGateRejected(final ActionGateRejectedEvent event) {
     final CaseInstance instance = caseInstanceCache.get(event.caseId());
     if (instance == null) {

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine.handler;
+
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.WorkResult;
+import io.casehub.api.model.event.CaseHubEventType;
+import io.casehub.api.model.event.EventStreamType;
+import io.casehub.api.spi.WorkerStatusListener;
+import io.casehub.engine.common.internal.event.ActionGateRejectedEvent;
+import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.engine.common.internal.history.EventLog;
+import io.casehub.engine.common.internal.model.CaseInstance;
+import io.casehub.engine.common.internal.model.PendingActionGate;
+import io.casehub.engine.common.spi.EventLogRepository;
+import io.casehub.engine.common.spi.cache.CaseInstanceCache;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * Handles a rejected action gate: clears {@code pendingActionGate}, writes {@code
+ * actionGateRejected} signal to the case context, notifies {@link WorkerStatusListener} that the
+ * worker faulted, and fires CONTEXT_CHANGED.
+ *
+ * <p>Uses {@link CaseInstanceCache} — {@code pendingActionGate} is an in-memory field not persisted
+ * by the JPA entity.
+ *
+ * <p>Ordering: gate is cleared BEFORE the signal is set, preventing a race where the test observes
+ * the signal but not yet the cleared gate. EventLog write is best-effort — CONTEXT_CHANGED fires
+ * regardless of EventLog success.
+ *
+ * <p>Case definitions must include a {@code contextChange(".actionGateRejected")} binding. The
+ * blackboard module also consumes ACTION_GATE_REJECTED to mark the PlanItem FAULTED, enabling stage
+ * autocomplete. Refs engine#402.
+ */
+@ApplicationScoped
+public class ActionGateRejectedHandler {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateRejectedHandler.class);
+
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject EventLogRepository eventLogRepository;
+  @Inject EventBus eventBus;
+  @Inject WorkerStatusListener workerStatusListener;
+
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_REJECTED)
+  public Uni<Void> onActionGateRejected(final ActionGateRejectedEvent event) {
+    final CaseInstance instance = caseInstanceCache.get(event.caseId());
+    if (instance == null) {
+      LOG.warnf(
+          "CaseInstance not in cache for gate rejection: caseId=%s gateId=%d — discarding",
+          event.caseId(), event.gateId());
+      return Uni.createFrom().voidItem();
+    }
+
+    if (isTerminal(instance.getState())) {
+      LOG.warnf(
+          "Gate rejected on terminated case (state=%s): caseId=%s gateId=%d — discarding",
+          instance.getState(), event.caseId(), event.gateId());
+      return Uni.createFrom().voidItem();
+    }
+
+    final PendingActionGate gate = instance.getPendingActionGate();
+    if (gate == null || gate.gateId() != event.gateId()) {
+      LOG.warnf(
+          "PendingActionGate mismatch or absent: caseId=%s expected gateId=%d actual=%s"
+              + " — discarding",
+          event.caseId(), event.gateId(), gate != null ? gate.gateId() : "null");
+      return Uni.createFrom().voidItem();
+    }
+
+    // Clear gate FIRST — before setting signal — prevents observer-thread race where the
+    // rejectionSignal is visible in context before the gate field is cleared.
+    instance.setPendingActionGate(null);
+
+    // Write rejection signal — case definitions react via contextChange(".actionGateRejected")
+    instance
+        .getCaseContext()
+        .set(
+            "actionGateRejected",
+            Map.of(
+                "actionType",
+                gate.plannedAction().actionType(),
+                "workerId",
+                gate.workerId(),
+                "rejectedBy",
+                event.rejectedBy() != null ? event.rejectedBy() : "unknown",
+                "resolution",
+                event.workItemResolution() != null ? event.workItemResolution() : ""));
+
+    workerStatusListener.onWorkerCompleted(
+        gate.workerId(),
+        WorkResult.faulted(gate.idempotency(), gate.workerId(), instance.getUuid()));
+
+    // Fire CONTEXT_CHANGED immediately — gate is already cleared and signal written
+    eventBus.publish(
+        EventBusAddresses.CONTEXT_CHANGED,
+        new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+
+    // EventLog write is best-effort and fire-and-forget — failures are logged, not propagated
+    writeResolutionEventLog(instance, gate)
+        .onFailure()
+        .invoke(
+            t ->
+                LOG.warnf(
+                    t,
+                    "ACTION_GATE_REJECTED EventLog write failed: caseId=%s gateId=%d — gate"
+                        + " resolution still applied",
+                    instance.getUuid(),
+                    gate.gateId()))
+        .onFailure()
+        .recoverWithNull()
+        .subscribe()
+        .asCompletionStage();
+
+    return Uni.createFrom().voidItem();
+  }
+
+  private Uni<Void> writeResolutionEventLog(
+      final CaseInstance instance, final PendingActionGate gate) {
+    final EventLog log = new EventLog();
+    log.setCaseId(instance.getUuid());
+    log.setWorkerId(gate.workerId());
+    log.setStreamType(EventStreamType.CASE);
+    log.setTimestamp(Instant.now());
+    log.setEventType(CaseHubEventType.ACTION_GATE_REJECTED);
+    return eventLogRepository.append(log, instance.tenancyId);
+  }
+
+  private static boolean isTerminal(final CaseStatus state) {
+    return state == CaseStatus.COMPLETED
+        || state == CaseStatus.FAULTED
+        || state == CaseStatus.CANCELLED;
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
@@ -21,6 +21,7 @@ import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.api.spi.WorkerStatusListener;
 import io.casehub.engine.common.internal.event.ActionGateRejectedEvent;
+import io.casehub.engine.common.internal.event.ActionGateWorkerFaultedEvent;
 import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
 import io.casehub.engine.common.internal.history.EventLog;
@@ -116,6 +117,13 @@ public class ActionGateRejectedHandler {
     eventBus.publish(
         EventBusAddresses.CONTEXT_CHANGED,
         new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+
+    // Notify the blackboard (if active) to mark the PlanItem FAULTED so stage autocomplete fires.
+    // Uses ACTION_GATE_WORKER_FAULTED (not WORKER_RETRIES_EXHAUSTED) to avoid case-fault
+    // transition.
+    eventBus.publish(
+        EventBusAddresses.ACTION_GATE_WORKER_FAULTED,
+        new ActionGateWorkerFaultedEvent(instance.getUuid(), gate.workerId(), gate.idempotency()));
 
     // EventLog write is best-effort and fire-and-forget — failures are logged, not propagated
     writeResolutionEventLog(instance, gate)

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
@@ -92,6 +92,13 @@ public class CaseStatusChangedHandler {
                 caseChannelProvider
                     .listChannels(caseInstance.getUuid())
                     .forEach(caseChannelProvider::closeChannel);
+                // Cancel pending gate WorkItem if case terminates while gate is pending
+                if (caseInstance.getPendingActionGate() != null) {
+                  eventBus.publish(
+                      EventBusAddresses.ACTION_GATE_CANCELLED,
+                      new io.casehub.engine.common.internal.event.ActionGateCancelledEvent(
+                          caseInstance.getUuid(), caseInstance.getPendingActionGate().gateId()));
+                }
                 return schedulerService.cancelAllTriggers(caseInstance.getUuid());
               }
               return Uni.createFrom().voidItem();

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -27,13 +27,19 @@ import io.casehub.api.model.Worker;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.api.spi.ContextDiffStrategy;
+import io.casehub.api.spi.PlannedAction;
+import io.casehub.api.spi.ReactiveActionRiskClassifier;
+import io.casehub.api.spi.RiskDecision;
 import io.casehub.api.spi.WorkerStatusListener;
+import io.casehub.engine.common.internal.event.ActionGateScheduleEvent;
 import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
 import io.casehub.engine.common.internal.event.WorkflowExecutionCompleted;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.internal.model.CaseInstance;
+import io.casehub.engine.common.internal.model.PendingActionGate;
 import io.casehub.engine.common.spi.CaseDefinitionRegistry;
+import io.casehub.engine.common.spi.CaseInstanceRepository;
 import io.casehub.engine.common.spi.EventLogRepository;
 import io.casehub.engine.common.spi.event.CaseLifecycleEvent;
 import io.casehub.engine.common.spi.event.WorkerDecisionEvent;
@@ -65,6 +71,8 @@ public class WorkflowExecutionCompletedHandler {
   @Inject CaseResumptionService caseResumptionService;
   @Inject WorkerStatusListener workerStatusListener;
   @Inject LedgerTraceIdProvider traceIdProvider;
+  @Inject ReactiveActionRiskClassifier actionRiskClassifier;
+  @Inject CaseInstanceRepository caseInstanceRepository;
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Logger LOG = Logger.getLogger(WorkflowExecutionCompletedHandler.class);
@@ -74,6 +82,12 @@ public class WorkflowExecutionCompletedHandler {
     final String traceId = traceIdProvider.currentTraceId().orElse(null);
     final CaseInstance caseInstance = event.caseInstance();
     final Worker worker = event.worker();
+
+    // Gate fork: if the worker declared a PlannedAction, classify before applying output.
+    if (event.plannedAction() != null) {
+      return handleWithPlannedAction(event, traceId);
+    }
+
     final Map<String, Object> rawOutput = event.output() == null ? Map.of() : event.output();
     final Instant now = Instant.now();
 
@@ -166,6 +180,161 @@ public class WorkflowExecutionCompletedHandler {
                     "Failed to handle WorkflowExecutionCompleted for caseId: "
                         + caseInstance.getUuid(),
                     t));
+  }
+
+  private Uni<Void> handleWithPlannedAction(
+      final WorkflowExecutionCompleted event, final String traceId) {
+    final CaseInstance caseInstance = event.caseInstance();
+    final Worker worker = event.worker();
+    final PlannedAction plannedAction = event.plannedAction();
+
+    // v1 concurrent-gate constraint: only one pending gate per case.
+    if (caseInstance.getPendingActionGate() != null) {
+      LOG.errorf(
+          "Concurrent gate not supported in v1: caseId=%s worker=%s already has a pending gate"
+              + " — proceeding as Autonomous for second action",
+          caseInstance.getUuid(), worker.getName());
+      // Re-dispatch as if plannedAction was null so the normal completion path runs.
+      final WorkflowExecutionCompleted withoutAction =
+          WorkflowExecutionCompleted.approved(
+              caseInstance, worker, event.idempotency(), event.output());
+      return onWorkflowExecutionCompletedHandler(withoutAction);
+    }
+
+    return actionRiskClassifier
+        .classify(plannedAction)
+        .onFailure()
+        .recoverWithItem(
+            t -> {
+              LOG.errorf(
+                  t,
+                  "ActionRiskClassifier threw for action type='%s' caseId=%s — applying fail-safe"
+                      + " GateRequired",
+                  plannedAction.actionType(),
+                  caseInstance.getUuid());
+              return new RiskDecision.GateRequired(
+                  "Classifier error — manual review required before proceeding",
+                  true,
+                  null,
+                  null,
+                  null);
+            })
+        .chain(
+            decision -> {
+              if (decision instanceof RiskDecision.Autonomous) {
+                // Autonomous — proceed as if there was no PlannedAction.
+                final WorkflowExecutionCompleted withoutAction =
+                    WorkflowExecutionCompleted.approved(
+                        caseInstance, worker, event.idempotency(), event.output());
+                return onWorkflowExecutionCompletedHandler(withoutAction);
+              }
+              return handleGate(event, (RiskDecision.GateRequired) decision, traceId);
+            });
+  }
+
+  private Uni<Void> handleGate(
+      final WorkflowExecutionCompleted event,
+      final RiskDecision.GateRequired gate,
+      final String traceId) {
+    final CaseInstance caseInstance = event.caseInstance();
+    final Worker worker = event.worker();
+    final Map<String, Object> rawOutput = event.output() == null ? Map.of() : event.output();
+    final PlannedAction plannedAction = event.plannedAction();
+    final Instant now = Instant.now();
+
+    final EventLog gateEventLog =
+        buildGateEventLog(
+            caseInstance, worker, rawOutput, plannedAction, gate, event.idempotency(), now);
+
+    return eventLogRepository
+        .append(gateEventLog, caseInstance.tenancyId)
+        .chain(
+            () -> {
+              caseInstance.setPendingActionGate(
+                  new PendingActionGate(
+                      gateEventLog.id,
+                      worker.getName(),
+                      event.idempotency(),
+                      rawOutput,
+                      plannedAction));
+              return caseInstanceRepository.update(caseInstance, caseInstance.tenancyId);
+            })
+        .invoke(
+            () ->
+                eventBus.publish(
+                    EventBusAddresses.ACTION_GATE_SCHEDULE,
+                    new ActionGateScheduleEvent(
+                        caseInstance.getUuid(),
+                        caseInstance.tenancyId,
+                        gateEventLog.id,
+                        plannedAction,
+                        gate)))
+        .chain(
+            () ->
+                Uni.createFrom()
+                    .completionStage(
+                        () ->
+                            lifecycleEvents.fireAsync(
+                                new CaseLifecycleEvent(
+                                    caseInstance.getUuid(),
+                                    caseInstance.tenancyId,
+                                    "ActionGate",
+                                    "ActionGatePending",
+                                    caseInstance.getState().name(),
+                                    worker.getName(),
+                                    "WORKER",
+                                    traceId)))
+                    .onFailure()
+                    .recoverWithItem(
+                        t -> {
+                          LOG.warnf(
+                              t,
+                              "CaseLifecycleEvent observer failed for caseId=%s"
+                                  + " event=ActionGatePending",
+                              caseInstance.getUuid());
+                          return null;
+                        })
+                    .replaceWithVoid())
+        .replaceWithVoid()
+        .onFailure()
+        .invoke(
+            t ->
+                LOG.error("Failed to handle action gate for caseId: " + caseInstance.getUuid(), t));
+  }
+
+  private EventLog buildGateEventLog(
+      final CaseInstance caseInstance,
+      final Worker worker,
+      final Map<String, Object> rawOutput,
+      final PlannedAction plannedAction,
+      final RiskDecision.GateRequired gate,
+      final String idempotency,
+      final Instant timestamp) {
+    final EventLog eventLog = new EventLog();
+    eventLog.setCaseId(caseInstance.getUuid());
+    eventLog.setWorkerId(worker.getName());
+    eventLog.setStreamType(EventStreamType.CASE);
+    eventLog.setTimestamp(timestamp);
+    eventLog.setEventType(CaseHubEventType.ACTION_GATE_PENDING);
+    final ObjectNode payload = OBJECT_MAPPER.createObjectNode();
+    payload.put("workerId", worker.getName());
+    payload.put("idempotency", idempotency);
+    payload.set("deferredOutput", OBJECT_MAPPER.valueToTree(rawOutput));
+    final ObjectNode actionNode = OBJECT_MAPPER.createObjectNode();
+    actionNode.put("description", plannedAction.description());
+    actionNode.put("actionType", plannedAction.actionType());
+    actionNode.set("context", OBJECT_MAPPER.valueToTree(plannedAction.context()));
+    payload.set("plannedAction", actionNode);
+    final ObjectNode gateNode = OBJECT_MAPPER.createObjectNode();
+    gateNode.put("reason", gate.reason());
+    gateNode.put("reversible", gate.reversible());
+    if (gate.expiresIn() != null) {
+      gateNode.put("expiresInSeconds", gate.expiresIn().getSeconds());
+    }
+    payload.set("gateRequired", gateNode);
+    eventLog.setPayload(payload);
+    eventLog.setMetadata(OBJECT_MAPPER.createObjectNode().put("inputDataHash", idempotency));
+    return eventLog;
   }
 
   private EventLog buildEventLog(

--- a/runtime/src/main/java/io/casehub/engine/internal/startup/ActionGateDeploymentHealthCheck.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/startup/ActionGateDeploymentHealthCheck.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.startup;
+
+import io.casehub.api.spi.ActionRiskClassifier;
+import io.casehub.api.spi.RiskClassifier;
+import io.quarkus.runtime.Startup;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+/**
+ * Startup check that warns if consumer-provided {@link ActionRiskClassifier} beans are registered
+ * but {@code casehub-engine-work-adapter} is not on the classpath.
+ *
+ * <p>If a classifier returns {@link io.casehub.api.spi.RiskDecision.GateRequired} without
+ * work-adapter present, the gate WorkItem is never created and the case stalls indefinitely. The
+ * warning appears in logs at startup so operators can fix the configuration before it causes
+ * production incidents.
+ *
+ * <p>Detection: uses CDI {@link Instance} unsatisfied check rather than classpath scanning —
+ * work-adapter provides {@code ActionGateWorkItemHandler} which injects {@code WorkItemService}. If
+ * {@code WorkItemService} is absent (unsatisfied), work-adapter is not on the classpath.
+ */
+@Startup
+@ApplicationScoped
+public class ActionGateDeploymentHealthCheck {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateDeploymentHealthCheck.class);
+
+  @Inject @RiskClassifier Instance<ActionRiskClassifier> classifiers;
+
+  /**
+   * Checks at startup whether a misconfigured deployment would silently stall cases.
+   *
+   * <p>The check runs once at application start. No-op when either: (a) no consumer classifiers are
+   * registered (the chain returns Autonomous — no gates possible), or (b) work-adapter is on the
+   * classpath.
+   */
+  public void checkConfiguration() {
+    if (classifiers.isUnsatisfied()) {
+      return; // No @RiskClassifier beans — always Autonomous, no gate possible
+    }
+
+    // Consumer classifiers present — verify work-adapter is available.
+    // We detect work-adapter by looking for the ActionGateWorkItemHandler class, which is only
+    // present when casehub-engine-work-adapter is on the classpath.
+    try {
+      Class.forName(
+          "io.casehub.workadapter.ActionGateWorkItemHandler",
+          false,
+          Thread.currentThread().getContextClassLoader());
+    } catch (ClassNotFoundException e) {
+      LOG.warn(
+          "CONFIGURATION WARNING: ActionRiskClassifier beans are registered but"
+              + " casehub-engine-work-adapter is NOT on the classpath. If any classifier returns"
+              + " GateRequired, the gate WorkItem will never be created and the case will stall"
+              + " indefinitely. Add casehub-engine-work-adapter to your deployment dependencies.");
+    }
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/startup/ActionGateDeploymentHealthCheck.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/startup/ActionGateDeploymentHealthCheck.java
@@ -18,6 +18,7 @@ package io.casehub.engine.internal.startup;
 import io.casehub.api.spi.ActionRiskClassifier;
 import io.casehub.api.spi.RiskClassifier;
 import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -51,6 +52,7 @@ public class ActionGateDeploymentHealthCheck {
    * registered (the chain returns Autonomous — no gates possible), or (b) work-adapter is on the
    * classpath.
    */
+  @PostConstruct
   public void checkConfiguration() {
     if (classifiers.isUnsatisfied()) {
       return; // No @RiskClassifier beans — always Autonomous, no gate possible

--- a/runtime/src/main/java/io/casehub/engine/internal/worker/ChainedReactiveActionRiskClassifier.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/worker/ChainedReactiveActionRiskClassifier.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.worker;
+
+import io.casehub.api.spi.ActionRiskClassifier;
+import io.casehub.api.spi.PlannedAction;
+import io.casehub.api.spi.ReactiveActionRiskClassifier;
+import io.casehub.api.spi.RiskClassifier;
+import io.casehub.api.spi.RiskDecision;
+import io.casehub.api.spi.RiskDecision.Autonomous;
+import io.casehub.api.spi.RiskDecision.GateRequired;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.stream.StreamSupport;
+import org.jboss.logging.Logger;
+
+/**
+ * Chains all {@link RiskClassifier}-qualified {@link ActionRiskClassifier} beans and returns the
+ * most restrictive {@link RiskDecision}.
+ *
+ * <p>When no consumer has registered a {@code @RiskClassifier} classifier, {@link #isUnsatisfied}
+ * returns true and the method returns {@link Autonomous} immediately — the chain IS the default.
+ *
+ * <p>Blocking classifiers (DB queries, external API calls) are offloaded to the worker thread pool
+ * via {@link Infrastructure#getDefaultWorkerPool()} to avoid blocking the Vert.x IO thread.
+ *
+ * <p>If any classifier throws, the fail-safe {@link GateRequired} is returned immediately — the
+ * action is gated for manual review. Fail-safe is required for AML/clinical compliance: a
+ * classifier failure must not permit a consequential action to proceed autonomously.
+ *
+ * <p>"Most restrictive" = fewest {@code candidateGroups}; tie → shorter {@code expiresIn}; tie →
+ * CDI iteration order (first wins). Union semantics are intentionally rejected: ["mlro"] ∪
+ * ["physician"] = ["mlro", "physician"] would allow a physician to approve a SAR filing they have
+ * no authority over.
+ */
+@ApplicationScoped
+public class ChainedReactiveActionRiskClassifier implements ReactiveActionRiskClassifier {
+
+  private static final Logger LOG = Logger.getLogger(ChainedReactiveActionRiskClassifier.class);
+
+  static final GateRequired FAIL_SAFE =
+      new GateRequired(
+          "Classifier error — manual review required before proceeding", true, null, null, null);
+
+  @Inject @RiskClassifier Instance<ActionRiskClassifier> classifiers;
+
+  @Override
+  public Uni<RiskDecision> classify(final PlannedAction action) {
+    if (classifiers.isUnsatisfied()) {
+      return Uni.createFrom().item(new Autonomous());
+    }
+    return Uni.createFrom()
+        .item(
+            () -> {
+              try {
+                return StreamSupport.stream(classifiers.spliterator(), false)
+                    .map(c -> c.classify(action))
+                    .reduce(new Autonomous(), this::mostRestrictive);
+              } catch (final Exception e) {
+                LOG.errorf(
+                    e,
+                    "ActionRiskClassifier threw for action type='%s' workerId='%s' caseId=%s — "
+                        + "applying fail-safe GateRequired",
+                    action.actionType(),
+                    action.workerId(),
+                    action.caseId());
+                return FAIL_SAFE;
+              }
+            })
+        .runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+  }
+
+  private RiskDecision mostRestrictive(final RiskDecision a, final RiskDecision b) {
+    if (!(b instanceof GateRequired gb)) return a;
+    if (!(a instanceof GateRequired ga)) return b;
+    return narrower(ga, gb);
+  }
+
+  /**
+   * Returns whichever gate is more restrictive (narrows the set of eligible approvers).
+   *
+   * <p>Fewer {@code candidateGroups} = more restrictive (a non-null group list with N members beats
+   * null, which means "no restriction" = {@link Integer#MAX_VALUE} effective groups).
+   */
+  private GateRequired narrower(final GateRequired a, final GateRequired b) {
+    final int sizeA = a.candidateGroups() == null ? Integer.MAX_VALUE : a.candidateGroups().size();
+    final int sizeB = b.candidateGroups() == null ? Integer.MAX_VALUE : b.candidateGroups().size();
+    if (sizeA != sizeB) return sizeA < sizeB ? a : b;
+    // Equal group count: a deadline is more restrictive than no deadline; shorter beats longer.
+    if (a.expiresIn() != null && b.expiresIn() != null) {
+      return a.expiresIn().compareTo(b.expiresIn()) <= 0 ? a : b;
+    }
+    if (a.expiresIn() != null) return a;
+    if (b.expiresIn() != null) return b;
+    return a; // tie → CDI iteration order (first wins)
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
@@ -101,7 +101,14 @@ class ActionGateIntegrationTest {
 
     final UUID caseId = startCase();
 
-    await().atMost(5, TimeUnit.SECONDS).until(() -> !CapturingClassifier.capturedActions.isEmpty());
+    // Wait for THIS case's gate specifically — not any classifier action (cross-test contamination)
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              final var inst = caseInstanceCache.get(caseId);
+              return inst != null && inst.getPendingActionGate() != null;
+            });
 
     // Case must NOT complete — gate is pending
     assertThat(caseInstanceCache.get(caseId).getState()).isEqualTo(CaseStatus.RUNNING);
@@ -185,11 +192,19 @@ class ActionGateIntegrationTest {
 
     final UUID caseId = startCase();
 
+    // Wait for THIS case's classifier to fire specifically
     await()
         .atMost(10, TimeUnit.SECONDS)
-        .until(() -> !CapturingClassifier.capturedActions.isEmpty());
+        .until(
+            () ->
+                CapturingClassifier.capturedActions.stream()
+                    .anyMatch(a -> caseId.equals(a.caseId())));
 
-    final PlannedAction action = CapturingClassifier.capturedActions.get(0);
+    final PlannedAction action =
+        CapturingClassifier.capturedActions.stream()
+            .filter(a -> caseId.equals(a.caseId()))
+            .findFirst()
+            .orElseThrow();
     assertThat(action.workerId()).isEqualTo("gate-worker");
     assertThat(action.caseId()).isEqualTo(caseId);
     assertThat(action.description()).isEqualTo("File SAR report");

--- a/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
@@ -224,7 +224,12 @@ class ActionGateIntegrationTest {
           .bindings(
               Binding.builder()
                   .name("gate-binding")
-                  .on(new ContextChangeTrigger(".filingResult == null"))
+                  // Prevent re-triggering while gate is pending (deferred output not applied)
+                  .on(
+                      new ContextChangeTrigger(
+                          ".filingResult == null and .actionGateApproved == null"
+                              + " and .actionGateRejected == null"
+                              + " and .actionGateExpired == null"))
                   .target(new CapabilityTarget(cap))
                   .build())
           .goals(goal)

--- a/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
@@ -117,6 +117,52 @@ class ActionGateIntegrationTest {
   }
 
   @Test
+  void concurrentGate_secondPlannedActionProceedsAutonomous_firstGatePreserved() {
+    // v1 constraint: when a second PlannedAction arrives while a gate is pending,
+    // the engine logs ERROR and proceeds as Autonomous for the second action.
+    // The second action bypasses classification — a known compliance risk documented in
+    // CaseInstance.
+    // This test verifies the constraint is enforced and the first gate is not corrupted.
+    CapturingClassifier.nextDecision =
+        new GateRequired("SAR filing requires MLRO sign-off", false, List.of("mlro"), null, null);
+    GateCaseHub.declareAction.set(true);
+
+    final UUID caseId = startCase();
+
+    // Wait for first gate to fire
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              final var inst = caseInstanceCache.get(caseId);
+              return inst != null && inst.getPendingActionGate() != null;
+            });
+
+    final long firstGateId = caseInstanceCache.get(caseId).getPendingActionGate().gateId();
+
+    // Now switch to Autonomous so the second worker execution (if triggered) would return
+    // Autonomous
+    // The concurrent gate detection fires before classify() — second action bypasses classification
+    CapturingClassifier.nextDecision = new RiskDecision.Autonomous();
+
+    // Wait briefly — if the binding re-triggers, the concurrent gate path fires
+    // The case must still be RUNNING (gate still pending) and first gate must not be replaced
+    await()
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              final var inst = caseInstanceCache.get(caseId);
+              // Gate must still be pending — second action proceeds as Autonomous but does not
+              // replace the first gate or complete the case (the binding guards prevent re-trigger)
+              assertThat(inst.getState()).isEqualTo(CaseStatus.RUNNING);
+              if (inst.getPendingActionGate() != null) {
+                // If gate still set, it must be the FIRST one
+                assertThat(inst.getPendingActionGate().gateId()).isEqualTo(firstGateId);
+              }
+            });
+  }
+
+  @Test
   void nullPlannedAction_classifierNotCalled_caseCompletes() {
     GateCaseHub.declareAction.set(false); // worker returns WorkerResult without PlannedAction
 

--- a/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CapabilityTarget;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
+import io.casehub.api.spi.ActionRiskClassifier;
+import io.casehub.api.spi.PlannedAction;
+import io.casehub.api.spi.RiskClassifier;
+import io.casehub.api.spi.RiskDecision;
+import io.casehub.api.spi.RiskDecision.Autonomous;
+import io.casehub.api.spi.RiskDecision.GateRequired;
+import io.casehub.engine.common.spi.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the ActionRiskClassifier gate fork in WorkflowExecutionCompletedHandler.
+ *
+ * <p>Verifies: Autonomous path proceeds normally; GateRequired path blocks case advancement; the
+ * classifier receives a fully enriched PlannedAction; null PlannedAction bypasses the classifier.
+ */
+@QuarkusTest
+class ActionGateIntegrationTest {
+
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject GateCaseHub gateCaseHub;
+
+  @BeforeEach
+  void resetBeans() {
+    CapturingClassifier.reset();
+    GateCaseHub.declareAction.set(false);
+  }
+
+  // --- Tests ---
+
+  @Test
+  void autonomousDecision_caseCompletesNormally() {
+    CapturingClassifier.nextDecision = new Autonomous();
+    GateCaseHub.declareAction.set(true);
+
+    final UUID caseId = startCase();
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .isEqualTo(CaseStatus.COMPLETED));
+
+    assertThat(CapturingClassifier.capturedActions).hasSize(1);
+    final PlannedAction action = CapturingClassifier.capturedActions.get(0);
+    assertThat(action.actionType()).isEqualTo("sar.file");
+    assertThat(action.workerId()).isNotNull();
+    assertThat(action.caseId()).isEqualTo(caseId);
+  }
+
+  @Test
+  void gateRequiredDecision_caseRemainsRunning_gateIsPending() {
+    CapturingClassifier.nextDecision =
+        new GateRequired("SAR filing requires MLRO sign-off", false, List.of("mlro"), null, null);
+    GateCaseHub.declareAction.set(true);
+
+    final UUID caseId = startCase();
+
+    await().atMost(5, TimeUnit.SECONDS).until(() -> !CapturingClassifier.capturedActions.isEmpty());
+
+    // Case must NOT complete — gate is pending
+    assertThat(caseInstanceCache.get(caseId).getState()).isEqualTo(CaseStatus.RUNNING);
+    // pendingActionGate must be set
+    assertThat(caseInstanceCache.get(caseId).getPendingActionGate()).isNotNull();
+    assertThat(caseInstanceCache.get(caseId).getPendingActionGate().gateId()).isPositive();
+    assertThat(caseInstanceCache.get(caseId).getPendingActionGate().workerId())
+        .isEqualTo("gate-worker");
+    assertThat(caseInstanceCache.get(caseId).getPendingActionGate().deferredOutput())
+        .containsKey("filingResult");
+    assertThat(caseInstanceCache.get(caseId).getPendingActionGate().plannedAction().actionType())
+        .isEqualTo("sar.file");
+  }
+
+  @Test
+  void nullPlannedAction_classifierNotCalled_caseCompletes() {
+    GateCaseHub.declareAction.set(false); // worker returns WorkerResult without PlannedAction
+
+    final UUID caseId = startCase();
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .isEqualTo(CaseStatus.COMPLETED));
+
+    assertThat(CapturingClassifier.capturedActions).isEmpty();
+  }
+
+  @Test
+  void classifierReceivesEnrichedPlannedAction_workerIdAndCaseIdPopulated() {
+    CapturingClassifier.nextDecision = new Autonomous();
+    GateCaseHub.declareAction.set(true);
+
+    final UUID caseId = startCase();
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .until(() -> !CapturingClassifier.capturedActions.isEmpty());
+
+    final PlannedAction action = CapturingClassifier.capturedActions.get(0);
+    assertThat(action.workerId()).isEqualTo("gate-worker");
+    assertThat(action.caseId()).isEqualTo(caseId);
+    assertThat(action.description()).isEqualTo("File SAR report");
+    assertThat(action.context()).containsEntry("accountId", "ACC-999");
+  }
+
+  // --- Test CDI beans ---
+
+  /**
+   * Configurable classifier — returns Autonomous by default; tests set nextDecision before starting
+   * a case.
+   */
+  @RiskClassifier
+  @Alternative
+  @Priority(1)
+  @ApplicationScoped
+  static class CapturingClassifier implements ActionRiskClassifier {
+
+    static final List<PlannedAction> capturedActions = new CopyOnWriteArrayList<>();
+    static volatile RiskDecision nextDecision = new Autonomous();
+
+    static void reset() {
+      capturedActions.clear();
+      nextDecision = new Autonomous();
+    }
+
+    @Override
+    public RiskDecision classify(final PlannedAction action) {
+      capturedActions.add(action);
+      return nextDecision;
+    }
+  }
+
+  /**
+   * Configurable CaseHub bean. When {@code declareAction=true} the worker includes a PlannedAction;
+   * otherwise it returns a plain WorkerResult.
+   */
+  @ApplicationScoped
+  static class GateCaseHub extends CaseHub {
+
+    static final AtomicBoolean declareAction = new AtomicBoolean(false);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      final Capability cap =
+          Capability.builder()
+              .name("file-sar-gate-test")
+              .inputSchema(".")
+              .outputSchema(".")
+              .build();
+      final Goal goal =
+          Goal.builder()
+              .name("filed")
+              .kind(GoalKind.SUCCESS)
+              .condition(".filingResult != null")
+              .build();
+      return CaseDefinition.builder()
+          .namespace("test-action-gate")
+          .name("Gate Integration Case")
+          .version("1.0.0")
+          .capabilities(cap)
+          .workers(
+              Worker.builder()
+                  .name("gate-worker")
+                  .capabilities(cap)
+                  .function(
+                      input -> {
+                        final Map<String, Object> output = Map.of("filingResult", "pending");
+                        if (declareAction.get()) {
+                          return WorkerResult.of(
+                              output,
+                              PlannedAction.of(
+                                  "File SAR report", "sar.file", Map.of("accountId", "ACC-999")));
+                        }
+                        return WorkerResult.of(output);
+                      })
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("gate-binding")
+                  .on(new ContextChangeTrigger(".filingResult == null"))
+                  .target(new CapabilityTarget(cap))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+
+  // --- Helpers ---
+
+  private UUID startCase() {
+    final AtomicReference<UUID> ref = new AtomicReference<>();
+    gateCaseHub.startCase(Map.of()).thenAccept(ref::set);
+    await().atMost(5, TimeUnit.SECONDS).until(() -> ref.get() != null);
+    return ref.get();
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/ActionGateResolutionTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ActionGateResolutionTest.java
@@ -272,11 +272,11 @@ class ActionGateResolutionTest {
 
   /**
    * Registers event bus codecs for gate resolution event types. Without @ConsumeEvent handlers,
-   * Quarkus doesn't register codecs for these types and publish() fails. These stubs exist only to
-   * register codecs; the real handlers (ActionGateApprovedHandler etc.) process the events.
+   * Quarkus doesn't register codecs for these types and publish() fails.
    *
-   * <p>When the real handlers are implemented, they will also register the codecs and these stubs
-   * become redundant — but harmless (multiple consumers receive the same event).
+   * <p>The real handlers (ActionGateApprovedHandler, ActionGateRejectedHandler, etc.) also consume
+   * these addresses and register their own codecs. These stubs coexist as additional consumers —
+   * Vert.x publish() fan-out means all consumers receive the event.
    */
   @ApplicationScoped
   static class GateCodecStubs {

--- a/runtime/src/test/java/io/casehub/engine/ActionGateResolutionTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ActionGateResolutionTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CapabilityTarget;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.ContextChangeTrigger;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
+import io.casehub.api.spi.ActionRiskClassifier;
+import io.casehub.api.spi.PlannedAction;
+import io.casehub.api.spi.RiskClassifier;
+import io.casehub.api.spi.RiskDecision;
+import io.casehub.api.spi.RiskDecision.GateRequired;
+import io.casehub.engine.common.internal.event.ActionGateApprovedEvent;
+import io.casehub.engine.common.internal.event.ActionGateRejectedEvent;
+import io.casehub.engine.common.internal.event.ActionGateScheduleEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.engine.common.spi.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.vertx.ConsumeEvent;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for gate resolution handlers — ActionGateApprovedHandler,
+ * ActionGateRejectedHandler, ActionGateExpiredHandler.
+ *
+ * <p>The work-adapter module is not on the runtime test classpath, so tests manually publish
+ * ActionGate*Event on the Vert.x event bus (simulating what ActionGateCompletionApplier would do
+ * after a human approves/rejects the gate WorkItem).
+ */
+@QuarkusTest
+class ActionGateResolutionTest {
+
+  @Inject CaseInstanceCache caseInstanceCache;
+  @Inject EventBus eventBus;
+  @Inject ResolutionCaseHub resolutionCaseHub;
+
+  @BeforeEach
+  void resetBeans() {
+    ResolutionClassifier.reset();
+    ResolutionCaseHub.declareAction.set(true);
+  }
+
+  @Test
+  void gateApproved_caseCompletes_deferredOutputApplied() {
+    ResolutionClassifier.nextDecision =
+        new GateRequired("SAR filing", false, List.of("mlro"), null, null);
+
+    final UUID caseId = startCase();
+
+    // Wait for gate to fire and pendingActionGate to be set
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              final var inst = caseInstanceCache.get(caseId);
+              return inst != null && inst.getPendingActionGate() != null;
+            });
+
+    final long gateId = caseInstanceCache.get(caseId).getPendingActionGate().gateId();
+
+    // Simulate work-adapter publishing ActionGateApprovedEvent after human approves
+    eventBus.publish(
+        EventBusAddresses.ACTION_GATE_APPROVED,
+        new ActionGateApprovedEvent(
+            caseId, gateId, "{\"approverNote\": \"approved\"}", "mlro-user"));
+
+    // Case should now complete — approved handler re-fires WorkflowExecutionCompleted
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .isEqualTo(CaseStatus.COMPLETED));
+
+    // pendingActionGate must be cleared
+    assertThat(caseInstanceCache.get(caseId).getPendingActionGate()).isNull();
+    // deferred output must be in case context
+    assertThat(caseInstanceCache.get(caseId).getCaseContext().get("gateWorkerOutput")).isNotNull();
+    // actionGateApproved signal must be in case context
+    assertThat(caseInstanceCache.get(caseId).getCaseContext().get("actionGateApproved"))
+        .isNotNull();
+  }
+
+  @Test
+  void gateRejected_caseRemainsRunning_rejectionSignalInContext() {
+    ResolutionClassifier.nextDecision =
+        new GateRequired("SAR filing", false, List.of("mlro"), null, null);
+
+    final UUID caseId = startCase();
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              final var inst = caseInstanceCache.get(caseId);
+              return inst != null && inst.getPendingActionGate() != null;
+            });
+
+    final long gateId = caseInstanceCache.get(caseId).getPendingActionGate().gateId();
+
+    // Simulate rejection from work-adapter
+    eventBus.publish(
+        EventBusAddresses.ACTION_GATE_REJECTED,
+        new ActionGateRejectedEvent(
+            caseId, gateId, "{\"reason\": \"insufficient evidence\"}", "mlro-user"));
+
+    // Wait for both: gate cleared AND signal written (gate cleared first per handler ordering)
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              final var inst = caseInstanceCache.get(caseId);
+              return inst.getPendingActionGate() == null
+                  && inst.getCaseContext().get("actionGateRejected") != null;
+            });
+
+    assertThat(caseInstanceCache.get(caseId).getPendingActionGate()).isNull();
+    assertThat(caseInstanceCache.get(caseId).getCaseContext().get("actionGateRejected"))
+        .isNotNull();
+    // Case stays RUNNING (no completion binding for rejection in this test)
+    assertThat(caseInstanceCache.get(caseId).getState()).isEqualTo(CaseStatus.RUNNING);
+  }
+
+  @Test
+  void terminalStateguard_approvedAfterCaseTermination_doesNotCorruptState() {
+    ResolutionClassifier.nextDecision = new RiskDecision.Autonomous();
+
+    // Start case with Autonomous — completes normally
+    ResolutionCaseHub.declareAction.set(false);
+    final UUID caseId = startCase();
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .isEqualTo(CaseStatus.COMPLETED));
+
+    // Publishing ActionGateApprovedEvent for a completed case — should be a no-op
+    eventBus.publish(
+        EventBusAddresses.ACTION_GATE_APPROVED,
+        new ActionGateApprovedEvent(caseId, 999L, null, null));
+
+    // Case should remain COMPLETED without errors
+    await()
+        .pollDelay(500, TimeUnit.MILLISECONDS)
+        .atMost(2, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(caseInstanceCache.get(caseId).getState())
+                    .isEqualTo(CaseStatus.COMPLETED));
+  }
+
+  // --- Supporting CDI beans ---
+
+  @RiskClassifier
+  @Alternative
+  @Priority(1)
+  @ApplicationScoped
+  static class ResolutionClassifier implements ActionRiskClassifier {
+
+    static volatile RiskDecision nextDecision = new RiskDecision.Autonomous();
+
+    static void reset() {
+      // Default to Autonomous to prevent cross-test contamination when multiple test classes
+      // share the same Quarkus instance. Tests that need GateRequired set it explicitly.
+      nextDecision = new RiskDecision.Autonomous();
+    }
+
+    @Override
+    public RiskDecision classify(final PlannedAction action) {
+      return nextDecision;
+    }
+  }
+
+  @ApplicationScoped
+  static class ResolutionCaseHub extends CaseHub {
+
+    static final AtomicBoolean declareAction = new AtomicBoolean(true);
+
+    @Override
+    public CaseDefinition getDefinition() {
+      final Capability cap =
+          Capability.builder()
+              .name("resolution-gate-cap")
+              .inputSchema(".")
+              .outputSchema(".")
+              .build();
+      final Goal goal =
+          Goal.builder()
+              .name("complete")
+              .kind(GoalKind.SUCCESS)
+              .condition(".gateWorkerOutput != null")
+              .build();
+      return CaseDefinition.builder()
+          .namespace("test-gate-resolution")
+          .name("Gate Resolution Case")
+          .version("1.0.0")
+          .capabilities(cap)
+          .workers(
+              Worker.builder()
+                  .name("resolution-worker")
+                  .capabilities(cap)
+                  .function(
+                      input -> {
+                        final Map<String, Object> output = Map.of("gateWorkerOutput", "produced");
+                        if (declareAction.get()) {
+                          return WorkerResult.of(
+                              output,
+                              PlannedAction.of("File resolution", "resolution.file", Map.of()));
+                        }
+                        return WorkerResult.of(output);
+                      })
+                  .build())
+          .bindings(
+              Binding.builder()
+                  .name("resolution-binding")
+                  // Only fire when not gated and not completed — prevents re-triggering while
+                  // pendingActionGate is set (deferred output not yet applied to context)
+                  .on(
+                      new ContextChangeTrigger(
+                          ".gateWorkerOutput == null and .actionGateRejected == null"
+                              + " and .actionGateApproved == null"
+                              + " and .actionGateExpired == null"))
+                  .target(new CapabilityTarget(cap))
+                  .build())
+          .goals(goal)
+          .completion(GoalExpression.allOf(goal))
+          .build();
+    }
+  }
+
+  // --- Codec-registering stubs — @ConsumeEvent triggers Quarkus codec registration ---
+
+  /**
+   * Registers event bus codecs for gate resolution event types. Without @ConsumeEvent handlers,
+   * Quarkus doesn't register codecs for these types and publish() fails. These stubs exist only to
+   * register codecs; the real handlers (ActionGateApprovedHandler etc.) process the events.
+   *
+   * <p>When the real handlers are implemented, they will also register the codecs and these stubs
+   * become redundant — but harmless (multiple consumers receive the same event).
+   */
+  @ApplicationScoped
+  static class GateCodecStubs {
+
+    static final List<ActionGateApprovedEvent> capturedApproved = new CopyOnWriteArrayList<>();
+    static final List<ActionGateRejectedEvent> capturedRejected = new CopyOnWriteArrayList<>();
+
+    @ConsumeEvent(EventBusAddresses.ACTION_GATE_APPROVED)
+    void onApproved(final ActionGateApprovedEvent e) {
+      capturedApproved.add(e);
+    }
+
+    @ConsumeEvent(EventBusAddresses.ACTION_GATE_REJECTED)
+    void onRejected(final ActionGateRejectedEvent e) {
+      capturedRejected.add(e);
+    }
+
+    // ACTION_GATE_SCHEDULE codec — registered by ActionGateWorkItemHandler stub below
+    @ConsumeEvent(EventBusAddresses.ACTION_GATE_SCHEDULE)
+    void onSchedule(final ActionGateScheduleEvent e) {
+      // no-op — just registers codec
+    }
+  }
+
+  // --- Helpers ---
+
+  private UUID startCase() {
+    final AtomicReference<UUID> ref = new AtomicReference<>();
+    resolutionCaseHub.startCase(Map.of()).thenAccept(ref::set);
+    await().atMost(5, TimeUnit.SECONDS).until(() -> ref.get() != null);
+    return ref.get();
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/CaseCancelSuspendResumeTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseCancelSuspendResumeTest.java
@@ -26,6 +26,7 @@ import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.spi.EventLogRepository;
@@ -373,7 +374,7 @@ class CaseCancelSuspendResumeTest {
                   .function(
                       input -> {
                         runCount.incrementAndGet();
-                        return Map.of("result", "done");
+                        return WorkerResult.of(Map.of("result", "done"));
                       })
                   .build())
           .bindings(

--- a/runtime/src/test/java/io/casehub/engine/CaseFaultedStateTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseFaultedStateTest.java
@@ -30,6 +30,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.RetryPolicy;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.spi.EventLogRepository;
@@ -286,7 +287,8 @@ class CaseFaultedStateTest {
               Worker.builder()
                   .name("error-producing-worker")
                   .capabilities(capability)
-                  .function(input -> Map.of("status", "error")) // satisfies failure goal
+                  .function(
+                      input -> WorkerResult.of(Map.of("status", "error"))) // satisfies failure goal
                   .build())
           .bindings(
               Binding.builder()

--- a/runtime/src/test/java/io/casehub/engine/CaseLifecycleCdiEventTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseLifecycleCdiEventTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.internal.model.CaseInstance;
 import io.casehub.engine.common.spi.CaseInstanceRepository;
 import io.casehub.engine.common.spi.event.CaseLifecycleEvent;
@@ -178,7 +179,7 @@ class CaseLifecycleCdiEventTest {
                   .capabilities(capability)
                   // Return done:true, trigger:false — so the ContextChangeTrigger
                   // (.trigger==true and .done!=true) never re-fires after the first execution.
-                  .function(input -> Map.of("done", true, "trigger", false))
+                  .function(input -> WorkerResult.of(Map.of("done", true, "trigger", false)))
                   .build())
           .bindings(
               Binding.builder()

--- a/runtime/src/test/java/io/casehub/engine/CaseLifecycleStateTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseLifecycleStateTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.spi.CaseInstanceRepository;
@@ -211,7 +212,7 @@ class CaseLifecycleStateTest {
               Worker.builder()
                   .name("idle-worker")
                   .capabilities(capability)
-                  .function(input -> Map.of("status", "done"))
+                  .function(input -> WorkerResult.of(Map.of("status", "done")))
                   .build())
           .bindings(
               Binding.builder()
@@ -252,7 +253,7 @@ class CaseLifecycleStateTest {
               Worker.builder()
                   .name("completing-worker")
                   .capabilities(capability)
-                  .function(input -> Map.of("status", "done"))
+                  .function(input -> WorkerResult.of(Map.of("status", "done")))
                   .build())
           .bindings(
               Binding.builder()

--- a/runtime/src/test/java/io/casehub/engine/CaseWaitingResumeTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseWaitingResumeTest.java
@@ -29,6 +29,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.spi.WorkOrchestrator;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
@@ -139,7 +140,7 @@ class CaseWaitingResumeTest {
               Worker.builder()
                   .name("analyse-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("result", "done"))
+                  .function(input -> WorkerResult.of(Map.of("result", "done")))
                   .build())
           .bindings(
               Binding.builder()

--- a/runtime/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -136,7 +137,7 @@ class ChoreographySelectionTest {
                   .function(
                       input -> {
                         record(input);
-                        return Map.of("result", "done");
+                        return WorkerResult.of(Map.of("result", "done"));
                       })
                   .build(),
               Worker.builder()
@@ -145,7 +146,7 @@ class ChoreographySelectionTest {
                   .function(
                       input -> {
                         record(input);
-                        return Map.of("result", "done");
+                        return WorkerResult.of(Map.of("result", "done"));
                       })
                   .build())
           .bindings(

--- a/runtime/src/test/java/io/casehub/engine/ContextChangeWhenFilterTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ContextChangeWhenFilterTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -142,7 +143,7 @@ class ContextChangeWhenFilterTest {
                   .function(
                       input -> {
                         guardedWorkerCount.incrementAndGet();
-                        return Map.of("guardedRan", true);
+                        return WorkerResult.of(Map.of("guardedRan", true));
                       })
                   .build(),
               Worker.builder()
@@ -151,7 +152,7 @@ class ContextChangeWhenFilterTest {
                   .function(
                       input -> {
                         ungardedWorkerCount.incrementAndGet();
-                        return Map.of("done", true);
+                        return WorkerResult.of(Map.of("done", true));
                       })
                   .build())
           .bindings(

--- a/runtime/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.spi.EventLogRepository;
@@ -206,7 +207,7 @@ class ContextDiffEndToEndTest {
               Worker.builder()
                   .name("diff-worker")
                   .capabilities(capability)
-                  .function(input -> Map.of("status", "done", "result", "ok"))
+                  .function(input -> WorkerResult.of(Map.of("status", "done", "result", "ok")))
                   .build())
           .bindings(
               Binding.builder()
@@ -245,7 +246,7 @@ class ContextDiffEndToEndTest {
               Worker.builder()
                   .name("partial-worker")
                   .capabilities(capability)
-                  .function(input -> Map.of("status", "done"))
+                  .function(input -> WorkerResult.of(Map.of("status", "done")))
                   .build())
           .bindings(
               Binding.builder()

--- a/runtime/src/test/java/io/casehub/engine/ContextDiffNoneStrategyTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ContextDiffNoneStrategyTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.spi.EventLogRepository;
@@ -119,7 +120,7 @@ class ContextDiffNoneStrategyTest {
               Worker.builder()
                   .name("none-worker")
                   .capabilities(capability)
-                  .function(input -> Map.of("status", "done"))
+                  .function(input -> WorkerResult.of(Map.of("status", "done")))
                   .build())
           .bindings(
               Binding.builder()

--- a/runtime/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
+++ b/runtime/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +90,8 @@ public class MultiWorkerPipelineBean extends CaseHub {
                                   if (!ctx.containsKey("documentId")) {
                                     throw new RuntimeException("Missing documentId");
                                   }
-                                  return Map.of("valid", true, "step", "validated");
+                                  return WorkerResult.of(
+                                      Map.of("valid", true, "step", "validated"));
                                 },
                                 Map.class))
                         .build())
@@ -107,14 +109,15 @@ public class MultiWorkerPipelineBean extends CaseHub {
                                   if (!ctx.containsKey("documentId")) {
                                     throw new RuntimeException("Missing documentId");
                                   }
-                                  return Map.of(
-                                      "enrichedData",
+                                  return WorkerResult.of(
                                       Map.of(
-                                          "source", "internal",
-                                          "tags", List.of("validated", "enriched"),
-                                          "documentId", ctx.get("documentId")),
-                                      "step",
-                                      "enriched");
+                                          "enrichedData",
+                                          Map.of(
+                                              "source", "internal",
+                                              "tags", List.of("validated", "enriched"),
+                                              "documentId", ctx.get("documentId")),
+                                          "step",
+                                          "enriched"));
                                 },
                                 Map.class))
                         .build())
@@ -132,11 +135,12 @@ public class MultiWorkerPipelineBean extends CaseHub {
                                   if (!ctx.containsKey("documentId")) {
                                     throw new RuntimeException("Missing documentId");
                                   }
-                                  return Map.of(
-                                      "publishedUrl",
-                                      "https://docs.example.com/" + ctx.get("documentId"),
-                                      "step",
-                                      "published");
+                                  return WorkerResult.of(
+                                      Map.of(
+                                          "publishedUrl",
+                                          "https://docs.example.com/" + ctx.get("documentId"),
+                                          "step",
+                                          "published"));
                                 },
                                 Map.class))
                         .build())

--- a/runtime/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
+++ b/runtime/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
@@ -28,7 +28,6 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
-import io.casehub.api.model.WorkerResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 import java.util.Map;
@@ -90,8 +89,7 @@ public class MultiWorkerPipelineBean extends CaseHub {
                                   if (!ctx.containsKey("documentId")) {
                                     throw new RuntimeException("Missing documentId");
                                   }
-                                  return WorkerResult.of(
-                                      Map.of("valid", true, "step", "validated"));
+                                  return Map.of("valid", true, "step", "validated");
                                 },
                                 Map.class))
                         .build())
@@ -109,15 +107,14 @@ public class MultiWorkerPipelineBean extends CaseHub {
                                   if (!ctx.containsKey("documentId")) {
                                     throw new RuntimeException("Missing documentId");
                                   }
-                                  return WorkerResult.of(
+                                  return Map.of(
+                                      "enrichedData",
                                       Map.of(
-                                          "enrichedData",
-                                          Map.of(
-                                              "source", "internal",
-                                              "tags", List.of("validated", "enriched"),
-                                              "documentId", ctx.get("documentId")),
-                                          "step",
-                                          "enriched"));
+                                          "source", "internal",
+                                          "tags", List.of("validated", "enriched"),
+                                          "documentId", ctx.get("documentId")),
+                                      "step",
+                                      "enriched");
                                 },
                                 Map.class))
                         .build())
@@ -135,12 +132,11 @@ public class MultiWorkerPipelineBean extends CaseHub {
                                   if (!ctx.containsKey("documentId")) {
                                     throw new RuntimeException("Missing documentId");
                                   }
-                                  return WorkerResult.of(
-                                      Map.of(
-                                          "publishedUrl",
-                                          "https://docs.example.com/" + ctx.get("documentId"),
-                                          "step",
-                                          "published"));
+                                  return Map.of(
+                                      "publishedUrl",
+                                      "https://docs.example.com/" + ctx.get("documentId"),
+                                      "step",
+                                      "published");
                                 },
                                 Map.class))
                         .build())

--- a/runtime/src/test/java/io/casehub/engine/NoOpLedgerEntryRepository.java
+++ b/runtime/src/test/java/io/casehub/engine/NoOpLedgerEntryRepository.java
@@ -79,6 +79,11 @@ class NoOpLedgerEntryRepository implements LedgerEntryRepository {
   }
 
   @Override
+  public List<LedgerEntry> findEventsByActorId(String actorId) {
+    return List.of();
+  }
+
+  @Override
   public Map<UUID, List<LedgerAttestation>> findAttestationsForEntries(Set<UUID> entryIds) {
     return Map.of();
   }

--- a/runtime/src/test/java/io/casehub/engine/OrchestrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/OrchestrationTest.java
@@ -30,6 +30,7 @@ import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.WorkStatus;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.spi.WorkOrchestrator;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
@@ -149,7 +150,7 @@ class OrchestrationTest {
               Worker.builder()
                   .name("analyse-worker")
                   .capabilities(cap)
-                  .function(input -> Map.of("analysis", "complete"))
+                  .function(input -> WorkerResult.of(Map.of("analysis", "complete")))
                   .build())
           .bindings(
               Binding.builder()

--- a/runtime/src/test/java/io/casehub/engine/ScheduleTriggerSimpleTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ScheduleTriggerSimpleTest.java
@@ -27,6 +27,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.ScheduleTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import io.casehub.engine.common.internal.model.CaseInstance;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
@@ -254,7 +255,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     executionCount.incrementAndGet();
-                    return Map.of("workDone", true);
+                    return WorkerResult.of(Map.of("workDone", true));
                   })
               .build();
 
@@ -296,7 +297,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     executionCount.incrementAndGet();
-                    return Map.of("workDone", true);
+                    return WorkerResult.of(Map.of("workDone", true));
                   })
               .build();
 
@@ -338,7 +339,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     executionCount.incrementAndGet();
-                    return Map.of("workDone", true);
+                    return WorkerResult.of(Map.of("workDone", true));
                   })
               .build();
 
@@ -381,7 +382,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     executionCount.incrementAndGet();
-                    return Map.of("workDone", true);
+                    return WorkerResult.of(Map.of("workDone", true));
                   })
               .build();
 
@@ -424,7 +425,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     executionCount.incrementAndGet();
-                    return Map.of("workDone", true);
+                    return WorkerResult.of(Map.of("workDone", true));
                   })
               .build();
 
@@ -467,7 +468,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     executionCount.incrementAndGet();
-                    return Map.of("workDone", true);
+                    return WorkerResult.of(Map.of("workDone", true));
                   })
               .build();
 
@@ -518,7 +519,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     worker1Count.incrementAndGet();
-                    return Map.of("work1Done", true);
+                    return WorkerResult.of(Map.of("work1Done", true));
                   })
               .build();
 
@@ -529,7 +530,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     worker2Count.incrementAndGet();
-                    return Map.of("work2Done", true);
+                    return WorkerResult.of(Map.of("work2Done", true));
                   })
               .build();
 
@@ -578,7 +579,7 @@ class ScheduleTriggerSimpleTest {
               .function(
                   ctx -> {
                     executionCount.incrementAndGet();
-                    return Map.of("workDone", true);
+                    return WorkerResult.of(Map.of("workDone", true));
                   })
               .build();
 

--- a/runtime/src/test/java/io/casehub/engine/SignalDedupExtendedTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SignalDedupExtendedTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -355,7 +356,7 @@ public class SignalDedupExtendedTest {
                               .computeIfAbsent(id, k -> new AtomicInteger())
                               .incrementAndGet();
                         }
-                        return Map.of("eventResult", "processed");
+                        return WorkerResult.of(Map.of("eventResult", "processed"));
                       })
                   .build())
           .bindings(
@@ -409,7 +410,7 @@ public class SignalDedupExtendedTest {
                               .computeIfAbsent(id, k -> new AtomicInteger())
                               .incrementAndGet();
                         }
-                        return Map.of("eventResult", "processed");
+                        return WorkerResult.of(Map.of("eventResult", "processed"));
                       })
                   .build())
           .bindings(

--- a/runtime/src/test/java/io/casehub/engine/SignalPersistenceAndDedupTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SignalPersistenceAndDedupTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.internal.model.CaseInstance;
@@ -290,8 +291,9 @@ public class SignalPersistenceAndDedupTest {
                         runCount.incrementAndGet();
                         Map<String, Object> payment = (Map<String, Object>) input.get("payment");
                         Number amount = (Number) payment.get("amount");
-                        return Map.of(
-                            "status", "processed", "lastProcessedAmount", amount.intValue());
+                        return WorkerResult.of(
+                            Map.of(
+                                "status", "processed", "lastProcessedAmount", amount.intValue()));
                       })
                   .build())
           .bindings(

--- a/runtime/src/test/java/io/casehub/engine/SignalTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SignalTest.java
@@ -29,6 +29,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -263,7 +264,7 @@ public class SignalTest {
                               .computeIfAbsent(orderId, k -> new AtomicInteger())
                               .incrementAndGet();
                         }
-                        return Map.of("status", "paid");
+                        return WorkerResult.of(Map.of("status", "paid"));
                       })
                   .build())
           .bindings(
@@ -323,7 +324,7 @@ public class SignalTest {
                   .function(
                       input -> {
                         paymentRunCount.incrementAndGet();
-                        return Map.of("paymentProcessed", true);
+                        return WorkerResult.of(Map.of("paymentProcessed", true));
                       })
                   .build(),
               Worker.builder()
@@ -332,7 +333,7 @@ public class SignalTest {
                   .function(
                       input -> {
                         documentRunCount.incrementAndGet();
-                        return Map.of("documentProcessed", true);
+                        return WorkerResult.of(Map.of("documentProcessed", true));
                       })
                   .build())
           .bindings(

--- a/runtime/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
+++ b/runtime/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Map;
 
@@ -75,16 +76,17 @@ public class SimpleCaseHubBean extends CaseHub {
                                   if (!context.containsKey("status")) {
                                     throw new RuntimeException("Missing status in context");
                                   }
-                                  return Map.of(
-                                      "processedDocument",
+                                  return WorkerResult.of(
                                       Map.of(
-                                          "id",
-                                          context.get("documentId"),
-                                          "content",
-                                          "Processed content for document "
-                                              + context.get("documentId")),
-                                      "status",
-                                      "processed");
+                                          "processedDocument",
+                                          Map.of(
+                                              "id",
+                                              context.get("documentId"),
+                                              "content",
+                                              "Processed content for document "
+                                                  + context.get("documentId")),
+                                          "status",
+                                          "processed"));
                                 },
                                 Map.class))
                         .build())

--- a/runtime/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
+++ b/runtime/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
@@ -28,7 +28,6 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.Worker;
-import io.casehub.api.model.WorkerResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Map;
 
@@ -76,17 +75,16 @@ public class SimpleCaseHubBean extends CaseHub {
                                   if (!context.containsKey("status")) {
                                     throw new RuntimeException("Missing status in context");
                                   }
-                                  return WorkerResult.of(
+                                  return Map.of(
+                                      "processedDocument",
                                       Map.of(
-                                          "processedDocument",
-                                          Map.of(
-                                              "id",
-                                              context.get("documentId"),
-                                              "content",
-                                              "Processed content for document "
-                                                  + context.get("documentId")),
-                                          "status",
-                                          "processed"));
+                                          "id",
+                                          context.get("documentId"),
+                                          "content",
+                                          "Processed content for document "
+                                              + context.get("documentId")),
+                                      "status",
+                                      "processed");
                                 },
                                 Map.class))
                         .build())

--- a/runtime/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
@@ -33,6 +33,7 @@ import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.WorkerContext;
 import io.casehub.api.model.WorkerExecutionContext;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.spi.CaseChannelProvider;
 import io.casehub.api.spi.ProvisionResult;
 import io.casehub.api.spi.ProvisioningException;
@@ -589,14 +590,13 @@ class SpiWiringIntegrationTest {
               .name("execution-context-recorder")
               .capabilities(capability)
               .function(
-                  (java.util.function.Function<Map<String, Object>, Map<String, Object>>)
-                      input -> {
-                        WorkerContext ctx = WorkerExecutionContext.current();
-                        if (ctx != null) {
-                          RecordingExecutionContextWorker.capturedChannels.add(ctx.channels());
-                        }
-                        return Map.of("recorded", true);
-                      })
+                  input -> {
+                    WorkerContext ctx = WorkerExecutionContext.current();
+                    if (ctx != null) {
+                      RecordingExecutionContextWorker.capturedChannels.add(ctx.channels());
+                    }
+                    return WorkerResult.of(Map.of("recorded", true));
+                  })
               .build();
 
       return CaseDefinition.builder()

--- a/runtime/src/test/java/io/casehub/engine/WorkBrokerEndToEndTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkBrokerEndToEndTest.java
@@ -28,6 +28,7 @@ import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -125,7 +126,7 @@ class WorkBrokerEndToEndTest {
                       input -> {
                         stage1BeforeStage2 = stage2Count.get() == 0;
                         stage1Count.incrementAndGet();
-                        return Map.of("stage", "processed");
+                        return WorkerResult.of(Map.of("stage", "processed"));
                       })
                   .build(),
               Worker.builder()
@@ -134,7 +135,7 @@ class WorkBrokerEndToEndTest {
                   .function(
                       input -> {
                         stage2Count.incrementAndGet();
-                        return Map.of("stage", "final");
+                        return WorkerResult.of(Map.of("stage", "final"));
                       })
                   .build())
           .bindings(

--- a/runtime/src/test/java/io/casehub/engine/WorkerIdempotencyTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerIdempotencyTest.java
@@ -26,6 +26,7 @@ import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.engine.common.internal.event.WorkerScheduleEvent;
@@ -635,7 +636,7 @@ public class WorkerIdempotencyTest {
                         .computeIfAbsent(taskId, k -> new AtomicInteger())
                         .incrementAndGet();
                   }
-                  return Map.of("taskResult", "done");
+                  return WorkerResult.of(Map.of("taskResult", "done"));
                 })
             .build();
 
@@ -699,7 +700,7 @@ public class WorkerIdempotencyTest {
                   .function(
                       input -> {
                         alphaRunCount.incrementAndGet();
-                        return Map.of("alphaResult", "done");
+                        return WorkerResult.of(Map.of("alphaResult", "done"));
                       })
                   .build(),
               Worker.builder()
@@ -708,7 +709,7 @@ public class WorkerIdempotencyTest {
                   .function(
                       input -> {
                         betaRunCount.incrementAndGet();
-                        return Map.of("betaResult", "done");
+                        return WorkerResult.of(Map.of("betaResult", "done"));
                       })
                   .build())
           .bindings(

--- a/runtime/src/test/java/io/casehub/engine/WorkerRecoveryTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerRecoveryTest.java
@@ -22,6 +22,7 @@ import io.casehub.api.engine.CaseHub;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.engine.common.internal.history.EventLog;
@@ -136,11 +137,12 @@ public class WorkerRecoveryTest {
                   .function(
                       input -> {
                         runCount.incrementAndGet();
-                        return Map.of(
-                            "status",
-                            "processed",
-                            "processedDocument",
-                            Map.of("id", input.get("documentId")));
+                        return WorkerResult.of(
+                            Map.of(
+                                "status",
+                                "processed",
+                                "processedDocument",
+                                Map.of("id", input.get("documentId"))));
                       })
                   .build())
           .build();

--- a/runtime/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
@@ -31,6 +31,7 @@ import io.casehub.api.model.GoalExpression;
 import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.RetryPolicy;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.spi.EventLogRepository;
@@ -488,7 +489,7 @@ public class WorkerRetryExtendedTest {
                           throw new RuntimeException(
                               "Simulated failure on attempt " + attempt + " of " + maxFail);
                         }
-                        return Map.of("status", "processed", "taskId", taskId);
+                        return WorkerResult.of(Map.of("status", "processed", "taskId", taskId));
                       })
                   // 5 max attempts, 100 ms between retries — allows tests up to 4 failures
                   .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(5, 100)))
@@ -545,7 +546,7 @@ public class WorkerRetryExtendedTest {
                           throw new RuntimeException(
                               "Signal-triggered failure on attempt " + attempt);
                         }
-                        return Map.of("status", "processed");
+                        return WorkerResult.of(Map.of("status", "processed"));
                       })
                   .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(5, 100)))
                   .build())
@@ -599,7 +600,7 @@ public class WorkerRetryExtendedTest {
                   .function(
                       input -> {
                         alphaAttempts.incrementAndGet();
-                        return Map.of("alphaResult", "alpha-done");
+                        return WorkerResult.of(Map.of("alphaResult", "alpha-done"));
                       })
                   .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(3, 100)))
                   .build(),
@@ -612,7 +613,7 @@ public class WorkerRetryExtendedTest {
                         if (attempt <= betaFailUntil.get()) {
                           throw new RuntimeException("Beta failure on attempt " + attempt);
                         }
-                        return Map.of("betaResult", "beta-done");
+                        return WorkerResult.of(Map.of("betaResult", "beta-done"));
                       })
                   .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(5, 100)))
                   .build())

--- a/runtime/src/test/java/io/casehub/engine/WorkerRetryTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerRetryTest.java
@@ -31,6 +31,7 @@ import io.casehub.api.model.GoalKind;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.RetryPolicy;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -120,21 +121,22 @@ public class WorkerRetryTest {
                   .function(
                       new Function<>() {
                         @Override
-                        public Map<String, Object> apply(Map<String, Object> stateContext) {
+                        public WorkerResult apply(Map<String, Object> stateContext) {
                           if (runCount.incrementAndGet() <= 2) {
                             throw new RuntimeException("Simulated processing failure");
                           }
 
-                          return Map.of(
-                              "processedDocument",
+                          return WorkerResult.of(
                               Map.of(
-                                  "id",
-                                  stateContext.get("documentId"),
-                                  "content",
-                                  "Processed content for document "
-                                      + stateContext.get("documentId")),
-                              "status",
-                              "processed");
+                                  "processedDocument",
+                                  Map.of(
+                                      "id",
+                                      stateContext.get("documentId"),
+                                      "content",
+                                      "Processed content for document "
+                                          + stateContext.get("documentId")),
+                                  "status",
+                                  "processed"));
                         }
                       })
                   .executionPolicy(new ExecutionPolicy(60000, new RetryPolicy(3, 1000)))

--- a/runtime/src/test/java/io/casehub/engine/WorkerScheduleDedupTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerScheduleDedupTest.java
@@ -24,6 +24,7 @@ import io.casehub.api.engine.CaseHub;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.engine.common.internal.event.WorkerScheduleEvent;
@@ -293,11 +294,12 @@ public class WorkerScheduleDedupTest {
             .function(
                 input -> {
                   runCount.incrementAndGet();
-                  return Map.of(
-                      "status",
-                      "processed",
-                      "processedDocument",
-                      Map.of("id", input.get("documentId")));
+                  return WorkerResult.of(
+                      Map.of(
+                          "status",
+                          "processed",
+                          "processedDocument",
+                          Map.of("id", input.get("documentId"))));
                 })
             .build();
 

--- a/runtime/src/test/java/io/casehub/engine/WorkerTimeoutTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerTimeoutTest.java
@@ -27,6 +27,7 @@ import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.ExecutionPolicy;
 import io.casehub.api.model.RetryPolicy;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.engine.common.internal.model.CaseInstance;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.quarkus.test.junit.QuarkusTest;
@@ -177,7 +178,7 @@ class WorkerTimeoutTest {
                   ctx -> {
                     executionCount.incrementAndGet();
                     // Completes immediately
-                    return Map.of("result", "fast-completed");
+                    return WorkerResult.of(Map.of("result", "fast-completed"));
                   })
               .build();
 
@@ -230,7 +231,7 @@ class WorkerTimeoutTest {
                     } catch (InterruptedException e) {
                       Thread.currentThread().interrupt();
                     }
-                    return Map.of("result", "should-not-complete");
+                    return WorkerResult.of(Map.of("result", "should-not-complete"));
                   })
               .build();
 
@@ -280,7 +281,7 @@ class WorkerTimeoutTest {
                     } catch (InterruptedException e) {
                       Thread.currentThread().interrupt();
                     }
-                    return Map.of("result", "slow-completed");
+                    return WorkerResult.of(Map.of("result", "slow-completed"));
                   })
               .build();
 
@@ -333,7 +334,7 @@ class WorkerTimeoutTest {
                     } catch (InterruptedException e) {
                       Thread.currentThread().interrupt();
                     }
-                    return Map.of("result", "should-not-complete");
+                    return WorkerResult.of(Map.of("result", "should-not-complete"));
                   })
               .build();
 

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
@@ -33,6 +33,7 @@ import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.ContextChangeTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.spi.ReactiveWorkerContextProvider;
 import io.casehub.api.spi.ReactiveWorkerProvisioner;
 import io.casehub.api.spi.routing.AgentAssignment;
@@ -112,7 +113,7 @@ class CaseContextChangedEventHandlerRoutingTest {
         Worker.builder()
             .name("analyst-worker")
             .capabilities(capability)
-            .function(input -> java.util.Map.of())
+            .function(input -> WorkerResult.of(java.util.Map.of()))
             .build();
 
     final CaseMetaModel metaModel = mock(CaseMetaModel.class);

--- a/runtime/src/test/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestratorTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestratorTest.java
@@ -29,6 +29,7 @@ import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.spi.routing.AgentAssignment;
 import io.casehub.api.spi.routing.AgentCandidate;
 import io.casehub.api.spi.routing.AgentRoutingStrategy;
@@ -290,7 +291,7 @@ class DefaultWorkOrchestratorTest {
         Worker.builder()
             .name("agent-worker")
             .capabilities(capability)
-            .function(input -> Map.of("result", "done"))
+            .function(input -> WorkerResult.of(Map.of("result", "done")))
             .agentDescriptor(AGENT_DESCRIPTOR)
             .build();
 
@@ -309,7 +310,7 @@ class DefaultWorkOrchestratorTest {
         Worker.builder()
             .name("analyst-worker")
             .capabilities(capability)
-            .function(input -> Map.of("result", "done"))
+            .function(input -> WorkerResult.of(Map.of("result", "done")))
             .build();
 
     return buildInstance(capabilityName, worker);

--- a/runtime/src/test/java/io/casehub/engine/internal/worker/ChainedReactiveActionRiskClassifierTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/worker/ChainedReactiveActionRiskClassifierTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.casehub.api.spi.ActionRiskClassifier;
+import io.casehub.api.spi.PlannedAction;
+import io.casehub.api.spi.RiskDecision;
+import io.casehub.api.spi.RiskDecision.Autonomous;
+import io.casehub.api.spi.RiskDecision.GateRequired;
+import jakarta.enterprise.inject.Instance;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterators;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ChainedReactiveActionRiskClassifierTest {
+
+  private ChainedReactiveActionRiskClassifier chain;
+
+  private static PlannedAction anyAction() {
+    return PlannedAction.of("desc", "spend.transfer", Map.of("amount", 100))
+        .withIdentity("w-1", UUID.randomUUID());
+  }
+
+  @BeforeEach
+  void setUp() {
+    chain = new ChainedReactiveActionRiskClassifier();
+  }
+
+  // --- Empty chain ---
+
+  @Test
+  void emptyChain_returnsAutonomous() {
+    chain.classifiers = unsatisfied();
+
+    RiskDecision result = chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result).isInstanceOf(Autonomous.class);
+  }
+
+  // --- Single classifier ---
+
+  @Test
+  void singleClassifier_returnsAutonomous_propagatesAutonomous() {
+    chain.classifiers = instanceOf(action -> new Autonomous());
+
+    RiskDecision result = chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result).isInstanceOf(Autonomous.class);
+  }
+
+  @Test
+  void singleClassifier_returnsGateRequired_propagatesGateRequired() {
+    final GateRequired gate =
+        new GateRequired("SAR filing", false, List.of("mlro"), Duration.ofHours(24), null);
+    chain.classifiers = instanceOf(action -> gate);
+
+    RiskDecision result = chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result).isInstanceOf(GateRequired.class);
+    assertThat(((GateRequired) result).reason()).isEqualTo("SAR filing");
+    assertThat(((GateRequired) result).candidateGroups()).containsExactly("mlro");
+  }
+
+  // --- Two classifiers, merge semantics ---
+
+  @Test
+  void twoClassifiers_bothAutonomous_returnsAutonomous() {
+    chain.classifiers = instanceOf(action -> new Autonomous(), action -> new Autonomous());
+
+    RiskDecision result = chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result).isInstanceOf(Autonomous.class);
+  }
+
+  @Test
+  void twoClassifiers_oneAutonomousOneGateRequired_returnsGateRequired() {
+    chain.classifiers =
+        instanceOf(
+            action -> new Autonomous(),
+            action -> new GateRequired("SUSAR filing", false, List.of("physician"), null, null));
+
+    RiskDecision result = chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result).isInstanceOf(GateRequired.class);
+    assertThat(((GateRequired) result).candidateGroups()).containsExactly("physician");
+  }
+
+  @Test
+  void twoClassifiers_fewerCandidateGroupsWins_notUnion() {
+    // AML returns ["mlro"] (1 group), clinical returns ["physician", "pharmacist"] (2 groups)
+    // Narrower (fewer groups) wins entirely — union ["mlro","physician","pharmacist"] is wrong
+    chain.classifiers =
+        instanceOf(
+            action -> new GateRequired("AML", false, List.of("mlro"), Duration.ofHours(24), null),
+            action ->
+                new GateRequired(
+                    "clinical", false, List.of("physician", "pharmacist"), null, null));
+
+    GateRequired result = (GateRequired) chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result.candidateGroups()).containsExactly("mlro");
+    assertThat(result.reason()).isEqualTo("AML");
+  }
+
+  @Test
+  void twoClassifiers_sameGroupCount_shorterExpiresInWins() {
+    chain.classifiers =
+        instanceOf(
+            action -> new GateRequired("slow", false, List.of("mlro"), Duration.ofHours(48), null),
+            action ->
+                new GateRequired("fast", false, List.of("analyst"), Duration.ofHours(24), null));
+
+    GateRequired result = (GateRequired) chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result.expiresIn()).isEqualTo(Duration.ofHours(24));
+    assertThat(result.reason()).isEqualTo("fast");
+  }
+
+  @Test
+  void twoClassifiers_sameGroupCount_deadlineBeatsNoDeadline() {
+    chain.classifiers =
+        instanceOf(
+            action -> new GateRequired("no-deadline", false, List.of("mlro"), null, null),
+            action ->
+                new GateRequired(
+                    "with-deadline", false, List.of("analyst"), Duration.ofHours(24), null));
+
+    GateRequired result = (GateRequired) chain.classify(anyAction()).await().indefinitely();
+
+    // expiresIn non-null is more restrictive than null
+    assertThat(result.expiresIn()).isEqualTo(Duration.ofHours(24));
+    assertThat(result.reason()).isEqualTo("with-deadline");
+  }
+
+  @Test
+  void twoClassifiers_nullCandidateGroupsVsRestricted_restrictedGroupsWins() {
+    // null candidateGroups means "no restriction" — fewer restrictions = effectively more groups
+    chain.classifiers =
+        instanceOf(
+            action -> new GateRequired("unrestricted", false, null, null, null),
+            action -> new GateRequired("restricted", false, List.of("mlro"), null, null));
+
+    GateRequired result = (GateRequired) chain.classify(anyAction()).await().indefinitely();
+
+    // ["mlro"] (1 group) beats null (Integer.MAX_VALUE groups) — narrower wins
+    assertThat(result.candidateGroups()).containsExactly("mlro");
+    assertThat(result.reason()).isEqualTo("restricted");
+  }
+
+  // --- Classifier throws → fail-safe ---
+
+  @Test
+  void classifierThrows_failSafeGateRequiredApplied() {
+    chain.classifiers =
+        instanceOf(
+            action -> {
+              throw new RuntimeException("DB unavailable");
+            });
+
+    RiskDecision result = chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result).isInstanceOf(GateRequired.class);
+    GateRequired gate = (GateRequired) result;
+    assertThat(gate.reason()).contains("Classifier error");
+    assertThat(gate.reversible()).isTrue();
+    assertThat(gate.candidateGroups()).isNull();
+  }
+
+  @Test
+  void classifierThrows_failSafeHasNullScope() {
+    chain.classifiers =
+        instanceOf(
+            action -> {
+              throw new IllegalStateException("config missing");
+            });
+
+    GateRequired result = (GateRequired) chain.classify(anyAction()).await().indefinitely();
+
+    assertThat(result.scope()).isNull();
+    assertThat(result.expiresIn()).isNull();
+  }
+
+  // --- Enrichment — classifier receives workerId and caseId ---
+
+  @Test
+  void classify_receivesEnrichedPlannedAction_withWorkerIdAndCaseId() {
+    final PlannedAction[] captured = {null};
+    chain.classifiers =
+        instanceOf(
+            action -> {
+              captured[0] = action;
+              return new Autonomous();
+            });
+
+    UUID caseId = UUID.randomUUID();
+    PlannedAction enriched =
+        PlannedAction.of("desc", "type", Map.of()).withIdentity("worker-x", caseId);
+    chain.classify(enriched).await().indefinitely();
+
+    assertThat(captured[0].workerId()).isEqualTo("worker-x");
+    assertThat(captured[0].caseId()).isEqualTo(caseId);
+  }
+
+  // --- Helpers ---
+
+  @SuppressWarnings("unchecked")
+  private static Instance<ActionRiskClassifier> unsatisfied() {
+    Instance<ActionRiskClassifier> inst = mock(Instance.class);
+    when(inst.isUnsatisfied()).thenReturn(true);
+    return inst;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Instance<ActionRiskClassifier> instanceOf(ActionRiskClassifier... classifiers) {
+    Instance<ActionRiskClassifier> inst = mock(Instance.class);
+    when(inst.isUnsatisfied()).thenReturn(false);
+    when(inst.spliterator())
+        .thenReturn(Spliterators.spliteratorUnknownSize(List.of(classifiers).iterator(), 0));
+    return inst;
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/scheduler/ConditionalTriggerConditionParameterTest.java
+++ b/runtime/src/test/java/io/casehub/engine/scheduler/ConditionalTriggerConditionParameterTest.java
@@ -21,6 +21,7 @@ import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.ScheduleTrigger;
 import io.casehub.api.model.Worker;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import java.time.Duration;
@@ -56,7 +57,7 @@ class ConditionalTriggerConditionParameterTest {
         Worker.builder()
             .name("test-worker")
             .capabilities(cap)
-            .function(ctx -> Map.of("workDone", true))
+            .function(ctx -> WorkerResult.of(Map.of("workDone", true)))
             .build();
 
     ExpressionEvaluator condition = new JQExpressionEvaluator(".status == \"ready\"");

--- a/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJob.java
+++ b/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerExecutionJob.java
@@ -25,7 +25,9 @@ import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.WorkerContext;
 import io.casehub.api.model.WorkerExecutionContext;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.ai.Agent;
+import io.casehub.api.spi.PlannedAction;
 import io.casehub.api.spi.WorkerContextProvider;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
 import io.casehub.engine.common.internal.event.WorkflowExecutionCompleted;
@@ -177,21 +179,22 @@ class QuartzWorkerExecutionJob implements Job {
                       eventLogId,
                       ex);
                 } else {
+                  // Workflow workers don't support PlannedAction in v1 — plannedAction=null.
                   eventBus.publish(
                       WORKER_EXECUTION_FINISHED,
                       new WorkflowExecutionCompleted(
-                          instance, workerForClosure, inputDataHash, output));
+                          instance, workerForClosure, inputDataHash, output, null));
                 }
               });
       return; // Quartz marks the job complete; async path handles the rest
     }
 
-    Map<String, Object> outputData;
+    WorkerResult workerResult;
     try {
       if (worker.getFunction().getValue() instanceof Function function) {
-        outputData = function(function, inputData, workerContext, timeoutMs);
+        workerResult = function(function, inputData, workerContext, timeoutMs);
       } else if (worker.getFunction().getValue() instanceof Agent agent) {
-        outputData = agent(agent, inputData, workerContext, timeoutMs);
+        workerResult = agent(agent, inputData, workerContext, timeoutMs);
       } else {
         throw new RuntimeException(
             "Worker function is not a function or agent: "
@@ -209,11 +212,18 @@ class QuartzWorkerExecutionJob implements Job {
       throw new JobExecutionException("Worker execution failed: " + worker.getName(), e.getCause());
     }
 
-    Map<String, Object> toContextOutputData = evalJqAsMap(outputData, capability.getOutputSchema());
+    final Map<String, Object> outputData =
+        evalJqAsMap(workerResult.output(), capability.getOutputSchema());
+    // Enrich PlannedAction with workerId and caseId before passing to the completion handler.
+    final PlannedAction enrichedAction =
+        workerResult.plannedAction() != null
+            ? workerResult.plannedAction().withIdentity(worker.getName(), instance.getUuid())
+            : null;
 
-    WorkflowExecutionCompleted event =
-        new WorkflowExecutionCompleted(instance, worker, inputDataHash, toContextOutputData);
-    eventBus.publish(WORKER_EXECUTION_FINISHED, event);
+    eventBus.publish(
+        WORKER_EXECUTION_FINISHED,
+        new WorkflowExecutionCompleted(
+            instance, worker, inputDataHash, outputData, enrichedAction));
   }
 
   private void handleWorkflowFailure(
@@ -232,8 +242,8 @@ class QuartzWorkerExecutionJob implements Job {
             instance, worker, capability, inputDataHash, eventLogId, cause));
   }
 
-  private Map<String, Object> function(
-      Function<Map<String, Object>, Map<String, Object>> function,
+  private WorkerResult function(
+      Function<Map<String, Object>, WorkerResult> function,
       Map<String, Object> inputData,
       WorkerContext workerContext,
       int timeoutMs)
@@ -241,7 +251,7 @@ class QuartzWorkerExecutionJob implements Job {
 
     LOG.debugf("Executing function with timeout: %d ms", timeoutMs);
 
-    CompletableFuture<Map<String, Object>> cf =
+    CompletableFuture<WorkerResult> cf =
         CompletableFuture.supplyAsync(
             () -> {
               WorkerExecutionContext.set(workerContext);
@@ -255,13 +265,13 @@ class QuartzWorkerExecutionJob implements Job {
     return cf.get(timeoutMs, TimeUnit.MILLISECONDS);
   }
 
-  private Map<String, Object> agent(
+  private WorkerResult agent(
       Agent agent, Map<String, Object> inputData, WorkerContext workerContext, int timeoutMs)
       throws TimeoutException, InterruptedException, ExecutionException {
 
     LOG.debugf("Executing agent with timeout: %d ms", timeoutMs);
 
-    CompletableFuture<Map<String, Object>> cf =
+    CompletableFuture<WorkerResult> cf =
         CompletableFuture.supplyAsync(
             () -> {
               WorkerExecutionContext.set(workerContext);

--- a/scheduler-quartz/src/test/java/io/casehub/engine/scheduler/quartz/AgentExecutionTest.java
+++ b/scheduler-quartz/src/test/java/io/casehub/engine/scheduler/quartz/AgentExecutionTest.java
@@ -26,6 +26,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.WorkerContext;
+import io.casehub.api.model.WorkerResult;
 import io.casehub.api.model.ai.Agent;
 import io.casehub.api.model.ai.ChatModelProvider;
 import io.casehub.api.model.ai.ModelType;
@@ -60,10 +61,10 @@ class AgentExecutionTest {
     WorkerContext context = new WorkerContext(null, null, null, null, null, null);
     int timeout = 5000;
 
-    Map<String, Object> result = invokeAgentMethod(agent, input, context, timeout);
+    WorkerResult result = invokeAgentMethod(agent, input, context, timeout);
 
     assertNotNull(result);
-    assertEquals("POSITIVE", result.get("sentiment"));
+    assertEquals("POSITIVE", result.output().get("sentiment"));
   }
 
   @Test
@@ -158,7 +159,7 @@ class AgentExecutionTest {
     };
   }
 
-  private Map<String, Object> invokeAgentMethod(
+  private WorkerResult invokeAgentMethod(
       Agent agent, Map<String, Object> input, WorkerContext context, int timeout) throws Exception {
     Method agentMethod =
         QuartzWorkerExecutionJob.class.getDeclaredMethod(
@@ -166,9 +167,7 @@ class AgentExecutionTest {
     agentMethod.setAccessible(true);
 
     try {
-      @SuppressWarnings("unchecked")
-      Map<String, Object> result =
-          (Map<String, Object>) agentMethod.invoke(job, agent, input, context, timeout);
+      WorkerResult result = (WorkerResult) agentMethod.invoke(job, agent, input, context, timeout);
       return result;
     } catch (java.lang.reflect.InvocationTargetException e) {
       // Re-throw the original exception

--- a/testing/src/main/java/io/casehub/testing/WorkResultSubmitter.java
+++ b/testing/src/main/java/io/casehub/testing/WorkResultSubmitter.java
@@ -66,7 +66,7 @@ public class WorkResultSubmitter {
               String idempotency = UUID.randomUUID().toString();
               eventBus.publish(
                   EventBusAddresses.WORKER_EXECUTION_FINISHED,
-                  new WorkflowExecutionCompleted(instance, worker, idempotency, output));
+                  WorkflowExecutionCompleted.approved(instance, worker, idempotency, output));
               return (Void) null;
             });
   }

--- a/work-adapter/src/main/java/io/casehub/workadapter/ActionGateCancelledHandler.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/ActionGateCancelledHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import io.casehub.engine.common.internal.event.ActionGateCancelledEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.work.runtime.model.WorkItem;
+import io.casehub.work.runtime.repository.WorkItemStore;
+import io.casehub.work.runtime.service.WorkItemService;
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import org.jboss.logging.Logger;
+
+/**
+ * Cancels an orphaned gate WorkItem when the owning case terminates.
+ *
+ * <p>Consumes {@link ActionGateCancelledEvent} on {@link EventBusAddresses#ACTION_GATE_CANCELLED},
+ * published by {@code CaseStatusChangedHandler} when a case transitions to a terminal state while
+ * {@code CaseInstance.pendingActionGate} is non-null.
+ *
+ * <p>Cancellation is a no-op if the WorkItem has already reached a terminal state (COMPLETED,
+ * REJECTED, etc.) — prevents race conditions when the gate resolves just before the case
+ * terminates.
+ */
+@ApplicationScoped
+public class ActionGateCancelledHandler {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateCancelledHandler.class);
+
+  @Inject WorkItemStore workItemStore;
+  @Inject WorkItemService workItemService;
+
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_CANCELLED, blocking = true)
+  @Transactional
+  public void onActionGateCancelled(final ActionGateCancelledEvent event) {
+    final String callerRef = GateCallerRef.encode(event.caseId(), event.gateId());
+    final Optional<WorkItem> workItemOpt = workItemStore.findByCallerRef(callerRef);
+
+    if (workItemOpt.isEmpty()) {
+      LOG.debugf(
+          "Gate WorkItem not found for cancellation: caseId=%s gateId=%d callerRef=%s — may have already been resolved",
+          event.caseId(), event.gateId(), callerRef);
+      return;
+    }
+
+    final WorkItem workItem = workItemOpt.get();
+    if (workItem.status != null && workItem.status.isTerminal()) {
+      LOG.debugf(
+          "Gate WorkItem already terminal (status=%s): caseId=%s gateId=%d — skipping cancellation",
+          workItem.status, event.caseId(), event.gateId());
+      return;
+    }
+
+    try {
+      workItemService.cancel(
+          workItem.id, "casehub-engine", "Case reached terminal state while gate was pending");
+      LOG.infof(
+          "Gate WorkItem cancelled (case terminated): caseId=%s gateId=%d",
+          event.caseId(), event.gateId());
+    } catch (final Exception e) {
+      LOG.warnf(
+          e,
+          "Failed to cancel gate WorkItem: caseId=%s gateId=%d — WorkItem may resolve against a terminated case",
+          event.caseId(),
+          event.gateId());
+    }
+  }
+}

--- a/work-adapter/src/main/java/io/casehub/workadapter/ActionGateCompletionApplier.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/ActionGateCompletionApplier.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import io.casehub.engine.common.internal.event.ActionGateApprovedEvent;
+import io.casehub.engine.common.internal.event.ActionGateExpiredEvent;
+import io.casehub.engine.common.internal.event.ActionGateRejectedEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.work.runtime.model.WorkItem;
+import io.casehub.work.runtime.model.WorkItemStatus;
+import io.vertx.mutiny.core.eventbus.EventBus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+/**
+ * Translates terminal WorkItem lifecycle events for gate callerRefs into gate resolution events on
+ * the engine event bus.
+ *
+ * <p>Called by {@link WorkItemLifecycleAdapter} when a gate callerRef ({@code
+ * "case:{caseId}/gate:{gateId}"}) is detected. Routes before the blackboard guard — gate WorkItems
+ * have no associated PlanItem.
+ *
+ * <p>Resolution mapping:
+ *
+ * <ul>
+ *   <li>COMPLETED → {@link ActionGateApprovedEvent} on {@link
+ *       EventBusAddresses#ACTION_GATE_APPROVED}
+ *   <li>REJECTED or CANCELLED → {@link ActionGateRejectedEvent} on {@link
+ *       EventBusAddresses#ACTION_GATE_REJECTED}
+ *   <li>EXPIRED → {@link ActionGateExpiredEvent} on {@link EventBusAddresses#ACTION_GATE_EXPIRED}
+ * </ul>
+ *
+ * <p>{@code approvedBy}/{@code rejectedBy} is sourced from {@code WorkItem.assigneeId} — the user
+ * who claimed and completed the WorkItem. If null (completed without explicit claim), falls back to
+ * parsing {@code resolution.completedBy}; otherwise null.
+ */
+@ApplicationScoped
+public class ActionGateCompletionApplier {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateCompletionApplier.class);
+
+  @Inject EventBus eventBus;
+
+  public void apply(
+      final GateCallerRef gateRef, final WorkItemStatus status, final WorkItem workItem) {
+    switch (status) {
+      case COMPLETED -> handleApproved(gateRef, workItem);
+      case REJECTED, CANCELLED -> handleRejected(gateRef, workItem);
+      case EXPIRED -> handleExpired(gateRef);
+      default ->
+          LOG.debugf(
+              "Gate WorkItem status %s for caseId=%s gateId=%d — no gate event published",
+              status, gateRef.caseId(), gateRef.gateId());
+    }
+  }
+
+  private void handleApproved(final GateCallerRef gateRef, final WorkItem workItem) {
+    final String approvedBy = resolveActorId(workItem);
+    eventBus.publish(
+        EventBusAddresses.ACTION_GATE_APPROVED,
+        new ActionGateApprovedEvent(
+            gateRef.caseId(), gateRef.gateId(), workItem.resolution, approvedBy));
+    LOG.infof(
+        "Gate approved: caseId=%s gateId=%d approvedBy=%s",
+        gateRef.caseId(), gateRef.gateId(), approvedBy);
+  }
+
+  private void handleRejected(final GateCallerRef gateRef, final WorkItem workItem) {
+    final String rejectedBy = resolveActorId(workItem);
+    eventBus.publish(
+        EventBusAddresses.ACTION_GATE_REJECTED,
+        new ActionGateRejectedEvent(
+            gateRef.caseId(), gateRef.gateId(), workItem.resolution, rejectedBy));
+    LOG.infof(
+        "Gate rejected: caseId=%s gateId=%d rejectedBy=%s",
+        gateRef.caseId(), gateRef.gateId(), rejectedBy);
+  }
+
+  private void handleExpired(final GateCallerRef gateRef) {
+    eventBus.publish(
+        EventBusAddresses.ACTION_GATE_EXPIRED,
+        new ActionGateExpiredEvent(gateRef.caseId(), gateRef.gateId()));
+    LOG.infof("Gate expired: caseId=%s gateId=%d", gateRef.caseId(), gateRef.gateId());
+  }
+
+  /**
+   * Resolves the approver/rejector identity from the WorkItem.
+   *
+   * <p>{@code assigneeId} is the primary source (user who claimed and completed). If null, falls
+   * back to {@code resolution.completedBy} if parseable; otherwise null.
+   */
+  private static String resolveActorId(final WorkItem workItem) {
+    if (workItem == null) return null;
+    if (workItem.assigneeId != null) return workItem.assigneeId;
+    // Fallback: try resolution JSON for completedBy
+    if (workItem.resolution != null) {
+      try {
+        final com.fasterxml.jackson.databind.JsonNode node =
+            new com.fasterxml.jackson.databind.ObjectMapper().readTree(workItem.resolution);
+        final com.fasterxml.jackson.databind.JsonNode completedBy = node.get("completedBy");
+        if (completedBy != null && !completedBy.isNull()) return completedBy.asText();
+      } catch (final Exception e) {
+        // Resolution is not JSON or completedBy is absent — return null
+      }
+    }
+    return null;
+  }
+}

--- a/work-adapter/src/main/java/io/casehub/workadapter/ActionGateCompletionApplier.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/ActionGateCompletionApplier.java
@@ -52,6 +52,8 @@ import org.jboss.logging.Logger;
 public class ActionGateCompletionApplier {
 
   private static final Logger LOG = Logger.getLogger(ActionGateCompletionApplier.class);
+  private static final com.fasterxml.jackson.databind.ObjectMapper MAPPER =
+      new com.fasterxml.jackson.databind.ObjectMapper();
 
   @Inject EventBus eventBus;
 
@@ -109,8 +111,7 @@ public class ActionGateCompletionApplier {
     // Fallback: try resolution JSON for completedBy
     if (workItem.resolution != null) {
       try {
-        final com.fasterxml.jackson.databind.JsonNode node =
-            new com.fasterxml.jackson.databind.ObjectMapper().readTree(workItem.resolution);
+        final com.fasterxml.jackson.databind.JsonNode node = MAPPER.readTree(workItem.resolution);
         final com.fasterxml.jackson.databind.JsonNode completedBy = node.get("completedBy");
         if (completedBy != null && !completedBy.isNull()) return completedBy.asText();
       } catch (final Exception e) {

--- a/work-adapter/src/main/java/io/casehub/workadapter/ActionGateWorkItemHandler.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/ActionGateWorkItemHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.casehub.engine.common.internal.event.ActionGateScheduleEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.work.runtime.model.WorkItemCreateRequest;
+import io.casehub.work.runtime.service.WorkItemService;
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+import org.jboss.logging.Logger;
+
+/**
+ * Creates a WorkItem when an action gate fires.
+ *
+ * <p>Consumes {@link ActionGateScheduleEvent} on {@link EventBusAddresses#ACTION_GATE_SCHEDULE}.
+ * Creates a WorkItem with:
+ *
+ * <ul>
+ *   <li>callerRef: {@code "case:{caseId}/gate:{gateId}"} — routes back to {@link
+ *       ActionGateCompletionApplier}
+ *   <li>title: {@link io.casehub.api.spi.RiskDecision.GateRequired#reason()}
+ *   <li>candidateGroups: from the gate decision (CSV)
+ *   <li>expiresAt: from {@code expiresIn} (if set)
+ *   <li>payload: full PlannedAction as JSON (approver sees what the agent proposed)
+ * </ul>
+ *
+ * <p>No PlanItem, no BlackboardRegistry — gate WorkItems are not backed by CMMN plan items. Refs
+ * engine#402.
+ */
+@ApplicationScoped
+public class ActionGateWorkItemHandler {
+
+  private static final Logger LOG = Logger.getLogger(ActionGateWorkItemHandler.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Inject WorkItemService workItemService;
+
+  @ConsumeEvent(value = EventBusAddresses.ACTION_GATE_SCHEDULE, blocking = true)
+  @Transactional
+  public void onActionGateSchedule(final ActionGateScheduleEvent event) {
+    final String callerRef = GateCallerRef.encode(event.caseId(), event.gateId());
+    final Instant expiresAt =
+        event.gateRequired().expiresIn() != null
+            ? Instant.now().plus(event.gateRequired().expiresIn())
+            : null;
+
+    final WorkItemCreateRequest request =
+        WorkItemCreateRequest.builder()
+            .title(event.gateRequired().reason())
+            .candidateGroups(candidateGroupsCsv(event.gateRequired().candidateGroups()))
+            .createdBy("casehub-engine")
+            .payload(buildPayload(event))
+            .expiresAt(expiresAt)
+            .callerRef(callerRef)
+            .scope(event.gateRequired().scope())
+            .build();
+
+    workItemService.create(request);
+    LOG.infof(
+        "Gate WorkItem created: caseId=%s gateId=%d callerRef=%s expiresAt=%s",
+        event.caseId(), event.gateId(), callerRef, expiresAt);
+  }
+
+  private static String candidateGroupsCsv(final java.util.List<String> groups) {
+    if (groups == null || groups.isEmpty()) return null;
+    return String.join(",", groups);
+  }
+
+  private static String buildPayload(final ActionGateScheduleEvent event) {
+    final ObjectNode root = MAPPER.createObjectNode();
+    root.put("description", event.plannedAction().description());
+    root.put("actionType", event.plannedAction().actionType());
+    root.put("reversible", event.gateRequired().reversible());
+    root.set("context", MAPPER.valueToTree(event.plannedAction().context()));
+    try {
+      return MAPPER.writeValueAsString(root);
+    } catch (final JsonProcessingException e) {
+      LOG.warnf(e, "Failed to serialize gate payload for gateId=%d — using null", event.gateId());
+      return null;
+    }
+  }
+}

--- a/work-adapter/src/main/java/io/casehub/workadapter/CallerRef.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/CallerRef.java
@@ -20,31 +20,56 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Parses and constructs the {@code callerRef} string embedded by CaseHub when spawning a
+ * Sealed hierarchy for the {@code callerRef} string embedded by CaseHub when spawning a
  * quarkus-work WorkItem child.
  *
- * <p>Format: {@code case:{caseId}/pi:{planItemId}}
+ * <p>Two concrete types:
  *
- * <p>CaseHub owns the semantics of this opaque string — quarkus-work stores it unchanged on the
- * WorkItem and echoes it back in every WorkItemLifecycleEvent. Refs casehubio/work#136.
+ * <ul>
+ *   <li>{@link PlanItemCallerRef} — {@code "case:{caseId}/pi:{planItemId}"} — standard WorkItem
+ *       created from a humanTask YAML binding. Routes back to a blackboard PlanItem.
+ *   <li>{@link GateCallerRef} — {@code "case:{caseId}/gate:{gateId}"} — WorkItem created for an
+ *       action gate. Routes to {@code ActionGateCompletionApplier}; bypasses the blackboard guard
+ *       in {@code WorkItemLifecycleAdapter}.
+ * </ul>
+ *
+ * <p>CaseHub owns the semantics of these opaque strings — quarkus-work stores them unchanged on the
+ * WorkItem and echoes them back in every WorkItemLifecycleEvent. Refs casehubio/work#136.
  */
-public record CallerRef(UUID caseId, String planItemId) {
+public sealed interface CallerRef permits PlanItemCallerRef, GateCallerRef {
 
-  private static final Pattern PATTERN = Pattern.compile("^case:([0-9a-fA-F-]{36})/pi:(.+)$");
+  UUID caseId();
 
-  public static String encode(UUID caseId, String planItemId) {
-    return "case:" + caseId + "/pi:" + planItemId;
+  /**
+   * Parses a callerRef string, returning {@code null} if the string is not a recognised CaseHub
+   * callerRef format.
+   */
+  static CallerRef parse(final String raw) {
+    if (raw == null) return null;
+    final Matcher pi = Patterns.PI.matcher(raw);
+    if (pi.matches()) {
+      try {
+        return new PlanItemCallerRef(UUID.fromString(pi.group(1)), pi.group(2));
+      } catch (IllegalArgumentException e) {
+        return null;
+      }
+    }
+    final Matcher gate = Patterns.GATE.matcher(raw);
+    if (gate.matches()) {
+      try {
+        return new GateCallerRef(UUID.fromString(gate.group(1)), Long.parseLong(gate.group(2)));
+      } catch (IllegalArgumentException e) {
+        return null; // covers both UUID parse and number parse errors
+      }
+    }
+    return null;
   }
 
-  /** Returns {@code null} if the string is not a CaseHub callerRef. */
-  public static CallerRef parse(String callerRef) {
-    if (callerRef == null) return null;
-    Matcher m = PATTERN.matcher(callerRef);
-    if (!m.matches()) return null;
-    try {
-      return new CallerRef(UUID.fromString(m.group(1)), m.group(2));
-    } catch (IllegalArgumentException e) {
-      return null;
-    }
+  /** Compiled patterns kept here to avoid re-compilation on each parse() call. */
+  final class Patterns {
+    static final Pattern PI = Pattern.compile("^case:([0-9a-fA-F-]{36})/pi:(.+)$");
+    static final Pattern GATE = Pattern.compile("^case:([0-9a-fA-F-]{36})/gate:(\\d+)$");
+
+    private Patterns() {}
   }
 }

--- a/work-adapter/src/main/java/io/casehub/workadapter/GateCallerRef.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/GateCallerRef.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import java.util.UUID;
+
+/**
+ * CallerRef for WorkItems created for an action gate.
+ *
+ * <p>Format: {@code "case:{caseId}/gate:{gateId}"}
+ *
+ * <p>{@code gateId} is the EventLog entry id of the {@code ACTION_GATE_PENDING} record, used to
+ * correlate the gate's deferred output at resolution time.
+ *
+ * <p>Gate callerRefs bypass the blackboard guard in {@code WorkItemLifecycleAdapter} — gates have
+ * no associated PlanItem. The routing check must happen before the blackboard guard. Refs
+ * engine#402.
+ */
+public record GateCallerRef(UUID caseId, long gateId) implements CallerRef {
+
+  public static String encode(final UUID caseId, final long gateId) {
+    return "case:" + caseId + "/gate:" + gateId;
+  }
+}

--- a/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
@@ -126,7 +126,7 @@ public class HumanTaskScheduleHandler {
       return;
     }
 
-    String callerRef = CallerRef.encode(event.caseId(), item.getPlanItemId());
+    String callerRef = PlanItemCallerRef.encode(event.caseId(), item.getPlanItemId());
     WorkItem workItem =
         workItemTemplateService.instantiate(
             template, target.title(), null, "casehub-engine", callerRef);
@@ -153,7 +153,7 @@ public class HumanTaskScheduleHandler {
   }
 
   private void handleInlineMode(PlanItem item, HumanTaskScheduleEvent event) {
-    String callerRef = CallerRef.encode(event.caseId(), item.getPlanItemId());
+    String callerRef = PlanItemCallerRef.encode(event.caseId(), item.getPlanItemId());
     createInline(event.target(), event.inputData(), callerRef, event.caseBudgetDeadline());
     planItemStore.save(
         new PlanItemSaveRequest(

--- a/work-adapter/src/main/java/io/casehub/workadapter/PlanItemCallerRef.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/PlanItemCallerRef.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import java.util.UUID;
+
+/**
+ * CallerRef for WorkItems created from humanTask YAML bindings.
+ *
+ * <p>Format: {@code "case:{caseId}/pi:{planItemId}"}
+ *
+ * <p>Routes WorkItem lifecycle events back to the associated PlanItem in the blackboard. Refs
+ * casehubio/work#136, engine#245.
+ */
+public record PlanItemCallerRef(UUID caseId, String planItemId) implements CallerRef {
+
+  public static String encode(final UUID caseId, final String planItemId) {
+    return "case:" + caseId + "/pi:" + planItemId;
+  }
+}

--- a/work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
@@ -84,14 +84,23 @@ public class WorkItemLifecycleAdapter {
     CallerRef ref = CallerRef.parse(workItem.callerRef);
     if (ref == null) return;
 
-    if (registry.get(ref.caseId()).isEmpty()) {
-      LOG.debugf(
-          "No CasePlanModel for caseId=%s — case may have completed or not use blackboard",
-          ref.caseId());
+    // Gate WorkItems bypass the blackboard guard — they have no PlanItem. Gate routing
+    // is handled by ActionGateCompletionApplier (wired in task #13 / engine#402).
+    if (ref instanceof GateCallerRef gateRef) {
+      routeGate(gateRef, status, workItem);
       return;
     }
 
-    applier.apply(ref.caseId(), ref.planItemId(), status, workItem);
+    if (!(ref instanceof PlanItemCallerRef piRef)) return;
+
+    if (registry.get(piRef.caseId()).isEmpty()) {
+      LOG.debugf(
+          "No CasePlanModel for caseId=%s — case may have completed or not use blackboard",
+          piRef.caseId());
+      return;
+    }
+
+    applier.apply(piRef.caseId(), piRef.planItemId(), status, workItem);
   }
 
   public void onWorkItemGroupLifecycle(@ObservesAsync WorkItemGroupLifecycleEvent event) {
@@ -99,26 +108,28 @@ public class WorkItemLifecycleAdapter {
     if (status != GroupStatus.COMPLETED && status != GroupStatus.REJECTED) return;
 
     CallerRef ref = CallerRef.parse(event.callerRef());
-    if (ref == null) return;
+    if (!(ref instanceof PlanItemCallerRef piRef)) return;
 
-    CasePlanModel plan = registry.get(ref.caseId()).orElse(null);
+    CasePlanModel plan = registry.get(piRef.caseId()).orElse(null);
     if (plan == null) {
-      LOG.debugf("No CasePlanModel for caseId=%s — group outcome ignored", ref.caseId());
+      LOG.debugf("No CasePlanModel for caseId=%s — group outcome ignored", piRef.caseId());
       return;
     }
 
-    PlanItem item = plan.getPlanItem(ref.planItemId()).orElse(null);
+    PlanItem item = plan.getPlanItem(piRef.planItemId()).orElse(null);
     if (item == null) {
       LOG.warnf(
-          "PlanItem %s not found in case %s for group outcome", ref.planItemId(), ref.caseId());
+          "PlanItem %s not found in case %s for group outcome", piRef.planItemId(), piRef.caseId());
       return;
     }
 
     if (!applyGroupStatus(item, status)) return;
 
-    CaseInstance instance = caseInstanceRepository.findByUuid(ref.caseId()).await().atMost(TIMEOUT);
+    CaseInstance instance =
+        caseInstanceRepository.findByUuid(piRef.caseId()).await().atMost(TIMEOUT);
     if (instance == null) {
-      LOG.warnf("CaseInstance not found for caseId=%s — cannot fire CONTEXT_CHANGED", ref.caseId());
+      LOG.warnf(
+          "CaseInstance not found for caseId=%s — cannot fire CONTEXT_CHANGED", piRef.caseId());
       return;
     }
 
@@ -159,25 +170,26 @@ public class WorkItemLifecycleAdapter {
     if (!(event.source() instanceof WorkItem workItem)) return;
 
     CallerRef ref = CallerRef.parse(workItem.callerRef);
-    if (ref == null) return;
+    if (!(ref instanceof PlanItemCallerRef piRef)) return;
 
-    CasePlanModel plan = registry.get(ref.caseId()).orElse(null);
+    CasePlanModel plan = registry.get(piRef.caseId()).orElse(null);
     if (plan == null) {
-      LOG.debugf("No CasePlanModel for caseId=%s — escalation signal skipped", ref.caseId());
+      LOG.debugf("No CasePlanModel for caseId=%s — escalation signal skipped", piRef.caseId());
       return;
     }
 
-    PlanItem item = plan.getPlanItem(ref.planItemId()).orElse(null);
+    PlanItem item = plan.getPlanItem(piRef.planItemId()).orElse(null);
     if (item == null) {
       LOG.warnf(
           "PlanItem %s not found in case %s — escalation signal skipped",
-          ref.planItemId(), ref.caseId());
+          piRef.planItemId(), piRef.caseId());
       return;
     }
 
-    CaseInstance instance = caseInstanceRepository.findByUuid(ref.caseId()).await().atMost(TIMEOUT);
+    CaseInstance instance =
+        caseInstanceRepository.findByUuid(piRef.caseId()).await().atMost(TIMEOUT);
     if (instance == null) {
-      LOG.warnf("CaseInstance not found for caseId=%s — escalation signal skipped", ref.caseId());
+      LOG.warnf("CaseInstance not found for caseId=%s — escalation signal skipped", piRef.caseId());
       return;
     }
 
@@ -203,6 +215,14 @@ public class WorkItemLifecycleAdapter {
 
     LOG.infof(
         "WorkItem escalation signal: caseId=%s planItemId=%s bindingName=%s newGroups=%s",
-        ref.caseId(), ref.planItemId(), item.getBindingName(), newGroups);
+        piRef.caseId(), piRef.planItemId(), item.getBindingName(), newGroups);
+  }
+
+  /** Stub — replaced by full ActionGateCompletionApplier routing in engine#402 task #13. */
+  private void routeGate(
+      final GateCallerRef gateRef, final WorkItemStatus status, final WorkItem workItem) {
+    LOG.debugf(
+        "Gate WorkItem lifecycle: caseId=%s gateId=%d status=%s — routing pending task #13",
+        gateRef.caseId(), gateRef.gateId(), status);
   }
 }

--- a/work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
@@ -66,6 +66,8 @@ public class WorkItemLifecycleAdapter {
 
   @Inject PlanItemCompletionApplier applier;
 
+  @Inject ActionGateCompletionApplier gateApplier;
+
   public void onWorkItemLifecycle(@ObservesAsync WorkItemLifecycleEvent event) {
     WorkItemStatus status = event.status();
 
@@ -218,11 +220,8 @@ public class WorkItemLifecycleAdapter {
         piRef.caseId(), piRef.planItemId(), item.getBindingName(), newGroups);
   }
 
-  /** Stub — replaced by full ActionGateCompletionApplier routing in engine#402 task #13. */
   private void routeGate(
       final GateCallerRef gateRef, final WorkItemStatus status, final WorkItem workItem) {
-    LOG.debugf(
-        "Gate WorkItem lifecycle: caseId=%s gateId=%d status=%s — routing pending task #13",
-        gateRef.caseId(), gateRef.gateId(), status);
+    gateApplier.apply(gateRef, status, workItem);
   }
 }

--- a/work-adapter/src/main/java/io/casehub/workadapter/recovery/HumanTaskRecoveryService.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/recovery/HumanTaskRecoveryService.java
@@ -20,7 +20,7 @@ import io.casehub.engine.common.spi.PlanItemStore;
 import io.casehub.work.runtime.model.WorkItem;
 import io.casehub.work.runtime.model.WorkItemStatus;
 import io.casehub.work.runtime.service.WorkItemService;
-import io.casehub.workadapter.CallerRef;
+import io.casehub.workadapter.PlanItemCallerRef;
 import io.casehub.workadapter.PlanItemCompletionApplier;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.annotation.Priority;
@@ -80,7 +80,7 @@ public class HumanTaskRecoveryService {
   }
 
   private boolean tryRecover(PlanItemRecord r) {
-    String callerRef = CallerRef.encode(r.caseId(), r.planItemId());
+    String callerRef = PlanItemCallerRef.encode(r.caseId(), r.planItemId());
     Optional<WorkItem> workItemOpt = workItemService.findByCallerRef(callerRef);
 
     if (workItemOpt.isEmpty()) {

--- a/work-adapter/src/test/java/io/casehub/workadapter/ActionGateHandlerTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/ActionGateHandlerTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.casehub.api.spi.PlannedAction;
+import io.casehub.api.spi.RiskDecision.GateRequired;
+import io.casehub.engine.common.internal.event.ActionGateApprovedEvent;
+import io.casehub.engine.common.internal.event.ActionGateCancelledEvent;
+import io.casehub.engine.common.internal.event.ActionGateExpiredEvent;
+import io.casehub.engine.common.internal.event.ActionGateRejectedEvent;
+import io.casehub.engine.common.internal.event.ActionGateScheduleEvent;
+import io.casehub.engine.common.internal.event.EventBusAddresses;
+import io.casehub.work.runtime.model.WorkItem;
+import io.casehub.work.runtime.model.WorkItemStatus;
+import io.casehub.work.runtime.repository.WorkItemStore;
+import io.casehub.work.testing.InMemoryWorkItemStore;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.vertx.ConsumeEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for ActionGateWorkItemHandler, ActionGateCompletionApplier, and gate routing in
+ * WorkItemLifecycleAdapter.
+ *
+ * <p>Uses @ConsumeEvent recording beans to capture gate resolution events. Quarkus registers codecs
+ * for event types when it scans @ConsumeEvent annotations at startup — the recorder beans enable
+ * this without requiring the engine runtime module on the classpath.
+ */
+@QuarkusTest
+class ActionGateHandlerTest {
+
+  private static final String TENANCY_ID = "test-tenant";
+
+  @Inject ActionGateWorkItemHandler actionGateWorkItemHandler;
+  @Inject ActionGateCompletionApplier actionGateCompletionApplier;
+  @Inject WorkItemStore workItemStore;
+
+  @BeforeEach
+  void setUp() {
+    GateEventRecorder.reset();
+    if (workItemStore instanceof InMemoryWorkItemStore mem) {
+      mem.clear();
+    }
+  }
+
+  @AfterEach
+  @Transactional
+  void tearDown() {
+    if (workItemStore instanceof InMemoryWorkItemStore mem) {
+      mem.clear();
+    }
+  }
+
+  // --- ActionGateWorkItemHandler ---
+
+  @Test
+  @Transactional
+  void onActionGateSchedule_createsWorkItemWithGateCallerRef() {
+    final UUID caseId = UUID.randomUUID();
+    final long gateId = 42L;
+    final GateRequired gate =
+        new GateRequired(
+            "SAR filing requires MLRO sign-off", false, List.of("mlro", "analyst"), null, null);
+    final PlannedAction action =
+        PlannedAction.of("File SAR", "sar.file", Map.of("accountId", "ACC-123"));
+
+    actionGateWorkItemHandler.onActionGateSchedule(
+        new ActionGateScheduleEvent(caseId, TENANCY_ID, gateId, action, gate));
+
+    final String expectedCallerRef = GateCallerRef.encode(caseId, gateId);
+    final WorkItem workItem = workItemStore.findByCallerRef(expectedCallerRef).orElse(null);
+
+    assertThat(workItem).isNotNull();
+    assertThat(workItem.callerRef).isEqualTo(expectedCallerRef);
+    assertThat(workItem.title).isEqualTo("SAR filing requires MLRO sign-off");
+    assertThat(workItem.candidateGroups).isEqualTo("mlro,analyst");
+    assertThat(workItem.payload).contains("sar.file");
+    assertThat(workItem.payload).contains("ACC-123");
+    assertThat(workItem.payload).contains("File SAR");
+  }
+
+  @Test
+  @Transactional
+  void onActionGateSchedule_noExpiresAt_whenExpiresInIsNull() {
+    final UUID caseId = UUID.randomUUID();
+    final GateRequired gate = new GateRequired("Confirm action", true, null, null, null);
+    final PlannedAction action = PlannedAction.of("Do something", "action.type", Map.of());
+
+    actionGateWorkItemHandler.onActionGateSchedule(
+        new ActionGateScheduleEvent(caseId, TENANCY_ID, 99L, action, gate));
+
+    final String callerRef = GateCallerRef.encode(caseId, 99L);
+    final WorkItem workItem = workItemStore.findByCallerRef(callerRef).orElse(null);
+    assertThat(workItem).isNotNull();
+    // candidateGroups is null when not specified — WorkItemService does not add defaults
+    assertThat(workItem.candidateGroups).isNull();
+    // expiresAt may be set by WorkItemService defaults; we don't assert null here
+  }
+
+  @Test
+  @Transactional
+  void onActionGateSchedule_withExpiresIn_setsExpiresAt() {
+    final UUID caseId = UUID.randomUUID();
+    final Instant before = Instant.now();
+    final GateRequired gate =
+        new GateRequired("Urgent review", false, List.of("mlro"), Duration.ofHours(24), null);
+
+    actionGateWorkItemHandler.onActionGateSchedule(
+        new ActionGateScheduleEvent(
+            caseId, TENANCY_ID, 77L, PlannedAction.of("d", "t", Map.of()), gate));
+
+    final WorkItem workItem =
+        workItemStore.findByCallerRef(GateCallerRef.encode(caseId, 77L)).orElse(null);
+    assertThat(workItem).isNotNull();
+    assertThat(workItem.expiresAt).isNotNull();
+    assertThat(workItem.expiresAt).isAfter(before.plus(Duration.ofHours(23)));
+    assertThat(workItem.expiresAt).isBefore(before.plus(Duration.ofHours(25)));
+  }
+
+  // --- ActionGateCompletionApplier ---
+
+  @Test
+  void completionApplier_completed_publishesApprovedEvent() {
+    final UUID caseId = UUID.randomUUID();
+    final long gateId = 10L;
+    final WorkItem workItem = new WorkItem();
+    workItem.callerRef = GateCallerRef.encode(caseId, gateId);
+    workItem.assigneeId = "user-mlro-001";
+    workItem.resolution = "{\"note\": \"approved\"}";
+
+    actionGateCompletionApplier.apply(
+        new GateCallerRef(caseId, gateId), WorkItemStatus.COMPLETED, workItem);
+
+    await().atMost(2, TimeUnit.SECONDS).until(() -> !GateEventRecorder.approvedEvents.isEmpty());
+
+    assertThat(GateEventRecorder.approvedEvents).hasSize(1);
+    assertThat(GateEventRecorder.approvedEvents.get(0).caseId()).isEqualTo(caseId);
+    assertThat(GateEventRecorder.approvedEvents.get(0).gateId()).isEqualTo(gateId);
+    assertThat(GateEventRecorder.approvedEvents.get(0).approvedBy())
+        .isEqualTo("user-mlro-001"); // from assigneeId
+    assertThat(GateEventRecorder.rejectedEvents).isEmpty();
+    assertThat(GateEventRecorder.expiredEvents).isEmpty();
+  }
+
+  @Test
+  void completionApplier_rejected_publishesRejectedEvent() {
+    final UUID caseId = UUID.randomUUID();
+    final long gateId = 20L;
+    final WorkItem workItem = new WorkItem();
+    workItem.callerRef = GateCallerRef.encode(caseId, gateId);
+    workItem.assigneeId = "user-mlro-002";
+    workItem.resolution = "{\"reason\": \"rejected\"}";
+
+    actionGateCompletionApplier.apply(
+        new GateCallerRef(caseId, gateId), WorkItemStatus.REJECTED, workItem);
+
+    await().atMost(2, TimeUnit.SECONDS).until(() -> !GateEventRecorder.rejectedEvents.isEmpty());
+
+    assertThat(GateEventRecorder.rejectedEvents).hasSize(1);
+    assertThat(GateEventRecorder.rejectedEvents.get(0).caseId()).isEqualTo(caseId);
+    assertThat(GateEventRecorder.rejectedEvents.get(0).rejectedBy()).isEqualTo("user-mlro-002");
+    assertThat(GateEventRecorder.approvedEvents).isEmpty();
+  }
+
+  @Test
+  void completionApplier_cancelled_publishesRejectedEvent() {
+    final UUID caseId = UUID.randomUUID();
+    final WorkItem workItem = new WorkItem();
+    workItem.callerRef = GateCallerRef.encode(caseId, 30L);
+
+    actionGateCompletionApplier.apply(
+        new GateCallerRef(caseId, 30L), WorkItemStatus.CANCELLED, workItem);
+
+    await().atMost(2, TimeUnit.SECONDS).until(() -> !GateEventRecorder.rejectedEvents.isEmpty());
+    assertThat(GateEventRecorder.rejectedEvents).hasSize(1);
+    assertThat(GateEventRecorder.rejectedEvents.get(0).caseId()).isEqualTo(caseId);
+  }
+
+  @Test
+  void completionApplier_expired_publishesExpiredEvent() {
+    final UUID caseId = UUID.randomUUID();
+    final WorkItem workItem = new WorkItem();
+    workItem.callerRef = GateCallerRef.encode(caseId, 40L);
+
+    actionGateCompletionApplier.apply(
+        new GateCallerRef(caseId, 40L), WorkItemStatus.EXPIRED, workItem);
+
+    await().atMost(2, TimeUnit.SECONDS).until(() -> !GateEventRecorder.expiredEvents.isEmpty());
+    assertThat(GateEventRecorder.expiredEvents).hasSize(1);
+    assertThat(GateEventRecorder.expiredEvents.get(0).caseId()).isEqualTo(caseId);
+    assertThat(GateEventRecorder.expiredEvents.get(0).gateId()).isEqualTo(40L);
+  }
+
+  // --- Recording CDI beans — @ConsumeEvent causes Quarkus to register codecs for event types ---
+
+  @ApplicationScoped
+  static class GateEventRecorder {
+
+    static final List<ActionGateApprovedEvent> approvedEvents = new CopyOnWriteArrayList<>();
+    static final List<ActionGateRejectedEvent> rejectedEvents = new CopyOnWriteArrayList<>();
+    static final List<ActionGateExpiredEvent> expiredEvents = new CopyOnWriteArrayList<>();
+    static final List<ActionGateCancelledEvent> cancelledEvents = new CopyOnWriteArrayList<>();
+
+    static void reset() {
+      approvedEvents.clear();
+      rejectedEvents.clear();
+      expiredEvents.clear();
+      cancelledEvents.clear();
+    }
+
+    @ConsumeEvent(EventBusAddresses.ACTION_GATE_APPROVED)
+    void onApproved(final ActionGateApprovedEvent event) {
+      approvedEvents.add(event);
+    }
+
+    @ConsumeEvent(EventBusAddresses.ACTION_GATE_REJECTED)
+    void onRejected(final ActionGateRejectedEvent event) {
+      rejectedEvents.add(event);
+    }
+
+    @ConsumeEvent(EventBusAddresses.ACTION_GATE_EXPIRED)
+    void onExpired(final ActionGateExpiredEvent event) {
+      expiredEvents.add(event);
+    }
+
+    @ConsumeEvent(EventBusAddresses.ACTION_GATE_CANCELLED)
+    void onCancelled(final ActionGateCancelledEvent event) {
+      cancelledEvents.add(event);
+    }
+  }
+}

--- a/work-adapter/src/test/java/io/casehub/workadapter/CallerRefTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/CallerRefTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.workadapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class CallerRefTest {
+
+  // --- PlanItemCallerRef encode/parse round-trip ---
+
+  @Test
+  void planItemCallerRef_encode_hasExpectedFormat() {
+    final UUID caseId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    final String encoded = PlanItemCallerRef.encode(caseId, "plan-item-abc");
+
+    assertThat(encoded).isEqualTo("case:00000000-0000-0000-0000-000000000001/pi:plan-item-abc");
+  }
+
+  @Test
+  void planItemCallerRef_parse_roundTrip() {
+    final UUID caseId = UUID.randomUUID();
+    final String encoded = PlanItemCallerRef.encode(caseId, "item-99");
+
+    final CallerRef parsed = CallerRef.parse(encoded);
+
+    assertThat(parsed).isInstanceOf(PlanItemCallerRef.class);
+    final PlanItemCallerRef pi = (PlanItemCallerRef) parsed;
+    assertThat(pi.caseId()).isEqualTo(caseId);
+    assertThat(pi.planItemId()).isEqualTo("item-99");
+  }
+
+  @Test
+  void planItemCallerRef_caseId_isAccessibleViaInterface() {
+    final UUID caseId = UUID.randomUUID();
+    final CallerRef ref = CallerRef.parse(PlanItemCallerRef.encode(caseId, "pi-1"));
+
+    assertThat(ref.caseId()).isEqualTo(caseId);
+  }
+
+  // --- GateCallerRef encode/parse round-trip ---
+
+  @Test
+  void gateCallerRef_encode_hasExpectedFormat() {
+    final UUID caseId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    final String encoded = GateCallerRef.encode(caseId, 42L);
+
+    assertThat(encoded).isEqualTo("case:00000000-0000-0000-0000-000000000002/gate:42");
+  }
+
+  @Test
+  void gateCallerRef_parse_roundTrip() {
+    final UUID caseId = UUID.randomUUID();
+    final long gateId = 9_876_543L;
+    final String encoded = GateCallerRef.encode(caseId, gateId);
+
+    final CallerRef parsed = CallerRef.parse(encoded);
+
+    assertThat(parsed).isInstanceOf(GateCallerRef.class);
+    final GateCallerRef gate = (GateCallerRef) parsed;
+    assertThat(gate.caseId()).isEqualTo(caseId);
+    assertThat(gate.gateId()).isEqualTo(gateId);
+  }
+
+  @Test
+  void gateCallerRef_caseId_isAccessibleViaInterface() {
+    final UUID caseId = UUID.randomUUID();
+    final CallerRef ref = CallerRef.parse(GateCallerRef.encode(caseId, 1L));
+
+    assertThat(ref.caseId()).isEqualTo(caseId);
+  }
+
+  // --- Discrimination: gate vs plan-item ---
+
+  @Test
+  void parse_piFormat_isNotGateCallerRef() {
+    final CallerRef ref = CallerRef.parse(PlanItemCallerRef.encode(UUID.randomUUID(), "x"));
+
+    assertThat(ref).isNotInstanceOf(GateCallerRef.class);
+  }
+
+  @Test
+  void parse_gateFormat_isNotPlanItemCallerRef() {
+    final CallerRef ref = CallerRef.parse(GateCallerRef.encode(UUID.randomUUID(), 5L));
+
+    assertThat(ref).isNotInstanceOf(PlanItemCallerRef.class);
+  }
+
+  // --- Null and invalid input ---
+
+  @Test
+  void parse_null_returnsNull() {
+    assertThat(CallerRef.parse(null)).isNull();
+  }
+
+  @Test
+  void parse_emptyString_returnsNull() {
+    assertThat(CallerRef.parse("")).isNull();
+  }
+
+  @Test
+  void parse_randomString_returnsNull() {
+    assertThat(CallerRef.parse("not-a-caller-ref")).isNull();
+  }
+
+  @Test
+  void parse_malformedUuid_returnsNull() {
+    assertThat(CallerRef.parse("case:not-a-uuid/pi:item-1")).isNull();
+  }
+
+  @Test
+  void parse_gateWithNonNumericId_returnsNull() {
+    assertThat(CallerRef.parse("case:00000000-0000-0000-0000-000000000001/gate:not-a-number"))
+        .isNull();
+  }
+
+  @Test
+  void parse_unknownSegmentType_returnsNull() {
+    assertThat(CallerRef.parse("case:00000000-0000-0000-0000-000000000001/unknown:value")).isNull();
+  }
+
+  // --- GateId precision ---
+
+  @Test
+  void gateCallerRef_gateId_preservesLargeValue() {
+    final long largeId = Long.MAX_VALUE;
+    final UUID caseId = UUID.randomUUID();
+    final CallerRef ref = CallerRef.parse(GateCallerRef.encode(caseId, largeId));
+
+    assertThat(((GateCallerRef) ref).gateId()).isEqualTo(largeId);
+  }
+}

--- a/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerTest.java
@@ -114,7 +114,7 @@ class HumanTaskScheduleHandlerTest {
         new HumanTaskScheduleEvent(
             caseId, "irb-binding", target, Map.of("caseRef", "T-42"), null, TENANCY_ID));
 
-    String expectedCallerRef = CallerRef.encode(caseId, planItem.getPlanItemId());
+    String expectedCallerRef = PlanItemCallerRef.encode(caseId, planItem.getPlanItemId());
 
     WorkItem created =
         workItemStore.scanAll().stream()
@@ -147,7 +147,7 @@ class HumanTaskScheduleHandlerTest {
             null,
             TENANCY_ID));
 
-    String expectedCallerRef = CallerRef.encode(caseId, planItem.getPlanItemId());
+    String expectedCallerRef = PlanItemCallerRef.encode(caseId, planItem.getPlanItemId());
     WorkItem created =
         workItemStore.scanAll().stream()
             .filter(w -> expectedCallerRef.equals(w.callerRef))

--- a/work-adapter/src/test/java/io/casehub/workadapter/NoOpLedgerEntryRepository.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/NoOpLedgerEntryRepository.java
@@ -79,6 +79,11 @@ class NoOpLedgerEntryRepository implements LedgerEntryRepository {
   }
 
   @Override
+  public List<LedgerEntry> findEventsByActorId(String actorId) {
+    return List.of();
+  }
+
+  @Override
   public Map<UUID, List<LedgerAttestation>> findAttestationsForEntries(Set<UUID> entryIds) {
     return Map.of();
   }

--- a/work-adapter/src/test/java/io/casehub/workadapter/NoOpReactiveLedgerEntryRepository.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/NoOpReactiveLedgerEntryRepository.java
@@ -75,6 +75,11 @@ class NoOpReactiveLedgerEntryRepository implements ReactiveLedgerEntryRepository
   }
 
   @Override
+  public Uni<List<LedgerEntry>> findEventsByActorId(String actorId) {
+    return Uni.createFrom().item(List.of());
+  }
+
+  @Override
   public Uni<List<LedgerEntry>> findByActorId(String actorId, Instant from, Instant to) {
     return Uni.createFrom().item(List.of());
   }

--- a/work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java
@@ -113,7 +113,7 @@ class WorkItemLifecycleAdapterTest {
     WorkItem workItem = new WorkItem();
     workItem.id = UUID.randomUUID();
     workItem.status = WorkItemStatus.REJECTED;
-    workItem.callerRef = CallerRef.encode(caseId, delegatedItemId);
+    workItem.callerRef = PlanItemCallerRef.encode(caseId, delegatedItemId);
     lifecycleEvents.fireAsync(
         WorkItemLifecycleEvent.of("workitem.rejected", workItem, "system", null));
 
@@ -134,7 +134,7 @@ class WorkItemLifecycleAdapterTest {
     WorkItem workItem = new WorkItem();
     workItem.id = UUID.randomUUID();
     workItem.status = WorkItemStatus.EXPIRED;
-    workItem.callerRef = CallerRef.encode(caseId, delegatedItemId);
+    workItem.callerRef = PlanItemCallerRef.encode(caseId, delegatedItemId);
     lifecycleEvents.fireAsync(
         WorkItemLifecycleEvent.of("workitem.expired", workItem, "system", null));
 
@@ -153,7 +153,7 @@ class WorkItemLifecycleAdapterTest {
     escalatedItem.id = UUID.randomUUID();
     escalatedItem.status = WorkItemStatus.ESCALATED;
     escalatedItem.candidateGroups = "committee-a,committee-b";
-    escalatedItem.callerRef = CallerRef.encode(caseId, planItemId);
+    escalatedItem.callerRef = PlanItemCallerRef.encode(caseId, planItemId);
 
     lifecycleEvents.fireAsync(
         WorkItemLifecycleEvent.of("workitem.escalated", escalatedItem, "system", null));
@@ -251,7 +251,7 @@ class WorkItemLifecycleAdapterTest {
     WorkItem workItem = new WorkItem();
     workItem.id = UUID.randomUUID();
     workItem.status = WorkItemStatus.COMPLETED;
-    workItem.callerRef = CallerRef.encode(caseId, htPlanItem.getPlanItemId());
+    workItem.callerRef = PlanItemCallerRef.encode(caseId, htPlanItem.getPlanItemId());
     workItem.resolution = "{ \"decision\": \"Approved\" }";
 
     lifecycleEvents.fireAsync(
@@ -288,7 +288,7 @@ class WorkItemLifecycleAdapterTest {
     WorkItem workItem = new WorkItem();
     workItem.id = UUID.randomUUID();
     workItem.status = WorkItemStatus.COMPLETED;
-    workItem.callerRef = CallerRef.encode(caseId, htPlanItem.getPlanItemId());
+    workItem.callerRef = PlanItemCallerRef.encode(caseId, htPlanItem.getPlanItemId());
     workItem.resolution = "{}";
 
     lifecycleEvents.fireAsync(
@@ -315,7 +315,7 @@ class WorkItemLifecycleAdapterTest {
     WorkItem workItem = new WorkItem();
     workItem.id = UUID.randomUUID();
     workItem.status = WorkItemStatus.COMPLETED;
-    workItem.callerRef = CallerRef.encode(caseId, htPlanItem.getPlanItemId());
+    workItem.callerRef = PlanItemCallerRef.encode(caseId, htPlanItem.getPlanItemId());
     workItem.resolution = "{ \"decision\": \"approved\" }";
 
     lifecycleEvents.fireAsync(
@@ -394,7 +394,7 @@ class WorkItemLifecycleAdapterTest {
             0,
             3,
             GroupStatus.REJECTED,
-            CallerRef.encode(caseId, delegatedItemId)));
+            PlanItemCallerRef.encode(caseId, delegatedItemId)));
 
     await()
         .atMost(5, TimeUnit.SECONDS)
@@ -443,7 +443,7 @@ class WorkItemLifecycleAdapterTest {
     WorkItem workItem = new WorkItem();
     workItem.id = UUID.randomUUID();
     workItem.status = status;
-    workItem.callerRef = CallerRef.encode(caseId, planItemId);
+    workItem.callerRef = PlanItemCallerRef.encode(caseId, planItemId);
     workItem.resolution = resolution;
     return WorkItemLifecycleEvent.of(
         "workitem." + status.name().toLowerCase(), workItem, "system", null);
@@ -458,6 +458,6 @@ class WorkItemLifecycleAdapterTest {
         2,
         0,
         status,
-        CallerRef.encode(caseId, planItemId));
+        PlanItemCallerRef.encode(caseId, planItemId));
   }
 }

--- a/work-adapter/src/test/java/io/casehub/workadapter/recovery/HumanTaskRecoveryServiceTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/recovery/HumanTaskRecoveryServiceTest.java
@@ -33,7 +33,7 @@ import io.casehub.work.runtime.model.WorkItem;
 import io.casehub.work.runtime.model.WorkItemStatus;
 import io.casehub.work.runtime.repository.WorkItemStore;
 import io.casehub.work.testing.InMemoryWorkItemStore;
-import io.casehub.workadapter.CallerRef;
+import io.casehub.workadapter.PlanItemCallerRef;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -67,7 +67,7 @@ class HumanTaskRecoveryServiceTest {
     if (workItemStore instanceof InMemoryWorkItemStore mem) mem.clear();
     caseId = UUID.randomUUID();
     planItemId = UUID.randomUUID().toString();
-    callerRef = CallerRef.encode(caseId, planItemId);
+    callerRef = PlanItemCallerRef.encode(caseId, planItemId);
 
     planItemStore.save(
         new PlanItemSaveRequest(


### PR DESCRIPTION
## Summary

Implements the `ActionRiskClassifier` SPI — a platform-level oversight gate for consequential worker actions. Workers declare what they are about to do (`PlannedAction`); the engine classifies the risk and gates the case pending human approval if needed. Workers write zero approval logic.

See design spec: `docs/specs/2026-06-05-action-risk-classifier-design.md`

## What changed

**Breaking change:** All worker function lambdas and `Agent.execute()` now return `WorkerResult` instead of `Map<String,Object>`. Migration: `return map` → `return WorkerResult.of(map)`.

**New SPI** (`api/spi/`):
- `ActionRiskClassifier` (blocking) + `ReactiveActionRiskClassifier` (Mutiny)
- `PlannedAction` — what the worker declares
- `RiskDecision` sealed: `Autonomous | GateRequired(reason, reversible, candidateGroups, expiresIn, scope)`
- `@RiskClassifier` CDI qualifier — prevents self-injection in the chain
- `WorkerResult` — new worker return type

**Engine runtime** (`runtime/`):
- `ChainedReactiveActionRiskClassifier`: chains all `@RiskClassifier` beans, most-restrictive-wins, fail-safe `GateRequired` on classifier error, offloads blocking classifiers to worker pool
- `WorkflowExecutionCompletedHandler`: gate fork — classifies before applying output
- `ActionGateApprovedHandler`: re-fires `WorkflowExecutionCompleted(plannedAction=null)` — reuses normal completion machinery
- `ActionGateRejectedHandler` / `ActionGateExpiredHandler`: write context signals, fire `CONTEXT_CHANGED`, publish `ACTION_GATE_WORKER_FAULTED` for blackboard
- `CaseStatusChangedHandler`: publishes `ActionGateCancelledEvent` on case termination with pending gate
- `ActionGateDeploymentHealthCheck`: warns at startup if classifiers registered without work-adapter

**Work-adapter** (`work-adapter/`):
- `CallerRef` sealed hierarchy: `PlanItemCallerRef | GateCallerRef` (structural change, 25 call sites)
- `ActionGateWorkItemHandler`: creates gate WorkItem from `ActionGateScheduleEvent`
- `ActionGateCompletionApplier`: COMPLETED/REJECTED/EXPIRED/CANCELLED → gate events
- `ActionGateCancelledHandler`: cancels orphaned gate WorkItem on case termination

**Blackboard** (`blackboard/`):
- `ActionGateRejectedPlanItemHandler` / `ActionGateExpiredPlanItemHandler`: mark PlanItem FAULTED on `ACTION_GATE_WORKER_FAULTED` — enables stage autocomplete

**Key design decisions:**
- `pendingActionGate` is in-memory only (not JPA-persisted) in v1 — restart loses pending gate (engine#433)
- Gate approval re-fires `WorkflowExecutionCompleted(plannedAction=null)` — reuses normal completion machinery including `PlanItemCompletionHandler` and `StageAutocompleteEvaluator`
- `ACTION_GATE_WORKER_FAULTED` distinct from `WORKER_RETRIES_EXHAUSTED` — gate faults must not case-fault the `CaseInstance`
- Binding trigger must exclude gate signals to prevent re-scheduling while gate is pending

## Consumer repos unblocked

- aml#42 — SAR filing, account freeze, law enforcement referral
- clinical#47 — SUSAR filing, dose modification, patient withdrawal
- devtown#56 — production deploy, contributor access, security escalation
- life#20 — spend threshold, non-refundable bookings, contractor instruction
- openclaw#6 — oversight channel gate (Epic 6 end-to-end wiring)

## Issues filed

- engine#431: workflow worker PlannedAction support (v1 limitation)
- engine#432: consumer `ReactiveActionRiskClassifier` support
- engine#433: persist `pendingActionGate` in `CaseInstanceEntity` (v2, restart resilience)
- engine#434: integration test for classifier-throws fail-safe

## Test coverage

- `ChainedReactiveActionRiskClassifierTest` — 12 unit tests (chain semantics, fail-safe, merge)
- `CallerRefTest` — 15 unit tests (parse/encode round-trips)
- `ActionGateIntegrationTest` — 5 integration tests (gate fork, autonomous/gated paths)
- `ActionGateResolutionTest` — 3 integration tests (approved, rejected, terminal guard)
- `ActionGateHandlerTest` — 7 integration tests (WorkItem creation, gate completion events)

Closes #402