### PR TITLE
feat: dynamic candidateGroups/candidateUsers for humanTask bindings — ListEvaluator sealed type (engine#387)

### DIFF
--- a/actor-state/src/main/java/io/casehub/actorstate/LedgerActorStateContributor.java
+++ b/actor-state/src/main/java/io/casehub/actorstate/LedgerActorStateContributor.java
@@ -21,6 +21,7 @@ import io.casehub.platform.api.actor.ActorStateContributor;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Map;
+import java.util.OptionalDouble;
 
 /** Contributes global and capability trust scores from casehub-ledger. */
 @ApplicationScoped
@@ -36,10 +37,10 @@ public class LedgerActorStateContributor implements ActorStateContributor {
   @Override
   public void contribute(final String actorId, final ActorStateAccumulator acc) {
     // Atomic: collect all data before calling accumulator methods.
-    // findScore().map(s -> s.trustScore): primitive double boxed to Double.
-    // null means no score computed yet — distinct from 0.0 (zero trust).
-    final Double globalScore =
-        trustGateService.findScore(actorId).map(s -> s.trustScore).orElse(null);
+    // currentScore() returns OptionalDouble — box to Double; null means no score yet,
+    // distinct from 0.0 (zero trust).
+    final OptionalDouble rawScore = trustGateService.currentScore(actorId);
+    final Double globalScore = rawScore.isPresent() ? rawScore.getAsDouble() : null;
     final Map<String, Double> capScores = trustGateService.allCapabilityScores(actorId);
     acc.trustScore(globalScore);
     capScores.forEach(acc::capabilityScore);

--- a/api/src/main/java/io/casehub/api/model/HumanTaskTarget.java
+++ b/api/src/main/java/io/casehub/api/model/HumanTaskTarget.java
@@ -17,6 +17,7 @@ package io.casehub.api.model;
 
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.ListEvaluator;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Set;
@@ -38,8 +39,8 @@ public final class HumanTaskTarget implements BindingTarget {
 
   private final String templateRef;
   private final String title;
-  private final Set<String> candidateGroups;
-  private final Set<String> candidateUsers;
+  private final ListEvaluator candidateGroups;
+  private final ListEvaluator candidateUsers;
   private final Duration expiresIn;
   private final Integer claimDeadlineHours;
   private final String priority;
@@ -87,11 +88,11 @@ public final class HumanTaskTarget implements BindingTarget {
     return title;
   }
 
-  public Set<String> candidateGroups() {
+  public ListEvaluator candidateGroups() {
     return candidateGroups;
   }
 
-  public Set<String> candidateUsers() {
+  public ListEvaluator candidateUsers() {
     return candidateUsers;
   }
 
@@ -129,8 +130,8 @@ public final class HumanTaskTarget implements BindingTarget {
 
     private final String templateRef;
     private String title;
-    private Set<String> candidateGroups;
-    private Set<String> candidateUsers;
+    private ListEvaluator candidateGroups;
+    private ListEvaluator candidateUsers;
     private Duration expiresIn;
     private Integer claimDeadlineHours;
     private String priority;
@@ -148,12 +149,22 @@ public final class HumanTaskTarget implements BindingTarget {
     }
 
     public Builder candidateGroups(Set<String> candidateGroups) {
-      this.candidateGroups = candidateGroups;
+      this.candidateGroups = new ListEvaluator.StaticList(candidateGroups);
+      return this;
+    }
+
+    public Builder candidateGroupsExpression(String jqExpression) {
+      this.candidateGroups = new ListEvaluator.JQList(jqExpression);
       return this;
     }
 
     public Builder candidateUsers(Set<String> candidateUsers) {
-      this.candidateUsers = candidateUsers;
+      this.candidateUsers = new ListEvaluator.StaticList(candidateUsers);
+      return this;
+    }
+
+    public Builder candidateUsersExpression(String jqExpression) {
+      this.candidateUsers = new ListEvaluator.JQList(jqExpression);
       return this;
     }
 

--- a/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
+++ b/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
@@ -350,11 +350,18 @@ public final class CaseDefinitionYamlMapper {
     if (schema.getOutputMapping() != null) {
       builder.outputMapping(schema.getOutputMapping());
     }
-    if (schema.getCandidateGroups() != null && !schema.getCandidateGroups().isEmpty()) {
-      builder.candidateGroups(new LinkedHashSet<>(schema.getCandidateGroups()));
+    Object rawGroups = schema.getCandidateGroups();
+    if (rawGroups instanceof List<?> list && !list.isEmpty()) {
+      builder.candidateGroups(new LinkedHashSet<>(castStringList("candidateGroups", list)));
+    } else if (rawGroups instanceof String expr && !expr.isBlank()) {
+      builder.candidateGroupsExpression(expr);
     }
-    if (schema.getCandidateUsers() != null && !schema.getCandidateUsers().isEmpty()) {
-      builder.candidateUsers(new LinkedHashSet<>(schema.getCandidateUsers()));
+
+    Object rawUsers = schema.getCandidateUsers();
+    if (rawUsers instanceof List<?> list && !list.isEmpty()) {
+      builder.candidateUsers(new LinkedHashSet<>(castStringList("candidateUsers", list)));
+    } else if (rawUsers instanceof String expr && !expr.isBlank()) {
+      builder.candidateUsersExpression(expr);
     }
     if (schema.getScope() != null) {
       builder.scope(schema.getScope());
@@ -380,5 +387,18 @@ public final class CaseDefinitionYamlMapper {
       builder.expiresIn(duration);
     }
     return builder.build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> castStringList(String fieldName, List<?> raw) {
+    for (Object element : raw) {
+      if (!(element instanceof String)) {
+        throw new IllegalArgumentException(
+            fieldName
+                + " list must contain only strings, found: "
+                + element.getClass().getSimpleName());
+      }
+    }
+    return (List<String>) raw;
   }
 }

--- a/api/src/main/java/io/casehub/api/model/evaluator/ListEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/ListEvaluator.java
@@ -34,7 +34,11 @@ import java.util.Set;
 public sealed interface ListEvaluator permits ListEvaluator.StaticList, ListEvaluator.JQList {
 
   /** A literal, pre-defined set of strings — no runtime evaluation. */
-  record StaticList(Set<String> values) implements ListEvaluator {}
+  record StaticList(Set<String> values) implements ListEvaluator {
+    public StaticList {
+      values = values == null ? null : Set.copyOf(values);
+    }
+  }
 
   /** A JQ expression that resolves to a JSON array of strings at runtime. */
   record JQList(String expression) implements ListEvaluator {}

--- a/api/src/main/java/io/casehub/api/model/evaluator/ListEvaluator.java
+++ b/api/src/main/java/io/casehub/api/model/evaluator/ListEvaluator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model.evaluator;
+
+import java.util.Set;
+
+/**
+ * Specification for a field that resolves to a list of strings at runtime.
+ *
+ * <p>Two implementations:
+ *
+ * <ul>
+ *   <li>{@link StaticList} — static set of strings, evaluated immediately without case context
+ *   <li>{@link JQList} — JQ expression evaluated against the case context at event-publish time
+ * </ul>
+ *
+ * <p>Intentionally separate from {@link ExpressionEvaluator}, which is the input type for {@code
+ * ExpressionEngine.evaluate(...): boolean}. {@code ListEvaluator} produces {@code Set<String>}, not
+ * a boolean — placing it in the {@code ExpressionEvaluator} hierarchy would be type pollution.
+ */
+public sealed interface ListEvaluator permits ListEvaluator.StaticList, ListEvaluator.JQList {
+
+  /** A literal, pre-defined set of strings — no runtime evaluation. */
+  record StaticList(Set<String> values) implements ListEvaluator {}
+
+  /** A JQ expression that resolves to a JSON array of strings at runtime. */
+  record JQList(String expression) implements ListEvaluator {}
+}

--- a/api/src/test/java/io/casehub/api/model/HumanTaskTargetTest.java
+++ b/api/src/test/java/io/casehub/api/model/HumanTaskTargetTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.casehub.api.model.evaluator.ExpressionEvaluator;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.ListEvaluator;
 import java.time.Duration;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -84,7 +85,7 @@ class HumanTaskTargetTest {
   }
 
   @Test
-  void inlineMode_candidateGroups_andExpiresIn() {
+  void candidateGroups_staticSet_wrapsInStaticList() {
     HumanTaskTarget target =
         HumanTaskTarget.inline()
             .title("Review")
@@ -92,8 +93,50 @@ class HumanTaskTargetTest {
             .expiresIn(Duration.ofHours(72))
             .build();
 
-    assertThat(target.candidateGroups()).containsExactlyInAnyOrder("ethics-committee");
+    assertThat(target.candidateGroups()).isInstanceOf(ListEvaluator.StaticList.class);
+    assertThat(((ListEvaluator.StaticList) target.candidateGroups()).values())
+        .containsExactlyInAnyOrder("ethics-committee");
     assertThat(target.expiresIn()).isEqualTo(Duration.ofHours(72));
+  }
+
+  @Test
+  void candidateGroups_jqExpression_wrapsInJQList() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline().title("Review").candidateGroupsExpression(".irb.groups").build();
+
+    assertThat(target.candidateGroups()).isInstanceOf(ListEvaluator.JQList.class);
+    assertThat(((ListEvaluator.JQList) target.candidateGroups()).expression())
+        .isEqualTo(".irb.groups");
+  }
+
+  @Test
+  void candidateGroups_absent_returnsNull() {
+    HumanTaskTarget target = HumanTaskTarget.inline().title("Review").build();
+
+    assertThat(target.candidateGroups()).isNull();
+  }
+
+  @Test
+  void candidateUsers_staticSet_wrapsInStaticList() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline().title("Review").candidateUsers(Set.of("user-a")).build();
+
+    assertThat(target.candidateUsers()).isInstanceOf(ListEvaluator.StaticList.class);
+    assertThat(((ListEvaluator.StaticList) target.candidateUsers()).values())
+        .containsExactlyInAnyOrder("user-a");
+  }
+
+  @Test
+  void candidateUsers_jqExpression_wrapsInJQList() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("Review")
+            .candidateUsersExpression(".approver.id | [.]")
+            .build();
+
+    assertThat(target.candidateUsers()).isInstanceOf(ListEvaluator.JQList.class);
+    assertThat(((ListEvaluator.JQList) target.candidateUsers()).expression())
+        .isEqualTo(".approver.id | [.]");
   }
 
   @Test

--- a/api/src/test/java/io/casehub/api/model/WorkerTest.java
+++ b/api/src/test/java/io/casehub/api/model/WorkerTest.java
@@ -36,6 +36,7 @@ class WorkerTest {
           null,
           null,
           null,
+          null,
           "code-review",
           List.of(),
           null,

--- a/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
+++ b/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
@@ -31,6 +31,7 @@ import io.casehub.api.model.SlaStartFrom;
 import io.casehub.api.model.Worker;
 import io.casehub.api.model.ai.Agent;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.ListEvaluator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -348,8 +349,12 @@ class CaseDefinitionYamlMapperTest {
             new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
 
     HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
-    assertThat(ht.candidateGroups()).containsExactlyInAnyOrder("architects", "seniors");
-    assertThat(ht.candidateUsers()).containsExactlyInAnyOrder("alice");
+    assertThat(ht.candidateGroups()).isInstanceOf(ListEvaluator.StaticList.class);
+    assertThat(((ListEvaluator.StaticList) ht.candidateGroups()).values())
+        .containsExactlyInAnyOrder("architects", "seniors");
+    assertThat(ht.candidateUsers()).isInstanceOf(ListEvaluator.StaticList.class);
+    assertThat(((ListEvaluator.StaticList) ht.candidateUsers()).values())
+        .containsExactlyInAnyOrder("alice");
     assertThat(ht.expiresIn()).isEqualTo(Duration.parse("PT24H"));
     assertThat(ht.inputMapping()).isInstanceOf(JQExpressionEvaluator.class);
     assertThat(((JQExpressionEvaluator) ht.inputMapping()).expression()).isEqualTo("{ pr: .pr }");
@@ -530,6 +535,112 @@ class CaseDefinitionYamlMapperTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("negative-binding")
         .hasMessageContaining("must be positive");
+  }
+
+  @Test
+  void humanTask_candidateGroups_jqExpression_roundTrips() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Dynamic Groups Case
+        version: 1.0.0
+        spec:
+          bindings:
+            - name: irb-review
+              on: { contextChange: {} }
+              humanTask:
+                title: "IRB Review"
+                candidateGroups: ".irb.candidateGroups"
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.candidateGroups()).isInstanceOf(ListEvaluator.JQList.class);
+    assertThat(((ListEvaluator.JQList) ht.candidateGroups()).expression())
+        .isEqualTo(".irb.candidateGroups");
+  }
+
+  @Test
+  void humanTask_candidateUsers_jqExpression_roundTrips() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Dynamic Users Case
+        version: 1.0.0
+        spec:
+          bindings:
+            - name: approval
+              on: { contextChange: {} }
+              humanTask:
+                title: "Approval"
+                candidateUsers: ".approver.id | [.]"
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.candidateUsers()).isInstanceOf(ListEvaluator.JQList.class);
+    assertThat(((ListEvaluator.JQList) ht.candidateUsers()).expression())
+        .isEqualTo(".approver.id | [.]");
+  }
+
+  @Test
+  void humanTask_candidateGroups_staticList_stillWorks() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: Static Groups Case
+        version: 1.0.0
+        spec:
+          bindings:
+            - name: review
+              on: { contextChange: {} }
+              humanTask:
+                title: "Review"
+                candidateGroups:
+                  - architects
+                  - seniors
+        """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.candidateGroups()).isInstanceOf(ListEvaluator.StaticList.class);
+    assertThat(((ListEvaluator.StaticList) ht.candidateGroups()).values())
+        .containsExactlyInAnyOrder("architects", "seniors");
+  }
+
+  @Test
+  void humanTask_candidateGroups_nonStringElement_throwsIllegalArgument() {
+    String yaml =
+        """
+        namespace: test
+        name: badGroupsCase
+        version: 1.0.0
+        spec:
+          bindings:
+            - name: review-binding
+              on: { contextChange: {} }
+              humanTask:
+                title: "Review"
+                candidateGroups:
+                  - valid-group
+                  - 123
+        """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("candidateGroups");
   }
 
   @Test

--- a/common/src/main/java/io/casehub/engine/common/internal/event/HumanTaskScheduleEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/HumanTaskScheduleEvent.java
@@ -18,6 +18,7 @@ package io.casehub.engine.common.internal.event;
 import io.casehub.api.model.HumanTaskTarget;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -39,5 +40,7 @@ public record HumanTaskScheduleEvent(
     String bindingName,
     HumanTaskTarget target,
     Map<String, Object> inputData,
+    Set<String> resolvedCandidateGroups,
+    Set<String> resolvedCandidateUsers,
     Instant caseBudgetDeadline,
     String tenancyId) {}

--- a/docs/adr/0008-list-evaluator-separate-sealed-hierarchy.md
+++ b/docs/adr/0008-list-evaluator-separate-sealed-hierarchy.md
@@ -1,0 +1,63 @@
+# 0008 — ListEvaluator as a separate sealed hierarchy from ExpressionEvaluator
+
+Date: 2026-06-07
+Status: Accepted
+
+## Context and Problem Statement
+
+`HumanTaskTarget.candidateGroups` and `candidateUsers` needed to support both static lists and JQ expressions evaluated at runtime. `ExpressionEvaluator` already exists in the codebase as a marker interface for boolean predicates dispatched by `ExpressionEngine.evaluate()`. The question was whether to reuse that hierarchy for list-producing expressions or introduce a separate type.
+
+## Decision Drivers
+
+* `ExpressionEvaluator` is the input type for `ExpressionEngine.evaluate(ExpressionEvaluator, CaseContext): boolean` — every existing implementation returns a boolean predicate
+* `ExpressionEngineRegistry` dispatches on `ExpressionEvaluator.type()` to route to the correct engine — a non-predicate type in the hierarchy could cause a misfire or uncaught dispatch error
+* Compiler-enforced exhaustiveness on sealed types is valuable for the handler switch
+
+## Considered Options
+
+* **Option A** — Introduce a new `LiteralListEvaluator` implementing `ExpressionEvaluator`
+* **Option B** — Introduce a separate `ListEvaluator` sealed interface with `StaticList` and `JQList` inner records
+* **Option C** — Use a plain `String` field for the JQ expression alongside the existing `Set<String>` (two fields, XOR)
+
+## Decision Outcome
+
+Chosen option: **Option B**, because `ListEvaluator` produces `Set<String>`, not `boolean`. Placing it in the `ExpressionEvaluator` hierarchy would be type pollution: `ExpressionEngineRegistry` would receive a type it cannot dispatch correctly, and readers of the `ExpressionEvaluator` interface javadoc would be misled about the return semantics.
+
+### Positive Consequences
+
+* Compiler enforces exhaustiveness on the `ListEvaluator` switch — no runtime uncaught case
+* `ExpressionEvaluator` hierarchy stays semantically pure (boolean predicates only)
+* When engine#439 adds dynamic `title`/`scope`, a `StringEvaluator` sealed type follows the same pattern without touching either existing hierarchy
+
+### Negative Consequences / Tradeoffs
+
+* One additional interface to understand; the name `ListEvaluator` vs `ExpressionEvaluator` requires a short explanation for new contributors
+
+## Pros and Cons of the Options
+
+### Option A — `LiteralListEvaluator` extends `ExpressionEvaluator`
+
+* ✅ Fewer types to introduce
+* ❌ `ExpressionEngineRegistry` receives a type it cannot dispatch — potential misfire
+* ❌ `ExpressionEvaluator.type()` constant (`"literal-list"`) has no registered engine — semantically undefined
+* ❌ Interface javadoc promises boolean predicate semantics; `LiteralListEvaluator` violates that contract
+
+### Option B — Separate `ListEvaluator` sealed interface (chosen)
+
+* ✅ `ExpressionEvaluator` hierarchy stays boolean-only
+* ✅ Sealed type gives compiler-enforced exhaustive switch on `StaticList` / `JQList`
+* ✅ No `type()` constant needed — `ListExpressionResolver` switches directly on concrete type
+* ❌ One extra interface
+
+### Option C — Two separate fields (expression String + static Set)
+
+* ✅ No new types
+* ❌ XOR constraint must be enforced at runtime, not compile time
+* ❌ Builder has two entry points for what is logically one field — confusing API
+* ❌ Does not compose with the existing `ExpressionEvaluator` pattern
+
+## Links
+
+* engine#387 — implementation issue
+* engine#439 — follow-on: dynamic `title`/`scope`/`expiresIn` via `StringEvaluator`
+* `api/src/main/java/io/casehub/api/model/evaluator/ListEvaluator.java`

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -9,3 +9,4 @@
 | 0005 | [@CrossTenant qualifier as convention-based access control gate](0005-cross-tenant-qualifier-convention-gate.md) | Accepted | 2026-06-02 |
 | 0006 | [Application-managed RLS with drop-and-create schema strategy](0006-application-managed-rls-drop-and-create.md) | Accepted | 2026-06-02 |
 | 0007 | [SystemCurrentPrincipal as interim engine-internal class](0007-system-current-principal-interim-engine-class.md) | Accepted | 2026-06-02 |
+| 0008 | [ListEvaluator as a separate sealed hierarchy from ExpressionEvaluator](0008-list-evaluator-separate-sealed-hierarchy.md) | Accepted | 2026-06-07 |

--- a/docs/specs/2026-06-07-humantask-dynamic-candidate-groups-design.md
+++ b/docs/specs/2026-06-07-humantask-dynamic-candidate-groups-design.md
@@ -1,0 +1,314 @@
+# Design: Dynamic candidateGroups and candidateUsers for humanTask Binding
+
+**Issue:** engine#387  
+**Date:** 2026-06-07  
+**Status:** Approved (rev 2 — post code review)
+
+## Problem
+
+`candidateGroups` and `candidateUsers` in a `humanTask` binding are static lists — fixed at case definition time. There is no way to derive them from the case context at runtime.
+
+```yaml
+humanTask:
+  candidateGroups: [irb-committee]   # hardcoded — cannot vary per case instance
+```
+
+`casehub-clinical` is the first concrete consumer: `IrbCommitteeAssignmentPolicy` (SPI) resolves the correct IRB committee per trial/site and writes the result to the case context. Without dynamic `candidateGroups`, the WorkItem routing ignores this output and always routes to the same static group.
+
+## Solution
+
+Apply the same pattern already used by `inputMapping`/`inputData`: the spec lives in `HumanTaskTarget`, is evaluated against the case context at event-publish time in `CaseContextChangedEventHandler`, and the resolved value is carried in `HumanTaskScheduleEvent`. `HumanTaskScheduleHandler` is unchanged in structure — it uses already-resolved data and never evaluates expressions.
+
+`candidateUsers` gets the same treatment for symmetry.
+
+## Data Model
+
+### `ListEvaluator` sealed interface (new)
+
+`api/src/main/java/io/casehub/api/model/evaluator/ListEvaluator.java`
+
+```java
+public sealed interface ListEvaluator permits ListEvaluator.StaticList, ListEvaluator.JQList {
+  record StaticList(Set<String> values) implements ListEvaluator {}
+  record JQList(String expression)      implements ListEvaluator {}
+}
+```
+
+**Why a separate hierarchy from `ExpressionEvaluator`:** `ExpressionEvaluator` is the input type for `ExpressionEngine.evaluate(...): boolean` — every current implementation (`JQExpressionEvaluator`, `LambdaExpressionEvaluator`) represents a boolean predicate. `ListEvaluator` produces a `Set<String>`, not a boolean. Placing it in the `ExpressionEvaluator` hierarchy would be type pollution and could confuse `ExpressionEngineRegistry` dispatch. The sealed `ListEvaluator` hierarchy is exhaustively checked by the compiler — no `type()` constant or runtime dispatch needed.
+
+When engine#439 adds dynamic `title`/`scope`, a `StringEvaluator` sealed type follows the same pattern.
+
+### `HumanTaskTarget` changes
+
+| Before | After |
+|--------|-------|
+| `Set<String> candidateGroups` | `@Nullable ListEvaluator candidateGroups` |
+| `Set<String> candidateUsers` | `@Nullable ListEvaluator candidateUsers` |
+| `candidateGroups()` → `Set<String>` | `candidateGroups()` → `@Nullable ListEvaluator` |
+| `candidateUsers()` → `Set<String>` | `candidateUsers()` → `@Nullable ListEvaluator` |
+
+Accessor names stay `candidateGroups()` / `candidateUsers()` — consistent with `inputMapping()` which names the field, not the evaluator type. All call sites that dereference the old `Set<String>` get a compile error, forcing explicit handling.
+
+**Builder methods:**
+
+```java
+// Static — unchanged call sites, wraps in StaticList
+builder.candidateGroups(Set.of("irb-committee"))
+
+// Dynamic JQ — distinct name, unambiguous intent
+builder.candidateGroupsExpression(".irb.candidateGroups")
+```
+
+`candidateGroups(String)` overload is **not added**. A bare string like `"irb-committee"` passed to such an overload would silently become a JQ expression, fail evaluation, and leave the PlanItem PENDING with no compiler warning. The distinct method name `candidateGroupsExpression` prevents this class of error. Same treatment for `candidateUsers` / `candidateUsersExpression`.
+
+### `HumanTaskScheduleEvent` changes
+
+Two new fields added after `inputData`:
+
+```java
+public record HumanTaskScheduleEvent(
+    UUID caseId,
+    String bindingName,
+    HumanTaskTarget target,
+    Map<String, Object> inputData,
+    Set<String> resolvedCandidateGroups,   // null = no spec; RESOLUTION_FAILED never reaches here
+    Set<String> resolvedCandidateUsers,    // null = no spec; RESOLUTION_FAILED never reaches here
+    Instant caseBudgetDeadline,
+    String tenancyId) {}
+```
+
+`null` = no spec was set on the binding (preserves template defaults in template mode). `RESOLUTION_FAILED` blocks event publication — the handler never sees it.
+
+## `ListExpressionResolver` (new class)
+
+`runtime/src/main/java/io/casehub/engine/internal/engine/ListExpressionResolver.java`
+
+`@ApplicationScoped` — injectable and directly unit-testable. Extracted from `CaseContextChangedEventHandler` so the six behavioral branches can be tested in isolation without spinning up a full handler.
+
+```java
+@ApplicationScoped
+public class ListExpressionResolver {
+
+  // Sentinel — private, but isFailed() exposes the check cleanly.
+  // Checked with ==, not .equals(), because only this reference
+  // can compare equal. The unmodifiableSet wrapper prevents accidental mutation.
+  static final Set<String> RESOLUTION_FAILED =
+      Collections.unmodifiableSet(new HashSet<>());
+
+  public static boolean isFailed(Set<String> result) {
+    return result == RESOLUTION_FAILED;
+  }
+
+  @Inject JQEvaluator jqEvaluator;
+
+  public @Nullable Set<String> resolve(
+      CaseInstance instance, @Nullable ListEvaluator spec, String fieldName) {
+    if (spec == null) return null;
+    return switch (spec) {
+      case StaticList s -> s.values();
+      case JQList jq   -> resolveJq(instance, jq, fieldName);
+    };
+  }
+
+  private Set<String> resolveJq(CaseInstance instance, JQList jq, String fieldName) { ... }
+}
+```
+
+**Implementation note:** `StaticList` and `JQList` are inner records of `ListEvaluator`. The switch arms require either `import static io.casehub.api.model.evaluator.ListEvaluator.*;` or fully qualified `ListEvaluator.StaticList` / `ListEvaluator.JQList` — add the static import to avoid a confused first compile.
+
+```java
+```
+
+### Log levels inside `resolveJq`
+
+| Condition | Level | Rationale |
+|-----------|-------|-----------|
+| JQ result is non-empty string array | — | Success |
+| JQ result is empty array `[]` | WARN | Transient — context may not have the value yet |
+| JQ result is non-array | ERROR | Misconfiguration — expression is wrong |
+| JQ evaluation throws | ERROR | Misconfiguration — invalid expression |
+
+Empty-array is WARN because the engine may re-trigger the binding when context changes and the expression might then return valid groups. Non-array and throw are ERROR because they represent authoring mistakes that will not self-correct.
+
+## Evaluation (`CaseContextChangedEventHandler`)
+
+`publishHumanTaskSchedule()` injects `ListExpressionResolver` and calls it for both fields:
+
+```java
+Set<String> resolvedGroups = resolver.resolve(caseInstance, target.candidateGroups(), "candidateGroups");
+Set<String> resolvedUsers  = resolver.resolve(caseInstance, target.candidateUsers(),  "candidateUsers");
+
+if (ListExpressionResolver.isFailed(resolvedGroups)
+    || ListExpressionResolver.isFailed(resolvedUsers)) {
+  // Either field failed — PlanItem stays PENDING, event not published.
+  // Error already logged by resolver with field name.
+  return Uni.createFrom().voidItem();
+}
+```
+
+Both fields are resolved before the guard check. A failure in either blocks the event — this includes the conjunction case where groups fails and users succeeds.
+
+## Handler (`HumanTaskScheduleHandler`)
+
+**`candidateGroupsCsv(HumanTaskTarget)` and `candidateUsersCsv(HumanTaskTarget)` removed.** Replaced by `toCsv(Set<String>)` — takes an already-resolved set.
+
+**Inline mode** — uses resolved sets from the event directly:
+
+```java
+WorkItemCreateRequest.builder()
+    .candidateGroups(toCsv(event.resolvedCandidateGroups()))
+    .candidateUsers(toCsv(event.resolvedCandidateUsers()))
+    ...
+```
+
+**Template mode** — after `instantiate()`, overrides routing only when resolved sets are non-null:
+
+```java
+if (event.resolvedCandidateGroups() != null) {
+  workItem.candidateGroups = toCsv(event.resolvedCandidateGroups());
+}
+if (event.resolvedCandidateUsers() != null) {
+  workItem.candidateUsers = toCsv(event.resolvedCandidateUsers());
+}
+```
+
+`null` = spec was absent → template's own groups are preserved. Non-null = binding overrides routing.
+
+## YAML Schema (`CaseDefinition.yaml`)
+
+`candidateGroups` and `candidateUsers` change from `type: array` to `oneOf`:
+
+```yaml
+candidateGroups:
+  oneOf:
+    - type: array
+      items: { type: string }
+      description: "Static list of groups eligible to claim this WorkItem"
+    - type: string
+      description: "JQ expression resolving to a list of group names from case context"
+candidateUsers:
+  oneOf:
+    - type: array
+      items: { type: string }
+    - type: string
+      description: "JQ expression resolving to a list of user IDs from case context"
+```
+
+jsonschema2pojo generates `Object candidateGroups` and `Object candidateUsers` in `io.casehub.model.HumanTask`. **Implementation note:** verify the generated type after `mvn generate-sources` — jsonschema2pojo `oneOf` handling is version-dependent. If it does not produce `Object`, read `candidateGroups` from the raw YAML `JsonNode` directly (`node.get("candidateGroups").isArray()` vs `isTextual()`) rather than the generated class — this keeps the mapper robust against future code-gen version changes.
+
+**`CaseDefinitionYamlMapper`** branches on the runtime type:
+
+```java
+Object rawGroups = schema.getCandidateGroups();
+if (rawGroups instanceof List<?> list && !list.isEmpty()) {
+  builder.candidateGroups(new LinkedHashSet<>(castStringList(list)));
+} else if (rawGroups instanceof String expr && !expr.isBlank()) {
+  builder.candidateGroupsExpression(expr);  // → JQList
+}
+// same pattern for candidateUsers
+```
+
+`castStringList()` validates elements are strings; throws `IllegalArgumentException` on bad YAML.
+
+## YAML Usage Examples
+
+```yaml
+# Static (existing — unchanged semantics)
+humanTask:
+  title: "IRB Review"
+  candidateGroups: [irb-committee]
+
+# Dynamic — groups resolved from case context at runtime
+humanTask:
+  title: "IRB Review"
+  candidateGroups: ".irb.candidateGroups"
+
+# Dynamic — nested path
+humanTask:
+  title: "Site Approval"
+  candidateGroups: ".site.approvalGroups"
+  candidateUsers: ".trial.principalInvestigatorId | [.]"
+```
+
+## Fluent DSL Usage
+
+```java
+// Existing — unchanged
+HumanTaskTarget.inline()
+    .title("IRB Review")
+    .candidateGroups(Set.of("irb-committee"))
+    .build()
+
+// New — dynamic
+HumanTaskTarget.inline()
+    .title("IRB Review")
+    .candidateGroupsExpression(".irb.candidateGroups")
+    .build()
+```
+
+## Testing
+
+### Unit tests
+
+**`HumanTaskTargetTest`**
+- `candidateGroups(Set<String>)` → `candidateGroups()` returns `StaticList` with correct values
+- `candidateGroupsExpression(String)` → `candidateGroups()` returns `JQList` with correct expression
+- Same assertions for `candidateUsers` / `candidateUsersExpression`
+
+**`CaseDefinitionYamlMapperTest`**
+- YAML `candidateGroups: ".irb.groups"` → `JQList`
+- YAML `candidateGroups: [irb-committee]` → `StaticList` (existing round-trip, updated assertions)
+- YAML `candidateGroups` absent → `null`
+
+**`ListExpressionResolverTest`** (new, unit — same package as `ListExpressionResolver`)
+- `null` spec → returns `null`
+- `StaticList(Set.of("a","b"))` → returns `Set.of("a","b")`, JQ never invoked
+- `JQList`, context has matching array → correct `Set<String>` returned
+- `JQList`, JQ returns non-array → `RESOLUTION_FAILED`, log at ERROR
+- `JQList`, JQ returns empty array `[]` → `RESOLUTION_FAILED`, log at WARN
+- `JQList`, JQ throws → `RESOLUTION_FAILED`, log at ERROR
+- **Conjunction case:** groups returns `RESOLUTION_FAILED`, users returns valid `Set<String>` → guard fires, event not published (tested at `CaseContextChangedEventHandler` level)
+
+**`HumanTaskScheduleHandlerTest`**
+- Inline: `resolvedCandidateGroups = Set.of("irb-committee")` → WorkItem created with `"irb-committee"` CSV
+- Inline: `resolvedCandidateGroups = null` → WorkItem created with null candidateGroups
+- Template: `resolvedCandidateGroups = Set.of("committee-a")` → `workItem.candidateGroups` overridden
+- Template: `resolvedCandidateGroups = null` → `workItem.candidateGroups` left as template default (not overridden)
+
+### Integration tests
+
+**`HumanTaskTargetDispatchTest`** (`@QuarkusTest`)
+
+Inline mode:
+- Case context contains `.irb = {candidateGroups: ["irb-committee"]}`, binding uses `candidateGroupsExpression: ".irb.candidateGroups"` → event carries `resolvedCandidateGroups = Set.of("irb-committee")`
+- JQ expression evaluates to non-array → event not published, PlanItem stays PENDING
+
+Template mode (new):
+- `resolvedCandidateGroups` non-null → instantiated WorkItem has `candidateGroups` overridden to resolved CSV
+- `resolvedCandidateGroups` null (spec absent on template binding) → WorkItem retains template's own candidateGroups
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `api/.../evaluator/ListEvaluator.java` | New — sealed interface with `StaticList`, `JQList` inner records |
+| `api/.../model/HumanTaskTarget.java` | `candidateGroups`/`candidateUsers` → `@Nullable ListEvaluator`; builder adds `candidateGroupsExpression`/`candidateUsersExpression` |
+| `api/.../converter/CaseDefinitionYamlMapper.java` | Branch on `Object` type; call `candidateGroupsExpression()` for string path |
+| `schema/.../schema/CaseDefinition.yaml` | `oneOf` for candidateGroups/candidateUsers |
+| `common/.../event/HumanTaskScheduleEvent.java` | Add `resolvedCandidateGroups`, `resolvedCandidateUsers` |
+| `runtime/.../engine/ListExpressionResolver.java` | New — `@ApplicationScoped`, injectable, testable |
+| `runtime/.../handler/CaseContextChangedEventHandler.java` | Inject `ListExpressionResolver`; resolve + guard before publish |
+| `work-adapter/.../HumanTaskScheduleHandler.java` | Use resolved fields; `toCsv(Set<String>)`; template override |
+| `api/src/test/.../HumanTaskTargetTest.java` | Updated accessor assertions; new JQ builder tests |
+| `api/src/test/.../CaseDefinitionYamlMapperTest.java` | New YAML expression test cases; updated static-list assertions |
+| `runtime/src/test/.../ListExpressionResolverTest.java` | New — six behavioral unit tests + conjunction case |
+| `work-adapter/src/test/.../HumanTaskScheduleHandlerTest.java` | Updated event construction; new template-override cases |
+| `work-adapter/src/test/.../HumanTaskScheduleHandlerAtomicityTest.java` | Updated event construction |
+| `runtime/src/test/.../HumanTaskTargetDispatchTest.java` | New inline + template integration test cases |
+| `casehub/garden: docs/protocols/casehub/yaml-humantask-binding-type.md` | Update PP-20260520-b2a932 — document dynamic candidateGroups/candidateUsers |
+
+## Out of Scope
+
+- Dynamic `title`, `scope`, `expiresIn` — same `ListEvaluator`/`StringEvaluator` pattern; tracked in engine#439
+- Platform doc update (casehub-engine.md) — tracked in parent#188
+- Surfacing resolution failures as observable events (structured error signals vs log-only) — known gap shared with template-not-found (engine#297); not addressed here

--- a/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
+++ b/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
@@ -389,6 +389,7 @@ class SemanticAgentRoutingStrategyTest {
             "domain-vocab",
             "slot-vocab",
             "disposition-vocab",
+            null,
             "research",
             List.of(
                 new AgentCapability(

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/ListExpressionResolver.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/ListExpressionResolver.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.model.evaluator.ListEvaluator;
+import io.casehub.api.model.evaluator.ListEvaluator.JQList;
+import io.casehub.api.model.evaluator.ListEvaluator.StaticList;
+import io.casehub.engine.common.internal.jq.JQEvaluator;
+import io.casehub.engine.common.internal.jq.ValidationResult;
+import io.casehub.engine.common.internal.model.CaseInstance;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.jboss.logging.Logger;
+
+/**
+ * Resolves {@link ListEvaluator} specs to concrete {@code Set<String>} values.
+ *
+ * <p>Extracted from {@code CaseContextChangedEventHandler} so the six evaluation branches can be
+ * unit-tested in isolation via {@link #resolveJq(JsonNode, JQList, String)}.
+ */
+@ApplicationScoped
+public class ListExpressionResolver {
+
+  private static final Logger LOG = Logger.getLogger(ListExpressionResolver.class);
+
+  /**
+   * Sentinel returned when JQ resolution fails. Checked with {@link #isFailed(Set)} (== identity,
+   * not .equals). The {@code unmodifiableSet} wrapper prevents accidental mutation; only this
+   * reference can compare equal via ==.
+   */
+  static final Set<String> RESOLUTION_FAILED = Collections.unmodifiableSet(new HashSet<>());
+
+  /** Returns {@code true} iff {@code result} is the {@link #RESOLUTION_FAILED} sentinel. */
+  public static boolean isFailed(Set<String> result) {
+    return result == RESOLUTION_FAILED;
+  }
+
+  @Inject JQEvaluator jqEvaluator;
+
+  /**
+   * Resolves a {@link ListEvaluator} to a concrete set of strings.
+   *
+   * @param instance the current case instance — only accessed when {@code spec} is a {@link JQList}
+   * @param spec the evaluator spec; null means "no restriction" → returns null
+   * @param fieldName for log messages only
+   * @return resolved set, null (no restriction), or {@link #RESOLUTION_FAILED}
+   */
+  public Set<String> resolve(CaseInstance instance, ListEvaluator spec, String fieldName) {
+    if (spec == null) return null;
+    return switch (spec) {
+      case StaticList s -> s.values();
+      case JQList jq -> resolveJq(instance.getCaseContext().asJsonNode(), jq, fieldName);
+    };
+  }
+
+  /** Package-private to allow direct unit testing without constructing a {@link CaseInstance}. */
+  Set<String> resolveJq(JsonNode context, JQList jq, String fieldName) {
+    try {
+      ValidationResult vr = jqEvaluator.eval(jq.expression(), context);
+      if (!vr.ok() || vr.output() == null || vr.output().isEmpty()) {
+        LOG.errorf(
+            "'%s' JQ evaluation failed: expression '%s' — %s",
+            fieldName, jq.expression(), vr.error());
+        return RESOLUTION_FAILED;
+      }
+      JsonNode result = vr.output().get(0);
+      if (!result.isArray()) {
+        LOG.errorf(
+            "'%s' JQ expression returned non-array: '%s' produced node type %s",
+            fieldName, jq.expression(), result.getNodeType());
+        return RESOLUTION_FAILED;
+      }
+      if (result.size() == 0) {
+        LOG.warnf(
+            "'%s' JQ expression returned empty array: '%s' — PlanItem stays PENDING",
+            fieldName, jq.expression());
+        return RESOLUTION_FAILED;
+      }
+      Set<String> groups = new LinkedHashSet<>();
+      for (JsonNode element : result) {
+        if (!element.isTextual()) {
+          LOG.errorf(
+              "'%s' JQ expression returned non-string element in array: node type %s",
+              fieldName, element.getNodeType());
+          return RESOLUTION_FAILED;
+        }
+        groups.add(element.asText());
+      }
+      return Collections.unmodifiableSet(groups);
+    } catch (Exception e) {
+      LOG.errorf(e, "'%s' JQ evaluation threw: expression '%s'", fieldName, jq.expression());
+      return RESOLUTION_FAILED;
+    }
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -364,6 +364,8 @@ public class CaseContextChangedEventHandler {
             binding.getName(),
             target,
             inputData,
+            null, // resolvedCandidateGroups — wired in Task 6
+            null, // resolvedCandidateUsers  — wired in Task 6
             caseBudgetDeadline,
             caseInstance.tenancyId));
 

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -60,6 +60,7 @@ import io.casehub.engine.common.spi.CaseDefinitionRegistry;
 import io.casehub.engine.common.spi.ExpressionEngineRegistry;
 import io.casehub.engine.common.spi.event.CaseLifecycleEvent;
 import io.casehub.engine.common.spi.scheduler.WorkerExecutionManager;
+import io.casehub.engine.internal.engine.ListExpressionResolver;
 import io.casehub.engine.internal.routing.AgentCandidateFactory;
 import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.quarkus.vertx.ConsumeEvent;
@@ -71,6 +72,7 @@ import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -83,6 +85,8 @@ public class CaseContextChangedEventHandler {
   @Inject EventBus eventBus;
 
   @Inject JQEvaluator jqEvaluator;
+
+  @Inject ListExpressionResolver listExpressionResolver;
 
   @Inject CaseDefinitionRegistry caseDefinitionRegistry;
 
@@ -348,6 +352,19 @@ public class CaseContextChangedEventHandler {
   private Uni<Void> publishHumanTaskSchedule(
       final CaseInstance caseInstance, final Binding binding, final HumanTaskTarget target) {
     final Map<String, Object> inputData = evaluateInputMapping(caseInstance, target);
+    final Set<String> resolvedGroups =
+        listExpressionResolver.resolve(caseInstance, target.candidateGroups(), "candidateGroups");
+    final Set<String> resolvedUsers =
+        listExpressionResolver.resolve(caseInstance, target.candidateUsers(), "candidateUsers");
+
+    if (ListExpressionResolver.isFailed(resolvedGroups)
+        || ListExpressionResolver.isFailed(resolvedUsers)) {
+      LOG.warnf(
+          "HumanTask list expression resolution failed for caseId=%s binding=%s — PlanItem stays PENDING",
+          caseInstance.getUuid(), binding.getName());
+      return Uni.createFrom().voidItem();
+    }
+
     final java.time.Instant caseBudgetDeadline =
         java.util.Optional.ofNullable(caseInstance.getPropagationContext())
             .flatMap(PropagationContext::getDeadline)
@@ -364,8 +381,8 @@ public class CaseContextChangedEventHandler {
             binding.getName(),
             target,
             inputData,
-            null, // resolvedCandidateGroups — wired in Task 6
-            null, // resolvedCandidateUsers  — wired in Task 6
+            resolvedGroups,
+            resolvedUsers,
             caseBudgetDeadline,
             caseInstance.tenancyId));
 

--- a/runtime/src/test/java/io/casehub/engine/HumanTaskTargetDispatchTest.java
+++ b/runtime/src/test/java/io/casehub/engine/HumanTaskTargetDispatchTest.java
@@ -89,6 +89,7 @@ class HumanTaskTargetDispatchTest {
 
     HumanTaskScheduleEvent event = HumanTaskEventRecorder.events.get(0);
     assertThat(event.resolvedCandidateGroups()).containsExactlyInAnyOrder("irb-committee");
+    assertThat(event.resolvedCandidateUsers()).isNull();
   }
 
   @Test

--- a/runtime/src/test/java/io/casehub/engine/HumanTaskTargetDispatchTest.java
+++ b/runtime/src/test/java/io/casehub/engine/HumanTaskTargetDispatchTest.java
@@ -29,6 +29,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.vertx.ConsumeEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -45,6 +46,9 @@ import org.junit.jupiter.api.Test;
 class HumanTaskTargetDispatchTest {
 
   @Inject HumanTaskCaseBean humanTaskCaseBean;
+  @Inject DynamicGroupsCaseBean dynamicGroupsCaseBean;
+  @Inject BadGroupsCaseBean badGroupsCaseBean;
+  @Inject ConjunctionFailCaseBean conjunctionFailCaseBean;
 
   @BeforeEach
   void reset() {
@@ -68,6 +72,56 @@ class HumanTaskTargetDispatchTest {
     assertThat(event.target().templateRef()).isEqualTo("irb-review-template");
     // inputMapping "{ applicantId: .applicantId }" evaluated: applicantId should be "A-42"
     assertThat(event.inputData()).containsEntry("applicantId", "A-42");
+  }
+
+  // ── Dynamic candidateGroups ─────────────────────────────────────────────────
+
+  @Test
+  void humanTaskBinding_dynamicCandidateGroups_resolvesFromContext() {
+    CompletionStage<UUID> future =
+        dynamicGroupsCaseBean.startCase(
+            Map.of("stage", "review", "irb", Map.of("candidateGroups", List.of("irb-committee"))));
+    future.toCompletableFuture().join();
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(HumanTaskEventRecorder.events).isNotEmpty());
+
+    HumanTaskScheduleEvent event = HumanTaskEventRecorder.events.get(0);
+    assertThat(event.resolvedCandidateGroups()).containsExactlyInAnyOrder("irb-committee");
+  }
+
+  @Test
+  void humanTaskBinding_dynamicCandidateGroups_jqReturnsNonArray_planItemStaysPending() {
+    CompletionStage<UUID> future =
+        badGroupsCaseBean.startCase(Map.of("stage", "review", "routing", "not-an-array"));
+    future.toCompletableFuture().join();
+
+    // Assert no event is published; during() ensures the condition holds for the duration
+    await()
+        .during(300, TimeUnit.MILLISECONDS)
+        .atMost(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(HumanTaskEventRecorder.events).isEmpty());
+  }
+
+  @Test
+  void
+      humanTaskBinding_dynamicCandidateGroups_conjunctionFail_groupsFailUsersSucceed_eventBlocked() {
+    // groups is a string (wrong type → RESOLUTION_FAILED), users is a valid array
+    // Either failure blocks the event — conjunction test
+    CompletionStage<UUID> future =
+        conjunctionFailCaseBean.startCase(
+            Map.of(
+                "stage", "review",
+                "groups", "wrong",
+                "users", List.of("user-1")));
+    future.toCompletableFuture().join();
+
+    // Assert no event is published; during() ensures the condition holds for the duration
+    await()
+        .during(300, TimeUnit.MILLISECONDS)
+        .atMost(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(HumanTaskEventRecorder.events).isEmpty());
   }
 
   /** Records HumanTaskScheduleEvent arrivals for test assertions. */
@@ -99,6 +153,82 @@ class HumanTaskTargetDispatchTest {
           .bindings(
               Binding.builder()
                   .name("review-binding")
+                  .humanTask(target)
+                  .on(new ContextChangeTrigger(".stage == \"review\""))
+                  .build())
+          .build();
+    }
+  }
+
+  /** Case with candidateGroupsExpression binding. */
+  @ApplicationScoped
+  static class DynamicGroupsCaseBean extends CaseHub {
+    @Override
+    public CaseDefinition getDefinition() {
+      HumanTaskTarget target =
+          HumanTaskTarget.inline()
+              .title("IRB Review")
+              .candidateGroupsExpression(".irb.candidateGroups")
+              .build();
+
+      return CaseDefinition.builder()
+          .namespace("test")
+          .name("DynamicGroupsCase")
+          .version("1.0.0")
+          .bindings(
+              Binding.builder()
+                  .name("review-binding")
+                  .humanTask(target)
+                  .on(new ContextChangeTrigger(".stage == \"review\""))
+                  .build())
+          .build();
+    }
+  }
+
+  /** Case with candidateGroupsExpression that resolves to a non-array. */
+  @ApplicationScoped
+  static class BadGroupsCaseBean extends CaseHub {
+    @Override
+    public CaseDefinition getDefinition() {
+      HumanTaskTarget target =
+          HumanTaskTarget.inline()
+              .title("Bad Groups")
+              .candidateGroupsExpression(".routing")
+              .build();
+
+      return CaseDefinition.builder()
+          .namespace("test")
+          .name("BadGroupsCase")
+          .version("1.0.0")
+          .bindings(
+              Binding.builder()
+                  .name("bad-binding")
+                  .humanTask(target)
+                  .on(new ContextChangeTrigger(".stage == \"review\""))
+                  .build())
+          .build();
+    }
+  }
+
+  /** Case where groups expression fails and users expression succeeds — conjunction failure. */
+  @ApplicationScoped
+  static class ConjunctionFailCaseBean extends CaseHub {
+    @Override
+    public CaseDefinition getDefinition() {
+      HumanTaskTarget target =
+          HumanTaskTarget.inline()
+              .title("Conjunction")
+              .candidateGroupsExpression(".groups")
+              .candidateUsersExpression(".users")
+              .build();
+
+      return CaseDefinition.builder()
+          .namespace("test")
+          .name("ConjunctionFailCase")
+          .version("1.0.0")
+          .bindings(
+              Binding.builder()
+                  .name("conjunction-binding")
                   .humanTask(target)
                   .on(new ContextChangeTrigger(".stage == \"review\""))
                   .build())

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/ListExpressionResolverTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/ListExpressionResolverTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.api.model.evaluator.ListEvaluator.JQList;
+import io.casehub.api.model.evaluator.ListEvaluator.StaticList;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for ListExpressionResolver. Uses @QuarkusTest so JQEvaluator is discovered via CDI (it
+ * is in casehub-engine-common, which is indexed in test application.properties). Tests call
+ * resolveJq() directly (package-private) to avoid constructing CaseInstance.
+ */
+@QuarkusTest
+class ListExpressionResolverTest {
+
+  @Inject ListExpressionResolver resolver;
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  // ── resolve() — top-level dispatch ──────────────────────────────────────────
+
+  @Test
+  void resolve_nullSpec_returnsNull() {
+    assertThat(resolver.resolve(null, null, "candidateGroups")).isNull();
+  }
+
+  @Test
+  void resolve_staticList_returnsValuesWithoutInvokingJQ() throws Exception {
+    StaticList spec = new StaticList(Set.of("irb-committee", "ethics-board"));
+    Set<String> result = resolver.resolve(null, spec, "candidateGroups");
+    assertThat(result).containsExactlyInAnyOrder("irb-committee", "ethics-board");
+  }
+
+  // ── resolveJq() — JQ evaluation path ────────────────────────────────────────
+
+  @Test
+  void resolveJq_validStringArray_returnsStringSet() throws Exception {
+    JsonNode context = mapper.readTree("{\"groups\": [\"ethics\", \"irb\"]}");
+    Set<String> result = resolver.resolveJq(context, new JQList(".groups"), "candidateGroups");
+    assertThat(result).containsExactlyInAnyOrder("ethics", "irb");
+    assertThat(ListExpressionResolver.isFailed(result)).isFalse();
+  }
+
+  @Test
+  void resolveJq_nonArray_returnsResolutionFailed() throws Exception {
+    JsonNode context = mapper.readTree("{\"groups\": \"not-an-array\"}");
+    Set<String> result = resolver.resolveJq(context, new JQList(".groups"), "candidateGroups");
+    assertThat(ListExpressionResolver.isFailed(result)).isTrue();
+  }
+
+  @Test
+  void resolveJq_emptyArray_returnsResolutionFailed() throws Exception {
+    JsonNode context = mapper.readTree("{\"groups\": []}");
+    Set<String> result = resolver.resolveJq(context, new JQList(".groups"), "candidateGroups");
+    assertThat(ListExpressionResolver.isFailed(result)).isTrue();
+  }
+
+  @Test
+  void resolveJq_absentField_returnsResolutionFailed() throws Exception {
+    JsonNode context = mapper.readTree("{}");
+    // .groups on {} produces null in JQ, which is not an array
+    Set<String> result = resolver.resolveJq(context, new JQList(".groups"), "candidateGroups");
+    assertThat(ListExpressionResolver.isFailed(result)).isTrue();
+  }
+
+  @Test
+  void resolveJq_invalidJqExpression_returnsResolutionFailed() throws Exception {
+    JsonNode context = mapper.readTree("{}");
+    Set<String> result =
+        resolver.resolveJq(context, new JQList("this is not valid jq !!!"), "candidateGroups");
+    assertThat(ListExpressionResolver.isFailed(result)).isTrue();
+  }
+
+  @Test
+  void resolveJq_arrayWithNonStringElement_returnsResolutionFailed() throws Exception {
+    JsonNode context = mapper.readTree("{\"groups\": [\"valid\", 42]}");
+    Set<String> result = resolver.resolveJq(context, new JQList(".groups"), "candidateGroups");
+    assertThat(ListExpressionResolver.isFailed(result)).isTrue();
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestratorTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestratorTest.java
@@ -205,6 +205,7 @@ class DefaultWorkOrchestratorTest {
           null,
           null,
           null,
+          null,
           "review",
           List.of(),
           null,

--- a/runtime/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
@@ -352,6 +352,7 @@ class DefaultWorkerSpiImplementationsTest {
             null,
             null,
             null,
+            null,
             "review",
             List.of(),
             null,

--- a/runtime/src/test/java/io/casehub/engine/internal/worker/NoOpCapabilityHealthTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/worker/NoOpCapabilityHealthTest.java
@@ -40,6 +40,7 @@ class NoOpCapabilityHealthTest {
             null,
             null,
             null,
+            null,
             "review",
             List.of(),
             null,

--- a/schema/src/main/resources/schema/CaseDefinition.yaml
+++ b/schema/src/main/resources/schema/CaseDefinition.yaml
@@ -272,13 +272,19 @@ $defs:
           (e.g. "casehubio/devtown/pr-review"). Null resolves preferences at root scope.
           Follow the platform convention: org / app / case-type.
       candidateGroups:
-        type: array
-        items: { type: string }
-        description: "Groups eligible to claim this WorkItem"
+        oneOf:
+          - type: array
+            items: { type: string }
+            description: "Static list of groups eligible to claim this WorkItem"
+          - type: string
+            description: "JQ expression resolving to a list of group names from case context (e.g. \".irb.candidateGroups\")"
       candidateUsers:
-        type: array
-        items: { type: string }
-        description: "Users eligible to claim this WorkItem"
+        oneOf:
+          - type: array
+            items: { type: string }
+            description: "Static list of users eligible to claim this WorkItem"
+          - type: string
+            description: "JQ expression resolving to a list of user IDs from case context"
       expiresIn:
         type: string
         description: "ISO 8601 duration after which the WorkItem expires (e.g. PT24H)"

--- a/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.HumanTaskTarget;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
+import io.casehub.api.model.evaluator.ListEvaluator;
 import io.casehub.blackboard.plan.CasePlanModel;
 import io.casehub.blackboard.plan.PlanItem;
 import io.casehub.blackboard.registry.BlackboardRegistry;
@@ -215,13 +216,20 @@ public class HumanTaskScheduleHandler {
   }
 
   private static String candidateGroupsCsv(HumanTaskTarget target) {
-    if (target.candidateGroups() == null || target.candidateGroups().isEmpty()) return null;
-    return String.join(",", target.candidateGroups());
+    return listEvaluatorToCsv(target.candidateGroups());
   }
 
   private static String candidateUsersCsv(HumanTaskTarget target) {
-    if (target.candidateUsers() == null || target.candidateUsers().isEmpty()) return null;
-    return String.join(",", target.candidateUsers());
+    return listEvaluatorToCsv(target.candidateUsers());
+  }
+
+  private static String listEvaluatorToCsv(ListEvaluator evaluator) {
+    if (evaluator == null) return null;
+    if (evaluator instanceof ListEvaluator.StaticList sl) {
+      return sl.values() == null || sl.values().isEmpty() ? null : String.join(",", sl.values());
+    }
+    // JQList — runtime evaluation against case context handled by ListExpressionResolver in Task 7
+    return null;
   }
 
   private static String extractOutputMappingExpression(HumanTaskTarget target) {

--- a/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/HumanTaskScheduleHandler.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.model.HumanTaskTarget;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
-import io.casehub.api.model.evaluator.ListEvaluator;
 import io.casehub.blackboard.plan.CasePlanModel;
 import io.casehub.blackboard.plan.PlanItem;
 import io.casehub.blackboard.registry.BlackboardRegistry;
@@ -40,6 +39,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.jboss.logging.Logger;
 
@@ -133,6 +133,12 @@ public class HumanTaskScheduleHandler {
             template, target.title(), null, "casehub-engine", callerRef);
 
     workItem.scope = target.scope();
+    if (event.resolvedCandidateGroups() != null) {
+      workItem.candidateGroups = toCsv(event.resolvedCandidateGroups());
+    }
+    if (event.resolvedCandidateUsers() != null) {
+      workItem.candidateUsers = toCsv(event.resolvedCandidateUsers());
+    }
     if (event.inputData() != null && !event.inputData().isEmpty()) {
       workItem.payload = serializePayload(event.inputData());
     }
@@ -155,7 +161,13 @@ public class HumanTaskScheduleHandler {
 
   private void handleInlineMode(PlanItem item, HumanTaskScheduleEvent event) {
     String callerRef = PlanItemCallerRef.encode(event.caseId(), item.getPlanItemId());
-    createInline(event.target(), event.inputData(), callerRef, event.caseBudgetDeadline());
+    createInline(
+        event.target(),
+        event.inputData(),
+        event.resolvedCandidateGroups(),
+        event.resolvedCandidateUsers(),
+        callerRef,
+        event.caseBudgetDeadline());
     planItemStore.save(
         new PlanItemSaveRequest(
             event.caseId(),
@@ -173,6 +185,8 @@ public class HumanTaskScheduleHandler {
   private void createInline(
       HumanTaskTarget target,
       Map<String, Object> inputData,
+      Set<String> resolvedGroups,
+      Set<String> resolvedUsers,
       String callerRef,
       Instant caseBudgetDeadline) {
     String payload = serializePayload(inputData);
@@ -183,8 +197,8 @@ public class HumanTaskScheduleHandler {
     WorkItemCreateRequest request =
         WorkItemCreateRequest.builder()
             .title(target.title())
-            .candidateGroups(candidateGroupsCsv(target))
-            .candidateUsers(candidateUsersCsv(target))
+            .candidateGroups(toCsv(resolvedGroups))
+            .candidateUsers(toCsv(resolvedUsers))
             .createdBy("casehub-engine")
             .payload(payload)
             .expiresAt(effectiveDeadline)
@@ -215,21 +229,9 @@ public class HumanTaskScheduleHandler {
     }
   }
 
-  private static String candidateGroupsCsv(HumanTaskTarget target) {
-    return listEvaluatorToCsv(target.candidateGroups());
-  }
-
-  private static String candidateUsersCsv(HumanTaskTarget target) {
-    return listEvaluatorToCsv(target.candidateUsers());
-  }
-
-  private static String listEvaluatorToCsv(ListEvaluator evaluator) {
-    if (evaluator == null) return null;
-    if (evaluator instanceof ListEvaluator.StaticList sl) {
-      return sl.values() == null || sl.values().isEmpty() ? null : String.join(",", sl.values());
-    }
-    // JQList — runtime evaluation against case context handled by ListExpressionResolver in Task 7
-    return null;
+  private static String toCsv(Set<String> values) {
+    if (values == null || values.isEmpty()) return null;
+    return String.join(",", values);
   }
 
   private static String extractOutputMappingExpression(HumanTaskTarget target) {

--- a/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerAtomicityTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerAtomicityTest.java
@@ -162,7 +162,8 @@ class HumanTaskScheduleHandlerAtomicityTest {
     try {
       eventBus.publish(
           EventBusAddresses.HUMAN_TASK_SCHEDULE,
-          new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null, TENANCY_ID));
+          new HumanTaskScheduleEvent(
+              caseId, "irb-binding", target, Map.of(), null, null, null, TENANCY_ID));
 
       try {
         assertThat(FailingWorkItemStore.putAttemptLatch.await(5, TimeUnit.SECONDS))

--- a/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerTest.java
@@ -93,7 +93,8 @@ class HumanTaskScheduleHandlerTest {
     HumanTaskTarget target = HumanTaskTarget.inline().title("Smoke").build();
     eventBus.publish(
         EventBusAddresses.HUMAN_TASK_SCHEDULE,
-        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null, TENANCY_ID));
+        new HumanTaskScheduleEvent(
+            caseId, "irb-binding", target, Map.of(), null, null, null, TENANCY_ID));
     await()
         .atMost(5, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.DELEGATED));
@@ -112,7 +113,14 @@ class HumanTaskScheduleHandlerTest {
 
     handler.onHumanTaskSchedule(
         new HumanTaskScheduleEvent(
-            caseId, "irb-binding", target, Map.of("caseRef", "T-42"), null, TENANCY_ID));
+            caseId,
+            "irb-binding",
+            target,
+            Map.of("caseRef", "T-42"),
+            null,
+            null,
+            null,
+            TENANCY_ID));
 
     String expectedCallerRef = PlanItemCallerRef.encode(caseId, planItem.getPlanItemId());
 
@@ -145,6 +153,8 @@ class HumanTaskScheduleHandlerTest {
             HumanTaskTarget.template(tmpl.id.toString()).build(),
             Map.of(),
             null,
+            null,
+            null,
             TENANCY_ID));
 
     String expectedCallerRef = PlanItemCallerRef.encode(caseId, planItem.getPlanItemId());
@@ -176,6 +186,8 @@ class HumanTaskScheduleHandlerTest {
             HumanTaskTarget.template(tmpl.id.toString()).build(),
             Map.of("trialId", "T-99", "phase", "III"),
             null,
+            null,
+            null,
             TENANCY_ID));
 
     WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
@@ -201,6 +213,8 @@ class HumanTaskScheduleHandlerTest {
             HumanTaskTarget.template(tmpl.id.toString()).build(),
             Map.of(),
             null,
+            null,
+            null,
             TENANCY_ID));
 
     WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
@@ -223,6 +237,8 @@ class HumanTaskScheduleHandlerTest {
             HumanTaskTarget.template(UUID.randomUUID().toString()).build(),
             Map.of(),
             null,
+            null,
+            null,
             TENANCY_ID));
 
     assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.PENDING);
@@ -237,6 +253,8 @@ class HumanTaskScheduleHandlerTest {
             "irb-binding",
             HumanTaskTarget.template("not-a-uuid").build(),
             Map.of(),
+            null,
+            null,
             null,
             TENANCY_ID));
 
@@ -257,7 +275,7 @@ class HumanTaskScheduleHandlerTest {
 
     handler.onHumanTaskSchedule(
         new HumanTaskScheduleEvent(
-            caseId, "irb-binding", target, Map.of(), budgetDeadline, TENANCY_ID));
+            caseId, "irb-binding", target, Map.of(), null, null, budgetDeadline, TENANCY_ID));
 
     WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
     assertThat(created).isNotNull();
@@ -276,7 +294,7 @@ class HumanTaskScheduleHandlerTest {
 
     handler.onHumanTaskSchedule(
         new HumanTaskScheduleEvent(
-            caseId, "irb-binding", target, Map.of(), budgetDeadline, TENANCY_ID));
+            caseId, "irb-binding", target, Map.of(), null, null, budgetDeadline, TENANCY_ID));
 
     WorkItem created = workItemStore.scanAll().stream().findFirst().orElse(null);
     assertThat(created).isNotNull();
@@ -290,7 +308,8 @@ class HumanTaskScheduleHandlerTest {
         HumanTaskTarget.inline().title("Unbounded Review").expiresIn(Duration.ofHours(48)).build();
 
     handler.onHumanTaskSchedule(
-        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null, TENANCY_ID));
+        new HumanTaskScheduleEvent(
+            caseId, "irb-binding", target, Map.of(), null, null, null, TENANCY_ID));
 
     assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.DELEGATED);
   }
@@ -308,6 +327,8 @@ class HumanTaskScheduleHandlerTest {
             HumanTaskTarget.inline().title("Review").build(),
             Map.of(),
             null,
+            null,
+            null,
             TENANCY_ID));
 
     assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.PENDING);
@@ -322,6 +343,8 @@ class HumanTaskScheduleHandlerTest {
             "unknown-binding",
             HumanTaskTarget.inline().title("Review").build(),
             Map.of(),
+            null,
+            null,
             null,
             TENANCY_ID));
 
@@ -340,7 +363,8 @@ class HumanTaskScheduleHandlerTest {
             .build();
 
     handler.onHumanTaskSchedule(
-        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null, TENANCY_ID));
+        new HumanTaskScheduleEvent(
+            caseId, "irb-binding", target, Map.of(), null, null, null, TENANCY_ID));
 
     io.casehub.work.runtime.model.WorkItem created =
         workItemStore.scanAll().stream().findFirst().orElse(null);
@@ -353,7 +377,8 @@ class HumanTaskScheduleHandlerTest {
     HumanTaskTarget target = HumanTaskTarget.inline().title("IRB Ethics Review").build();
 
     handler.onHumanTaskSchedule(
-        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null, TENANCY_ID));
+        new HumanTaskScheduleEvent(
+            caseId, "irb-binding", target, Map.of(), null, null, null, TENANCY_ID));
 
     io.casehub.work.runtime.model.WorkItem created =
         workItemStore.scanAll().stream().findFirst().orElse(null);
@@ -371,7 +396,8 @@ class HumanTaskScheduleHandlerTest {
             .build();
 
     handler.onHumanTaskSchedule(
-        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null, TENANCY_ID));
+        new HumanTaskScheduleEvent(
+            caseId, "irb-binding", target, Map.of(), null, null, null, TENANCY_ID));
 
     io.casehub.work.runtime.model.WorkItem created =
         workItemStore.scanAll().stream().findFirst().orElse(null);
@@ -386,12 +412,43 @@ class HumanTaskScheduleHandlerTest {
     HumanTaskTarget target = HumanTaskTarget.template(tmpl.id.toString()).build();
 
     handler.onHumanTaskSchedule(
-        new HumanTaskScheduleEvent(caseId, "irb-binding", target, Map.of(), null, TENANCY_ID));
+        new HumanTaskScheduleEvent(
+            caseId, "irb-binding", target, Map.of(), null, null, null, TENANCY_ID));
 
     io.casehub.work.runtime.model.WorkItem created =
         workItemStore.scanAll().stream().findFirst().orElse(null);
     assertThat(created).isNotNull();
     assertThat(created.scope).isNull();
+  }
+
+  @Test
+  void inlineMode_candidateGroupsExpression_workItemHasNullGroups_pendingTask7() {
+    // JQ expression path: listEvaluatorToCsv returns null for JQList until Task 7 wires the
+    // resolver.
+    // This test documents the known gap — update it in Task 7 to pass resolved groups via the
+    // event.
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("IRB Review")
+            .candidateGroupsExpression(".irb.candidateGroups")
+            .build();
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(
+            caseId, "irb-binding", target, Map.of(), null, null, null, TENANCY_ID));
+
+    String expectedCallerRef = PlanItemCallerRef.encode(caseId, planItem.getPlanItemId());
+    WorkItem created =
+        workItemStore.scanAll().stream()
+            .filter(w -> expectedCallerRef.equals(w.callerRef))
+            .findFirst()
+            .orElse(null);
+    assertThat(created).isNotNull();
+    assertThat(created.status).isEqualTo(WorkItemStatus.PENDING);
+    // JQ not evaluated in handler — candidateGroups is null until Task 7 wires
+    // ListExpressionResolver
+    assertThat(created.candidateGroups).isNull();
+    assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.DELEGATED);
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────
@@ -410,6 +467,8 @@ class HumanTaskScheduleHandlerTest {
             "irb-binding",
             HumanTaskTarget.inline().title("Review").build(),
             Map.of(),
+            null,
+            null,
             null,
             TENANCY_ID));
 

--- a/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskScheduleHandlerTest.java
@@ -421,17 +421,36 @@ class HumanTaskScheduleHandlerTest {
     assertThat(created.scope).isNull();
   }
 
+  // ── Dynamic candidateGroups — inline mode ────────────────────────────────
+
   @Test
-  void inlineMode_candidateGroupsExpression_workItemHasNullGroups_pendingTask7() {
-    // JQ expression path: listEvaluatorToCsv returns null for JQList until Task 7 wires the
-    // resolver.
-    // This test documents the known gap — update it in Task 7 to pass resolved groups via the
-    // event.
-    HumanTaskTarget target =
-        HumanTaskTarget.inline()
-            .title("IRB Review")
-            .candidateGroupsExpression(".irb.candidateGroups")
-            .build();
+  void inlineMode_resolvedCandidateGroups_passedToWorkItem() {
+    HumanTaskTarget target = HumanTaskTarget.inline().title("IRB Review").build();
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(
+            caseId,
+            "irb-binding",
+            target,
+            Map.of(),
+            Set.of("irb-committee"),
+            null,
+            null,
+            TENANCY_ID));
+
+    String expectedCallerRef = PlanItemCallerRef.encode(caseId, planItem.getPlanItemId());
+    WorkItem created =
+        workItemStore.scanAll().stream()
+            .filter(w -> expectedCallerRef.equals(w.callerRef))
+            .findFirst()
+            .orElse(null);
+    assertThat(created).isNotNull();
+    assertThat(created.candidateGroups).isEqualTo("irb-committee");
+  }
+
+  @Test
+  void inlineMode_nullResolvedCandidateGroups_workItemHasNullGroups() {
+    HumanTaskTarget target = HumanTaskTarget.inline().title("Open Review").build();
 
     handler.onHumanTaskSchedule(
         new HumanTaskScheduleEvent(
@@ -444,11 +463,105 @@ class HumanTaskScheduleHandlerTest {
             .findFirst()
             .orElse(null);
     assertThat(created).isNotNull();
-    assertThat(created.status).isEqualTo(WorkItemStatus.PENDING);
-    // JQ not evaluated in handler — candidateGroups is null until Task 7 wires
-    // ListExpressionResolver
     assertThat(created.candidateGroups).isNull();
-    assertThat(planItem.getStatus()).isEqualTo(PlanItemStatus.DELEGATED);
+  }
+
+  // ── Dynamic candidateGroups — template mode ───────────────────────────────
+
+  @Test
+  void templateMode_resolvedCandidateGroups_overridesTemplateDefaults() {
+    WorkItemTemplate tmpl = persistTemplate("IRB Review Template");
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(
+            caseId,
+            "irb-binding",
+            HumanTaskTarget.template(tmpl.id.toString()).build(),
+            Map.of(),
+            Set.of("committee-a", "committee-b"),
+            null,
+            null,
+            TENANCY_ID));
+
+    WorkItem created =
+        workItemStore.scanAll().stream()
+            .filter(w -> w.callerRef != null && w.callerRef.startsWith("case:"))
+            .findFirst()
+            .orElse(null);
+    assertThat(created).isNotNull();
+    assertThat(created.candidateGroups.split(","))
+        .containsExactlyInAnyOrder("committee-a", "committee-b");
+  }
+
+  @Test
+  void templateMode_nullResolvedCandidateGroups_keepsTemplateDefaults() {
+    WorkItemTemplate tmpl = persistTemplate("IRB Review Template");
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(
+            caseId,
+            "irb-binding",
+            HumanTaskTarget.template(tmpl.id.toString()).build(),
+            Map.of(),
+            null, // spec absent — do not override template defaults
+            null,
+            null,
+            TENANCY_ID));
+
+    WorkItem created =
+        workItemStore.scanAll().stream()
+            .filter(w -> w.callerRef != null && w.callerRef.startsWith("case:"))
+            .findFirst()
+            .orElse(null);
+    assertThat(created).isNotNull();
+    // Template has no candidateGroups set (persistTemplate doesn't set them) — stays null
+    assertThat(created.candidateGroups).isNull();
+  }
+
+  // ── Dynamic candidateUsers — inline mode ──────────────────────────────────
+
+  @Test
+  void inlineMode_resolvedCandidateUsers_passedToWorkItem() {
+    HumanTaskTarget target = HumanTaskTarget.inline().title("IRB Review").build();
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(
+            caseId, "irb-binding", target, Map.of(), null, Set.of("user-a"), null, TENANCY_ID));
+
+    String expectedCallerRef = PlanItemCallerRef.encode(caseId, planItem.getPlanItemId());
+    WorkItem created =
+        workItemStore.scanAll().stream()
+            .filter(w -> expectedCallerRef.equals(w.callerRef))
+            .findFirst()
+            .orElse(null);
+    assertThat(created).isNotNull();
+    assertThat(created.candidateUsers).isEqualTo("user-a");
+  }
+
+  // ── Dynamic candidateUsers — template mode ────────────────────────────────
+
+  @Test
+  void templateMode_resolvedCandidateUsers_overridesTemplateDefaults() {
+    WorkItemTemplate tmpl = persistTemplate("IRB Review Template");
+
+    handler.onHumanTaskSchedule(
+        new HumanTaskScheduleEvent(
+            caseId,
+            "irb-binding",
+            HumanTaskTarget.template(tmpl.id.toString()).build(),
+            Map.of(),
+            null,
+            Set.of("user-x", "user-y"),
+            null,
+            TENANCY_ID));
+
+    WorkItem created =
+        workItemStore.scanAll().stream()
+            .filter(w -> w.callerRef != null && w.callerRef.startsWith("case:"))
+            .findFirst()
+            .orElse(null);
+    assertThat(created).isNotNull();
+    assertThat(created.candidateUsers.split(",")).containsExactlyInAnyOrder("user-x", "user-y");
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds JQ expression support for `candidateGroups` and `candidateUsers` in `humanTask` YAML bindings. Previously these were static lists only.

```yaml
# Static (existing — unchanged)
humanTask:
  candidateGroups: [irb-committee]

# Dynamic — resolved from case context at task creation
humanTask:
  candidateGroups: ".irb.candidateGroups"
```

## Design

- `ListEvaluator` sealed interface (`StaticList` / `JQList` inner records) — separate hierarchy from `ExpressionEvaluator` (which is a boolean predicate; merging them would cause `ExpressionEngineRegistry` dispatch errors)
- Expressions evaluated at event-publish time in `CaseContextChangedEventHandler` via `ListExpressionResolver @ApplicationScoped` — handler receives pre-resolved `Set<String>`, never a raw expression
- Either field failing resolution (non-array result, empty array, exception) blocks the `HumanTaskScheduleEvent` — PlanItem stays PENDING
- Template mode: `resolvedCandidateGroups != null` overrides template routing; `null` preserves template defaults
- ADR-0008 records the `ListEvaluator` hierarchy decision

## Changes

- `api/` — `ListEvaluator.java` sealed interface; `HumanTaskTarget` builder gains `candidateGroupsExpression(String)` / `candidateUsersExpression(String)`; YAML schema `oneOf` for both fields; mapper branches on `Object` type
- `common/` — `HumanTaskScheduleEvent` gains `resolvedCandidateGroups` and `resolvedCandidateUsers` fields
- `runtime/` — `ListExpressionResolver` (8-branch unit tests); `CaseContextChangedEventHandler` resolves and guards
- `work-adapter/` — `HumanTaskScheduleHandler` uses resolved fields; `toCsv(Set<String>)` replaces target-bound helpers; template override
- `docs/adr/0008-list-evaluator-separate-sealed-hierarchy.md`
- `docs/specs/2026-06-07-humantask-dynamic-candidate-groups-design.md`

## Test plan

- [ ] `HumanTaskTargetTest` — builder overloads, `ListEvaluator` types returned
- [ ] `CaseDefinitionYamlMapperTest` — JQ string and static list YAML round-trips; non-string element throws
- [ ] `ListExpressionResolverTest` — 8 branches: null/static/valid-JQ/non-array/empty/absent/invalid/non-string-element
- [ ] `HumanTaskTargetDispatchTest` — dynamic resolution end-to-end; failure blocks event; conjunction test (groups fail + users succeed)
- [ ] `HumanTaskScheduleHandlerTest` — inline mode resolved/null; template override/skip; candidateUsers coverage

## Refs

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)