### PR TITLE
feat(panels): CaseContext panel architecture — working, semantic, episodic memory stratification

### DIFF
--- a/api/src/main/java/io/casehub/api/context/CaseContext.java
+++ b/api/src/main/java/io/casehub/api/context/CaseContext.java
@@ -24,6 +24,8 @@ import java.util.function.Function;
 
 public interface CaseContext {
 
+  ReadablePanel panel(String name);
+
   Map<String, Object> getData();
 
   CaseContext set(String key, Object value);

--- a/api/src/main/java/io/casehub/api/context/ContextPanel.java
+++ b/api/src/main/java/io/casehub/api/context/ContextPanel.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.context;
+
+public final class ContextPanel {
+  public static final String WORKING = "working";
+  public static final String SEMANTIC = "semantic";
+  public static final String EPISODIC = "episodic";
+
+  private ContextPanel() {}
+}

--- a/api/src/main/java/io/casehub/api/context/ReadOnlyPanelException.java
+++ b/api/src/main/java/io/casehub/api/context/ReadOnlyPanelException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.context;
+
+public class ReadOnlyPanelException extends RuntimeException {
+  public ReadOnlyPanelException(String panelName) {
+    super("Panel '" + panelName + "' is read-only — writes are not permitted");
+  }
+}

--- a/api/src/main/java/io/casehub/api/context/ReadablePanel.java
+++ b/api/src/main/java/io/casehub/api/context/ReadablePanel.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.context;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface ReadablePanel {
+
+  String panelName();
+
+  boolean isReadOnly();
+
+  Object get(String key);
+
+  <T> T getAs(String key, Class<T> type);
+
+  <T> T getOrDefault(String key, T defaultValue);
+
+  String getString(String key);
+
+  Integer getInt(String key);
+
+  Long getLong(String key);
+
+  Double getDouble(String key);
+
+  Boolean getBoolean(String key);
+
+  <T> List<T> getList(String key, Class<T> elementType);
+
+  boolean contains(String key);
+
+  Set<String> getKeys();
+
+  Map<String, Object> getData();
+
+  Map<String, Object> getAll(String... keys);
+
+  Object getPath(String path);
+
+  String getPathAsString(String path);
+
+  boolean isEmpty();
+
+  int size();
+
+  long getVersion();
+
+  JsonNode asJsonNode();
+}

--- a/api/src/main/java/io/casehub/api/context/ReadablePanel.java
+++ b/api/src/main/java/io/casehub/api/context/ReadablePanel.java
@@ -63,4 +63,6 @@ public interface ReadablePanel {
   long getVersion();
 
   JsonNode asJsonNode();
+
+  ReadablePanel snapshot();
 }

--- a/api/src/main/java/io/casehub/api/context/WritablePanel.java
+++ b/api/src/main/java/io/casehub/api/context/WritablePanel.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.context;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface WritablePanel extends ReadablePanel {
+
+  WritablePanel set(String key, Object value);
+
+  WritablePanel setAll(Map<String, Object> values);
+
+  WritablePanel setPath(String path, Object value);
+
+  WritablePanel remove(String key);
+
+  WritablePanel clear();
+
+  WritablePanel merge(ReadablePanel other);
+
+  Object computeIfAbsent(String key, Function<String, Object> mappingFunction);
+
+  Object putIfAbsent(String key, Object value);
+
+  boolean compareAndSet(String key, Object expected, Object newValue);
+
+  WritablePanel update(String key, Function<Object, Object> updateFunction);
+
+  Optional<JsonNode> applyAndDiff(String path, Object value);
+
+  void applyDiff(JsonNode diff);
+
+  JsonNode diff(ReadablePanel other);
+}

--- a/api/src/main/java/io/casehub/api/engine/CaseHubRuntime.java
+++ b/api/src/main/java/io/casehub/api/engine/CaseHubRuntime.java
@@ -21,6 +21,7 @@ import io.casehub.api.model.event.CaseEventLogRecord;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -34,6 +35,16 @@ public interface CaseHubRuntime {
   CompletionStage<UUID> startCase(
       CaseDefinition definition,
       Object inputData,
+      UUID parentCaseId,
+      PropagationContext propagationContext);
+
+  CompletionStage<UUID> startCase(
+      CaseDefinition definition, Object inputData, Map<String, Object> semanticData);
+
+  CompletionStage<UUID> startCase(
+      CaseDefinition definition,
+      Object inputData,
+      Map<String, Object> semanticData,
       UUID parentCaseId,
       PropagationContext propagationContext);
 

--- a/api/src/main/java/io/casehub/api/model/CaseDefinition.java
+++ b/api/src/main/java/io/casehub/api/model/CaseDefinition.java
@@ -279,6 +279,22 @@ public class CaseDefinition {
       return this;
     }
 
+    public Builder panel(String name) {
+      if (this.panelNames == null) {
+        this.panelNames = new java.util.ArrayList<>();
+      }
+      this.panelNames.add(name);
+      return this;
+    }
+
+    public Builder panels(String... names) {
+      if (this.panelNames == null) {
+        this.panelNames = new java.util.ArrayList<>();
+      }
+      java.util.Collections.addAll(this.panelNames, names);
+      return this;
+    }
+
     public CaseDefinition build() {
       CaseDefinition caseHubDefinition =
           new CaseDefinition(

--- a/api/src/main/java/io/casehub/api/model/CaseDefinition.java
+++ b/api/src/main/java/io/casehub/api/model/CaseDefinition.java
@@ -18,6 +18,7 @@ package io.casehub.api.model;
 import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class CaseDefinition {
@@ -35,6 +36,8 @@ public class CaseDefinition {
   private final List<Milestone> milestones;
   private final List<Goal> goals;
   private CaseCompletion completion;
+  private Map<String, Object> semanticData;
+  private EpisodicMemoryConfig episodicMemoryConfig;
 
   public CaseDefinition(String namespace, String name, String version) {
     this.namespace = namespace;
@@ -119,6 +122,22 @@ public class CaseDefinition {
     this.completion = completion;
   }
 
+  public Map<String, Object> getSemanticData() {
+    return semanticData;
+  }
+
+  public void setSemanticData(Map<String, Object> semanticData) {
+    this.semanticData = semanticData;
+  }
+
+  public EpisodicMemoryConfig getEpisodicMemoryConfig() {
+    return episodicMemoryConfig;
+  }
+
+  public void setEpisodicMemoryConfig(EpisodicMemoryConfig config) {
+    this.episodicMemoryConfig = config;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -136,6 +155,8 @@ public class CaseDefinition {
     private List<Milestone> milestones;
     private List<Goal> goals;
     private CaseCompletion completion;
+    private Map<String, Object> semanticData;
+    private EpisodicMemoryConfig episodicMemoryConfig;
 
     private Builder() {}
 
@@ -228,6 +249,21 @@ public class CaseDefinition {
       return this;
     }
 
+    public Builder semanticData(Map<String, Object> semanticData) {
+      this.semanticData = semanticData;
+      return this;
+    }
+
+    public Builder episodicMemory(String domain, String entityId) {
+      this.episodicMemoryConfig = EpisodicMemoryConfig.of(domain, entityId);
+      return this;
+    }
+
+    public Builder episodicMemory(String domain, String entityId, int recent) {
+      this.episodicMemoryConfig = EpisodicMemoryConfig.of(domain, entityId, recent);
+      return this;
+    }
+
     public CaseDefinition build() {
       CaseDefinition caseHubDefinition =
           new CaseDefinition(
@@ -252,6 +288,8 @@ public class CaseDefinition {
         caseHubDefinition.goals.addAll(goals);
       }
       caseHubDefinition.setCompletion(completion);
+      caseHubDefinition.setSemanticData(semanticData);
+      caseHubDefinition.setEpisodicMemoryConfig(episodicMemoryConfig);
 
       return caseHubDefinition;
     }

--- a/api/src/main/java/io/casehub/api/model/CaseDefinition.java
+++ b/api/src/main/java/io/casehub/api/model/CaseDefinition.java
@@ -38,6 +38,7 @@ public class CaseDefinition {
   private CaseCompletion completion;
   private Map<String, Object> semanticData;
   private EpisodicMemoryConfig episodicMemoryConfig;
+  private List<String> panelNames;
 
   public CaseDefinition(String namespace, String name, String version) {
     this.namespace = namespace;
@@ -138,6 +139,14 @@ public class CaseDefinition {
     this.episodicMemoryConfig = config;
   }
 
+  public List<String> getPanelNames() {
+    return panelNames;
+  }
+
+  public void setPanelNames(List<String> panelNames) {
+    this.panelNames = panelNames;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -157,6 +166,7 @@ public class CaseDefinition {
     private CaseCompletion completion;
     private Map<String, Object> semanticData;
     private EpisodicMemoryConfig episodicMemoryConfig;
+    private List<String> panelNames;
 
     private Builder() {}
 
@@ -264,6 +274,11 @@ public class CaseDefinition {
       return this;
     }
 
+    public Builder panelNames(List<String> panelNames) {
+      this.panelNames = panelNames;
+      return this;
+    }
+
     public CaseDefinition build() {
       CaseDefinition caseHubDefinition =
           new CaseDefinition(
@@ -290,6 +305,7 @@ public class CaseDefinition {
       caseHubDefinition.setCompletion(completion);
       caseHubDefinition.setSemanticData(semanticData);
       caseHubDefinition.setEpisodicMemoryConfig(episodicMemoryConfig);
+      caseHubDefinition.setPanelNames(panelNames);
 
       return caseHubDefinition;
     }

--- a/api/src/main/java/io/casehub/api/model/ContextChangeTrigger.java
+++ b/api/src/main/java/io/casehub/api/model/ContextChangeTrigger.java
@@ -21,16 +21,28 @@ import io.casehub.api.model.evaluator.JQExpressionEvaluator;
 public class ContextChangeTrigger implements Trigger {
 
   private final ExpressionEvaluator filter;
+  private final String listenPanel;
 
   public ContextChangeTrigger(String filter) {
     this.filter = new JQExpressionEvaluator(filter);
+    this.listenPanel = null;
   }
 
   public ContextChangeTrigger(ExpressionEvaluator filter) {
     this.filter = filter;
+    this.listenPanel = null;
+  }
+
+  public ContextChangeTrigger(ExpressionEvaluator filter, String listenPanel) {
+    this.filter = filter;
+    this.listenPanel = listenPanel;
   }
 
   public ExpressionEvaluator getFilter() {
     return filter;
+  }
+
+  public String getListenPanel() {
+    return listenPanel;
   }
 }

--- a/api/src/main/java/io/casehub/api/model/EpisodicMemoryConfig.java
+++ b/api/src/main/java/io/casehub/api/model/EpisodicMemoryConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.model;
+
+import java.util.Objects;
+
+public record EpisodicMemoryConfig(
+    String domain, // MemoryDomain name
+    String entityId, // JQ expression against semantic panel; result -> List<String>
+    int recent // max items; default 10
+    ) {
+  public EpisodicMemoryConfig {
+    Objects.requireNonNull(domain, "domain is required");
+    Objects.requireNonNull(entityId, "entityId is required");
+    if (recent < 1) recent = 10;
+  }
+
+  public static EpisodicMemoryConfig of(String domain, String entityId) {
+    return new EpisodicMemoryConfig(domain, entityId, 10);
+  }
+
+  public static EpisodicMemoryConfig of(String domain, String entityId, int recent) {
+    return new EpisodicMemoryConfig(domain, entityId, recent);
+  }
+}

--- a/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
+++ b/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
@@ -25,6 +25,7 @@ import io.casehub.api.model.AnyOfGoalExpression;
 import io.casehub.api.model.Binding;
 import io.casehub.api.model.Capability;
 import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.EpisodicMemoryConfig;
 import io.casehub.api.model.Goal;
 import io.casehub.api.model.GoalBasedCompletion;
 import io.casehub.api.model.GoalExpression;
@@ -121,9 +122,20 @@ public final class CaseDefinitionYamlMapper {
     if (yamlStream == null) {
       throw new IllegalArgumentException("InputStream cannot be null");
     }
+    // Read bytes once so we can parse both as JsonNode (for free-form fields) and typed schema
+    // model
+    final byte[] bytes = yamlStream.readAllBytes();
+    final JsonNode rawNode = objectMapper.readTree(bytes);
+    // Disable FAIL_ON_UNKNOWN_PROPERTIES so free-form schema fields (e.g. semanticData with
+    // additionalProperties:true) are silently ignored by the generated empty schema class.
+    final ObjectMapper lenient =
+        objectMapper
+            .copy()
+            .disable(
+                com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     final io.casehub.model.CaseDefinition schema =
-        objectMapper.readValue(yamlStream, io.casehub.model.CaseDefinition.class);
-    return convertToApiModel(schema, registry);
+        lenient.readValue(bytes, io.casehub.model.CaseDefinition.class);
+    return convertToApiModel(schema, rawNode, objectMapper, registry);
   }
 
   /**
@@ -149,7 +161,10 @@ public final class CaseDefinitionYamlMapper {
    * @return API model CaseDefinition
    */
   private static CaseDefinition convertToApiModel(
-      final io.casehub.model.CaseDefinition schema, final ExpressionEngineRegistry registry) {
+      final io.casehub.model.CaseDefinition schema,
+      final JsonNode rawNode,
+      final ObjectMapper objectMapper,
+      final ExpressionEngineRegistry registry) {
     final String expressionLang =
         schema.getExpressionLang() != null
             ? schema.getExpressionLang()
@@ -161,9 +176,36 @@ public final class CaseDefinitionYamlMapper {
     def.setDsl(schema.getDsl());
     def.setTitle(schema.getTitle());
 
+    // semanticData — free-form object; read directly from raw JsonNode to avoid empty generated
+    // class
+    final JsonNode semanticDataNode = rawNode.get("semanticData");
+    if (semanticDataNode != null && !semanticDataNode.isNull() && semanticDataNode.isObject()) {
+      @SuppressWarnings("unchecked")
+      final Map<String, Object> semData = objectMapper.convertValue(semanticDataNode, Map.class);
+      def.setSemanticData(semData);
+    }
+
+    // episodic.memory config — typed via generated Episodic/Memory classes
+    if (schema.getEpisodic() != null && schema.getEpisodic().getMemory() != null) {
+      final io.casehub.model.Memory mem = schema.getEpisodic().getMemory();
+      final int recent = mem.getRecent() != null ? mem.getRecent() : 10;
+      def.setEpisodicMemoryConfig(
+          EpisodicMemoryConfig.of(mem.getDomain(), mem.getEntityId(), recent));
+    }
+
+    // panels — user-defined panel names
+    if (schema.getPanels() != null && !schema.getPanels().isEmpty()) {
+      final List<String> panelNames =
+          schema.getPanels().stream()
+              .map(io.casehub.model.Panel::getName)
+              .filter(java.util.Objects::nonNull)
+              .toList();
+      def.setPanelNames(panelNames);
+    }
+
     // Convert capabilities
     final Map<String, Capability> capabilityMap = new LinkedHashMap<>();
-    if (schema.getSpec().getCapabilities() != null) {
+    if (schema.getSpec() != null && schema.getSpec().getCapabilities() != null) {
       for (io.casehub.model.Capability sc : schema.getSpec().getCapabilities()) {
         final Capability cap =
             new Capability(sc.getName(), sc.getInputSchema(), sc.getOutputSchema());
@@ -174,7 +216,7 @@ public final class CaseDefinitionYamlMapper {
     }
 
     // Convert workers
-    if (schema.getSpec().getWorkers() != null) {
+    if (schema.getSpec() != null && schema.getSpec().getWorkers() != null) {
       for (io.casehub.model.Worker sw : schema.getSpec().getWorkers()) {
         final List<Capability> workerCaps =
             sw.getCapabilities().stream().map(capabilityMap::get).collect(Collectors.toList());
@@ -192,7 +234,7 @@ public final class CaseDefinitionYamlMapper {
     }
 
     // Convert bindings
-    if (schema.getSpec().getBindings() != null) {
+    if (schema.getSpec() != null && schema.getSpec().getBindings() != null) {
       for (io.casehub.model.Binding sr : schema.getSpec().getBindings()) {
         final Binding binding = convertBinding(sr, capabilityMap, registry, expressionLang);
         def.getBindings().add(binding);
@@ -200,7 +242,7 @@ public final class CaseDefinitionYamlMapper {
     }
 
     // Convert milestones
-    if (schema.getSpec().getMilestones() != null) {
+    if (schema.getSpec() != null && schema.getSpec().getMilestones() != null) {
       for (io.casehub.model.Milestone sm : schema.getSpec().getMilestones()) {
         final Milestone.Builder milestoneBuilder =
             Milestone.builder()
@@ -258,7 +300,7 @@ public final class CaseDefinitionYamlMapper {
 
     // Convert goals
     final Map<String, Goal> goalMap = new LinkedHashMap<>();
-    if (schema.getSpec().getGoals() != null) {
+    if (schema.getSpec() != null && schema.getSpec().getGoals() != null) {
       for (io.casehub.model.Goal sg : schema.getSpec().getGoals()) {
         final Goal goal =
             new Goal(
@@ -272,7 +314,7 @@ public final class CaseDefinitionYamlMapper {
     }
 
     // Convert completion
-    if (schema.getSpec().getCompletion() != null) {
+    if (schema.getSpec() != null && schema.getSpec().getCompletion() != null) {
       final io.casehub.model.CaseCompletion sc = schema.getSpec().getCompletion();
       final GoalExpression successExpr = convertGoalExpression(sc.getSuccess(), goalMap);
       final GoalExpression failureExpr = convertGoalExpression(sc.getFailure(), goalMap);
@@ -374,8 +416,9 @@ public final class CaseDefinitionYamlMapper {
 
     if (schemaTrigger.getContextChange() != null) {
       final String filter = schemaTrigger.getContextChange().getFilter();
+      final String listenPanel = schemaTrigger.getContextChange().getListenPanel();
       return new io.casehub.api.model.ContextChangeTrigger(
-          filter != null ? registry.create(filter, expressionLang) : null);
+          filter != null ? registry.create(filter, expressionLang) : null, listenPanel);
     }
 
     // TODO: Add support for CloudEventTrigger and ScheduleTrigger

--- a/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
+++ b/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
@@ -1086,4 +1086,135 @@ class CaseDefinitionYamlMapperTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("unknown-lang");
   }
+
+  // ── semanticData / episodic.memory / panels / listenPanel tests ────────────
+
+  @Test
+  void parseSemanticData() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: fraud
+        version: 1.0.0
+        semanticData:
+          threshold: 0.8
+          domain: "fraud-check"
+        """;
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    assertThat(def.getSemanticData()).isNotNull();
+    assertThat(((Number) def.getSemanticData().get("threshold")).doubleValue())
+        .isCloseTo(0.8, org.assertj.core.data.Offset.offset(0.001));
+    assertThat(def.getSemanticData().get("domain")).isEqualTo("fraud-check");
+  }
+
+  @Test
+  void parseEpisodicMemoryConfig() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: fraud2
+        version: 1.0.0
+        episodic:
+          memory:
+            domain: "fraud-check"
+            entityId: ".semantic.customerId"
+            recent: 5
+        """;
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    assertThat(def.getEpisodicMemoryConfig()).isNotNull();
+    assertThat(def.getEpisodicMemoryConfig().domain()).isEqualTo("fraud-check");
+    assertThat(def.getEpisodicMemoryConfig().entityId()).isEqualTo(".semantic.customerId");
+    assertThat(def.getEpisodicMemoryConfig().recent()).isEqualTo(5);
+  }
+
+  @Test
+  void parseEpisodicMemoryConfig_defaultRecent() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: fraud3
+        version: 1.0.0
+        episodic:
+          memory:
+            domain: "fraud-check"
+            entityId: ".semantic.customerId"
+        """;
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    assertThat(def.getEpisodicMemoryConfig()).isNotNull();
+    assertThat(def.getEpisodicMemoryConfig().recent()).isEqualTo(10);
+  }
+
+  @Test
+  void parsePanels() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: multi-panel
+        version: 1.0.0
+        panels:
+          - name: "raw"
+          - name: "extracted"
+        """;
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    assertThat(def.getPanelNames()).containsExactly("raw", "extracted");
+  }
+
+  @Test
+  void parseListenPanel() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: listen-panel-test
+        version: 1.0.0
+        spec:
+          capabilities:
+            - name: analyze
+          bindings:
+            - name: analysis-binding
+              capability: analyze
+              on:
+                contextChange:
+                  filter: ".raw != null"
+                  listenPanel: "raw"
+        """;
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    assertThat(def.getBindings()).hasSize(1);
+    assertThat(def.getBindings().get(0).getOn()).isInstanceOf(ContextChangeTrigger.class);
+    ContextChangeTrigger trigger = (ContextChangeTrigger) def.getBindings().get(0).getOn();
+    assertThat(trigger.getListenPanel()).isEqualTo("raw");
+  }
+
+  @Test
+  void parseListenPanel_absent_isNull() throws IOException {
+    String yaml =
+        """
+        namespace: test
+        name: no-listen-panel
+        version: 1.0.0
+        spec:
+          capabilities:
+            - name: analyze
+          bindings:
+            - name: b1
+              capability: analyze
+              on:
+                contextChange:
+                  filter: ".x == 1"
+        """;
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    ContextChangeTrigger trigger = (ContextChangeTrigger) def.getBindings().get(0).getOn();
+    assertThat(trigger.getListenPanel()).isNull();
+  }
 }

--- a/blackboard/src/test/java/io/casehub/blackboard/it/BasicBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/BasicBlackboardTest.java
@@ -237,7 +237,7 @@ class BasicBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("once-cap")
-            .inputSchema("{ phase: .phase }")
+            .inputSchema("{ phase: .working.phase }")
             .outputSchema("{ phase: .phase }")
             .build();
 
@@ -259,7 +259,7 @@ class BasicBlackboardTest {
               Binding.builder()
                   .name("on-start-phase")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".phase == \"start\""))
+                  .on(new ContextChangeTrigger(".working.phase == \"start\""))
                   .build())
           // No goals — case stays RUNNING, enabling post-completion assertions
           .build();
@@ -276,7 +276,7 @@ class BasicBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("never-cap")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
@@ -299,7 +299,7 @@ class BasicBlackboardTest {
                   .capability(cap)
                   .on(
                       new ContextChangeTrigger(
-                          ".phase == \"start\"")) // context has "status", not "phase"
+                          ".working.phase == \"start\"")) // context has "status", not "phase"
                   .build())
           .build();
     }
@@ -315,14 +315,14 @@ class BasicBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("completing-cap")
-            .inputSchema("{ phase: .phase }")
+            .inputSchema("{ phase: .working.phase }")
             .outputSchema("{ phase: .phase }")
             .build();
 
     private final Goal successGoal =
         Goal.builder()
             .name("processingComplete")
-            .condition(".phase == \"done\"")
+            .condition(".working.phase == \"done\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -343,7 +343,7 @@ class BasicBlackboardTest {
               Binding.builder()
                   .name("trigger-on-active")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".phase == \"active\""))
+                  .on(new ContextChangeTrigger(".working.phase == \"active\""))
                   .build())
           .goals(successGoal)
           .completion(GoalExpression.allOf(successGoal))
@@ -362,14 +362,14 @@ class BasicBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("milestone-cap")
-            .inputSchema("{ go: .go }")
+            .inputSchema("{ go: .working.go }")
             .outputSchema("{ go: .go, docsUploaded: .docsUploaded }")
             .build();
 
     private final Milestone docsReceived =
         Milestone.builder()
             .name("docs-received")
-            .completionCriteria(".docsUploaded == true")
+            .completionCriteria(".working.docsUploaded == true")
             .build();
 
     @Override
@@ -389,7 +389,7 @@ class BasicBlackboardTest {
               Binding.builder()
                   .name("on-go-true")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".go == true"))
+                  .on(new ContextChangeTrigger(".working.go == true"))
                   .build())
           .milestones(docsReceived)
           // No goals — case stays RUNNING for milestone assertions

--- a/blackboard/src/test/java/io/casehub/blackboard/it/ExitConditionBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/ExitConditionBlackboardTest.java
@@ -96,7 +96,7 @@ class ExitConditionBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("exit-writer")
-            .inputSchema("{ phase: .phase }")
+            .inputSchema("{ phase: .working.phase }")
             .outputSchema("{ phase: .phase }")
             .build();
 
@@ -117,7 +117,7 @@ class ExitConditionBlackboardTest {
               Binding.builder()
                   .name("trigger-on-active")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".phase == \"active\""))
+                  .on(new ContextChangeTrigger(".working.phase == \"active\""))
                   .build())
           .build();
     }

--- a/blackboard/src/test/java/io/casehub/blackboard/it/LambdaEntryConditionBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/LambdaEntryConditionBlackboardTest.java
@@ -111,7 +111,7 @@ class LambdaEntryConditionBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("lambda-cap")
-            .inputSchema("{ value: .value }")
+            .inputSchema("{ value: .working.value }")
             .outputSchema("{ done: .done }")
             .build();
 
@@ -132,7 +132,7 @@ class LambdaEntryConditionBlackboardTest {
               Binding.builder()
                   .name("trigger-on-value")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".value != null"))
+                  .on(new ContextChangeTrigger(".working.value != null"))
                   .build())
           .build();
     }

--- a/blackboard/src/test/java/io/casehub/blackboard/it/MixedWorkersBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/MixedWorkersBlackboardTest.java
@@ -133,14 +133,14 @@ class MixedWorkersBlackboardTest {
     private final Capability capA =
         Capability.builder()
             .name("cap-a")
-            .inputSchema("{ phaseA: .phaseA }")
+            .inputSchema("{ phaseA: .working.phaseA }")
             .outputSchema("{ phaseA: .phaseA }")
             .build();
 
     private final Capability capB =
         Capability.builder()
             .name("cap-b")
-            .inputSchema("{ phaseB: .phaseB }")
+            .inputSchema("{ phaseB: .working.phaseB }")
             .outputSchema("{ phaseB: .phaseB }")
             .build();
 
@@ -166,12 +166,12 @@ class MixedWorkersBlackboardTest {
               Binding.builder()
                   .name("trigger-a")
                   .capability(capA)
-                  .on(new ContextChangeTrigger(".phaseA == \"start\""))
+                  .on(new ContextChangeTrigger(".working.phaseA == \"start\""))
                   .build(),
               Binding.builder()
                   .name("trigger-b")
                   .capability(capB)
-                  .on(new ContextChangeTrigger(".phaseB == \"start\""))
+                  .on(new ContextChangeTrigger(".working.phaseB == \"start\""))
                   .build())
           .build();
     }

--- a/blackboard/src/test/java/io/casehub/blackboard/it/PlanConfigurerBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/PlanConfigurerBlackboardTest.java
@@ -197,7 +197,7 @@ class PlanConfigurerBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("configured-cap")
-            .inputSchema("{ probe: .probe }")
+            .inputSchema("{ probe: .working.probe }")
             .outputSchema("{ probe: .probe }")
             .build();
 
@@ -218,7 +218,7 @@ class PlanConfigurerBlackboardTest {
               Binding.builder()
                   .name("on-probe-tick")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".probe == \"tick\""))
+                  .on(new ContextChangeTrigger(".working.probe == \"tick\""))
                   .build())
           // No goals — case stays RUNNING for post-signal assertions
           .build();

--- a/blackboard/src/test/java/io/casehub/blackboard/it/SequentialStagesBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/SequentialStagesBlackboardTest.java
@@ -104,7 +104,7 @@ class SequentialStagesBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("phase-writer")
-            .inputSchema("{ phase: .phase }")
+            .inputSchema("{ phase: .working.phase }")
             .outputSchema("{ phase: .phase }")
             .build();
 
@@ -125,7 +125,7 @@ class SequentialStagesBlackboardTest {
               Binding.builder()
                   .name("trigger-on-start")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".phase == \"start\""))
+                  .on(new ContextChangeTrigger(".working.phase == \"start\""))
                   .build())
           .build();
     }

--- a/blackboard/src/test/java/io/casehub/blackboard/it/StageBlackboardTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/it/StageBlackboardTest.java
@@ -407,7 +407,7 @@ class StageBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("signal-cap")
-            .inputSchema("{ probe: .probe }")
+            .inputSchema("{ probe: .working.probe }")
             .outputSchema("{ probe: .probe }")
             .build();
 
@@ -428,7 +428,7 @@ class StageBlackboardTest {
               Binding.builder()
                   .name("on-probe-tick")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".probe == \"tick\""))
+                  .on(new ContextChangeTrigger(".working.probe == \"tick\""))
                   .build())
           // No goals — case stays RUNNING
           .build();
@@ -446,7 +446,7 @@ class StageBlackboardTest {
     private final Capability cap =
         Capability.builder()
             .name("once-signal-cap")
-            .inputSchema("{ go: .go }")
+            .inputSchema("{ go: .working.go }")
             .outputSchema("{ go: .go }")
             .build();
 
@@ -469,7 +469,7 @@ class StageBlackboardTest {
               Binding.builder()
                   .name("on-go-true")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".go == true"))
+                  .on(new ContextChangeTrigger(".working.go == true"))
                   .build())
           // No goals — case stays RUNNING
           .build();

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseIntegrationTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseIntegrationTest.java
@@ -81,7 +81,7 @@ class SubCaseIntegrationTest {
     private final Capability cap =
         Capability.builder()
             .name("child-work")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
@@ -122,7 +122,7 @@ class SubCaseIntegrationTest {
               Binding.builder()
                   .name("spawn-child")
                   .subCase(child)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build())
           .build();
     }

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseMofNIntegrationTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseMofNIntegrationTest.java
@@ -147,7 +147,7 @@ class SubCaseMofNIntegrationTest {
     private static final Capability CAP =
         Capability.builder()
             .name("mofn-child-cap")
-            .inputSchema("{ trigger: .trigger }")
+            .inputSchema("{ trigger: .working.trigger }")
             .outputSchema("{ trigger: .trigger }")
             .build();
 
@@ -191,17 +191,17 @@ class SubCaseMofNIntegrationTest {
               Binding.builder()
                   .name("spawn-a")
                   .subCase(child)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build(),
               Binding.builder()
                   .name("spawn-b")
                   .subCase(child)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build(),
               Binding.builder()
                   .name("spawn-c")
                   .subCase(child)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build())
           .build();
     }

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseParallelIntegrationTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseParallelIntegrationTest.java
@@ -149,7 +149,7 @@ class SubCaseParallelIntegrationTest {
     private static final Capability CAP =
         Capability.builder()
             .name("allof-child-cap")
-            .inputSchema("{ trigger: .trigger }")
+            .inputSchema("{ trigger: .working.trigger }")
             .outputSchema("{ trigger: .trigger }")
             .build();
 
@@ -193,17 +193,17 @@ class SubCaseParallelIntegrationTest {
               Binding.builder()
                   .name("spawn-site-a")
                   .subCase(child)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build(),
               Binding.builder()
                   .name("spawn-site-b")
                   .subCase(child)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build(),
               Binding.builder()
                   .name("spawn-site-c")
                   .subCase(child)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build())
           .build();
     }

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCasePropagationContextTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCasePropagationContextTest.java
@@ -90,7 +90,7 @@ class SubCasePropagationContextTest {
     private static final Capability CAP =
         Capability.builder()
             .name("prop-child-cap")
-            .inputSchema("{ trigger: .trigger }")
+            .inputSchema("{ trigger: .working.trigger }")
             .outputSchema("{ trigger: .trigger }")
             .build();
 
@@ -127,7 +127,7 @@ class SubCasePropagationContextTest {
               Binding.builder()
                   .name("spawn-prop-child")
                   .subCase(child)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build())
           .build();
     }

--- a/common/src/main/java/io/casehub/engine/common/internal/event/CaseContextChangedEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/CaseContextChangedEvent.java
@@ -15,16 +15,17 @@
  */
 package io.casehub.engine.common.internal.event;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.context.CaseContext;
 import io.casehub.engine.common.internal.model.CaseInstance;
 import java.util.Objects;
 
-public record CaseContextChangedEvent(CaseInstance instance, JsonNode contextSnapshot) {
+public record CaseContextChangedEvent(
+    CaseInstance instance, CaseContext contextSnapshot, String changedPanel) {
 
   public CaseContextChangedEvent {
     instance = Objects.requireNonNull(instance, "instance cannot be null");
-    contextSnapshot =
-        Objects.requireNonNull(contextSnapshot, "contextSnapshot cannot be null").deepCopy();
+    contextSnapshot = Objects.requireNonNull(contextSnapshot, "contextSnapshot cannot be null");
+    // changedPanel may be null (case started/resumed — evaluate all bindings)
   }
 
   @Override
@@ -33,11 +34,11 @@ public record CaseContextChangedEvent(CaseInstance instance, JsonNode contextSna
     if (o == null || getClass() != o.getClass()) return false;
     CaseContextChangedEvent that = (CaseContextChangedEvent) o;
     return Objects.equals(instance, that.instance)
-        && Objects.equals(contextSnapshot, that.contextSnapshot);
+        && Objects.equals(changedPanel, that.changedPanel);
   }
 
   @Override
   public String toString() {
-    return "CaseStateContextChangedEvent{" + "uuid=" + instance.getUuid() + '}';
+    return "CaseContextChangedEvent{uuid=" + instance.getUuid() + ", panel=" + changedPanel + '}';
   }
 }

--- a/common/src/main/java/io/casehub/engine/common/internal/event/EventBusAddresses.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/EventBusAddresses.java
@@ -83,6 +83,11 @@ public final class EventBusAddresses {
    */
   public static final String ACTION_GATE_CANCELLED = "casehub.action.gate.cancelled";
 
+  /** Returns an event bus address scoped to a specific panel name. */
+  public static String panelChanged(String panelName) {
+    return "casehub.context.changed." + panelName;
+  }
+
   /**
    * Published by ActionGateRejectedHandler and ActionGateExpiredHandler when a gate is resolved
    * negatively (rejected or expired). Consumed by the blackboard module to mark the associated

--- a/docs/specs/2026-06-09-casefile-panels-design.md
+++ b/docs/specs/2026-06-09-casefile-panels-design.md
@@ -1,0 +1,561 @@
+# CaseContext Panels Design
+
+**Issues:** engine#80 (memory stratification), engine#81 (hierarchical blackboard panels)  
+**Epic:** engine#445 (full Drools integration — typed blackboard memory)  
+**Date:** 2026-06-09  
+**Status:** Approved (rev 6)
+
+---
+
+## Overview
+
+`CaseContext` is currently a flat `Map<String, Object>`. Everything — worker output, engine signals, domain initialisation data, execution history — shares one unstructured namespace. This design introduces **panels**: named, policy-aware partitions of `CaseContext` that give structure to the blackboard.
+
+Issue #80 delivers three built-in panels with specific memory semantics (working, semantic, episodic). Issue #81 delivers user-defined panels with panel-scoped change events. Both are designed together because they share the same panel infrastructure; implementation is sequential (#80 first, #81 on top).
+
+---
+
+## Core Abstractions
+
+### ReadablePanel and WritablePanel
+
+Panels are NOT a subtype of `CaseContext`. They are a distinct hierarchy:
+
+```java
+// api/context/ReadablePanel.java
+public interface ReadablePanel {
+    String panelName();
+    boolean isReadOnly();
+
+    Object get(String key);
+    <T> T getAs(String key, Class<T> type);
+    <T> T getOrDefault(String key, T defaultValue);
+    boolean contains(String key);
+    Set<String> getKeys();
+    Map<String, Object> getData();
+    Map<String, Object> getAll(String... keys);
+    Object getPath(String path);
+    String getPathAsString(String path);
+    boolean isEmpty();
+    int size();
+    long getVersion();
+    JsonNode asJsonNode();
+    ReadablePanel snapshot();
+}
+
+// api/context/WritablePanel.java
+public interface WritablePanel extends ReadablePanel {
+    WritablePanel set(String key, Object value);
+    WritablePanel setAll(Map<String, Object> values);
+    WritablePanel setPath(String path, Object value);
+    WritablePanel remove(String key);
+    WritablePanel clear();           // clears this panel only
+    WritablePanel merge(ReadablePanel other);
+    Object computeIfAbsent(String key, Function<String, Object> mappingFunction);
+    Object putIfAbsent(String key, Object value);
+    boolean compareAndSet(String key, Object expected, Object newValue);
+    WritablePanel update(String key, Function<Object, Object> updateFunction);
+    Optional<JsonNode> applyAndDiff(String path, Object value);
+    void applyDiff(JsonNode diff);
+    JsonNode diff(ReadablePanel other);
+}
+```
+
+**Why separate hierarchies:** `ContextPanel extends CaseContext` with read-only panels throwing `UnsupportedOperationException` on write methods is an LSP violation. Any method receiving `CaseContext` can silently receive a read-only panel and blow up. A `PanelView` with `set()` has the same problem. The type-level split is the correct resolution: callers of `CaseContext.panel(name)` always receive `ReadablePanel`, which guarantees no surprise on any method they call.
+
+User-defined panels implement `WritablePanel`. No additional interface — the engine imposes no ordering semantics on panels. Panel evaluation ordering is the Drools integration's concern, expressed through its own configuration when designed.
+
+### `CaseContext` interface change
+
+One new method:
+
+```java
+ReadablePanel panel(String name);
+```
+
+All existing flat methods (`get`, `set`, `asJsonNode`, etc.) are retained as working-panel convenience delegates. `panel(WORKING)` casts to `WritablePanel` internally — the flat API is the primary path for worker writes.
+
+**`asJsonNode()` changes semantics**: returns the full panel document rather than just working data:
+
+```json
+{
+  "working":  { "result": "done", "score": 42 },
+  "semantic": { "domain": "fraud-check", "customerId": "C-123" },
+  "episodic": {
+    "workers": [{"name": "extractor", "runs": 2, "lastOutcome": "COMPLETED"}],
+    "milestones": ["data-ready"],
+    "goals": [],
+    "memory": [...]
+  },
+  "inferences": { "featureScore": 0.87 }
+}
+```
+
+This is the breaking change that restructures JQ expression syntax (see Migration).
+
+**`getVersion()` on root context**: delegates to the working panel's version counter. Each panel maintains its own version independently. Engine writes to the episodic panel do not increment the working panel version and do not interfere with idempotency detection in `applyAndDiff`.
+
+**Multi-panel operation semantics** (explicit decisions for methods that previously operated on the whole flat map):
+
+| Method | Panel-aware behaviour |
+|---|---|
+| `get(key)`, `set(key, v)` etc. | Delegate to working panel — unchanged for callers |
+| `asJsonNode()` | Returns full panel document `{"working":{...},"semantic":{...},...}` |
+| `getVersion()` | Returns working panel version |
+| `snapshot()` | Snapshots ALL panels; result is a full panel document snapshot |
+| `applyAndDiff(path, value)` | Operates on working panel only; patch is working-panel-relative (format unchanged: `/result`, not `/working/result`); this preserves EventLog patch replay correctness |
+| `applyDiff(patch)` | Applies working-panel-relative patches to working panel only; does not touch semantic or episodic |
+| `diff(other)` | Diffs working panels only |
+| `merge(other)` | Merges `other`'s working panel data into this working panel |
+| `clear()` | Clears working panel only; never touches semantic or episodic |
+
+**`MapCaseFile` (migration shim)**: Its `snapshot()` currently does `new MapCaseFile(base.getData())` which drops non-working panels via `getData()` delegation. Must be updated to propagate all panels to the returned snapshot. The rest of `MapCaseFile` is unaffected — it uses the flat API which correctly delegates to working.
+
+### `CaseContextImpl` internal restructure
+
+```java
+// Before
+private final Map<String, Object> data = new LinkedHashMap<>();
+
+// After — internal panels map; each entry is a panel implementation
+private final Map<String, WritablePanelImpl> panels = new ConcurrentHashMap<>();
+// flat API delegates to panels.get(ContextPanel.WORKING)
+```
+
+Each `WritablePanelImpl` holds its own `Map<String, Object> data` + `ReadWriteLock` + `version` counter. Read-only panels (semantic, episodic) are wrapped in `ReadOnlyPanelView` which implements `ReadablePanel` and delegates reads, throwing `UnsupportedOperationException` only if a caller somehow obtains a direct reference — which the type system now prevents for external callers.
+
+New static factory for panel-aware reconstruction:
+
+```java
+public static CaseContextImpl fromPanelDocument(JsonNode panelDoc) { ... }
+```
+
+Used exclusively by recovery (see below).
+
+### Panel name constants
+
+```java
+// api/context/ContextPanel.java  (replaces the ContextPanel extends CaseContext concept)
+public final class ContextPanel {
+    public static final String WORKING  = "working";
+    public static final String SEMANTIC = "semantic";
+    public static final String EPISODIC = "episodic";
+    private ContextPanel() {}
+}
+```
+
+---
+
+## Built-in Panels (#80)
+
+### Working panel (`"working"`)
+
+Read-write. The default panel. All existing flat API calls (`context.set("key", value)`, `context.get("key")`) operate here without change. Workers write their output here. The engine writes its signals here (`actionGateRejected`, `workItemEscalated`, `actionGateApproved`, `actionGateExpired`). Milestone tracking data written by `DefaultWorkerExecutionRecoveryService` (`milestones.{name}.lifecycleStatus` etc.) lives here.
+
+### Semantic panel (`"semantic"`)
+
+Read-only. Populated once at case start from two sources merged in order:
+1. Case definition `semanticData` block (static defaults for this case type)
+2. Call-site `semanticData` parameter on `CaseHubRuntime.startCase()` (instance-specific; overrides definition defaults on conflict)
+
+Marked read-only after initialisation — any attempt to write is prevented by the `ReadablePanel` type returned by `panel(SEMANTIC)`. Workers read it as `.semantic.key` in JQ expressions.
+
+**New YAML field:**
+```yaml
+semanticData:
+  threshold: 0.8
+  domain: "fraud-check"
+```
+
+**New DSL builder method:**
+```java
+CaseDefinition.builder()
+    .semanticData(Map.of("threshold", 0.8, "domain", "fraud-check"))
+```
+
+### Episodic panel (`"episodic"`)
+
+`ReadablePanel` to external callers. Written by the engine only via engine-internal `WritablePanel` access. Two sub-sections:
+
+**Intra-case** (always present): structured summary from `EventLog`.
+- At case start: rebuilt from existing `EventLog` entries (handles recovered cases) via `CaseContextImpl.fromPanelDocument()`
+- Updated by engine after: worker completes (`WORKER_EXECUTION_FINISHED`), milestone reached, goal reached
+- Updates fire `casehub.context.changed.episodic` only — not the full `CONTEXT_CHANGED`
+- Structure:
+```json
+{
+  "workers": [
+    {"name": "extractor", "runs": 2, "lastOutcome": "COMPLETED", "lastTimestamp": "..."}
+  ],
+  "milestones": ["data-ready"],
+  "goals": []
+}
+```
+
+**Inter-case** (optional): snapshot from `ReactiveCaseMemoryStore` at case start.
+- Present only if: case definition declares `episodic.memory` AND `ReactiveCaseMemoryStore` is non-NoOp
+- `ReactiveCaseMemoryStore.query(MemoryQuery): Uni<List<Memory>>` chains directly into the reactive `startCase()` flow — no blocking wrapper needed
+- `NoOpCaseMemoryStore @DefaultBean` (bridged via `BlockingToReactiveBridge`) means zero cost when unconfigured
+- `tenantId` for the query is supplied by the engine from `CurrentPrincipal.tenancyId()` — not declared in the case definition
+- Populated once at case start; not updated during the case run
+
+**New YAML field:**
+```yaml
+episodic:
+  memory:
+    domain: "fraud-check"            # String; becomes new MemoryDomain("fraud-check")
+    entityId: ".semantic.customerId" # JQ expr against semantic panel; string → List.of(), array → direct
+    recent: 10                       # default: 10; maps to MemoryQuery.withLimit(n)
+```
+
+`entityId` is a JQ expression evaluated against the semantic panel (populated first). A string result is wrapped in `List.of(value)` for `MemoryQuery.entityIds`. An array result passes through directly (max 25 per `MemoryQuery` contract). The engine projects `{text, attributes}` from each `Memory` record into the panel — `memoryId`, `entityId`, `domain`, `tenantId`, `caseId`, `createdAt` are operational metadata excluded from the projection:
+
+```json
+"memory": [
+  {
+    "text": "Customer C-123 had two prior fraud investigations in 2025",
+    "attributes": {"outcome": "HIGH_RISK", "confidence": "0.9200"}
+  },
+  {
+    "text": "Score threshold breached Q4 2025",
+    "attributes": {"actor-id": "analyst-1", "valid-from": "2025-10-01"}
+  }
+]
+```
+
+`attributes` keys follow `MemoryAttributeKeys` conventions (`outcome`, `confidence`, `actor-id`, `actor-role`, `valid-from`, `valid-until`) but are not constrained to them.
+
+JQ access patterns for workers:
+```
+.episodic.memory[].text
+.episodic.memory[].attributes.outcome
+.episodic.memory[] | select(.attributes.outcome == "HIGH_RISK")
+.episodic.memory | map(select(.attributes.confidence != null))
+```
+
+**`MemoryQuery` construction** — uses existing factory methods from `io.casehub.platform.api.memory.MemoryQuery`. The query is cross-case by design: it retrieves memories for the entity across ALL prior cases. No `withCaseId()` — adding the current case's UUID would return empty results since the case just started and has no stored memories yet.
+
+```java
+// Single entity (JQ result is a string)
+MemoryQuery query = MemoryQuery
+    .forEntity(entityId, new MemoryDomain(domain), currentPrincipal.tenancyId())
+    .withLimit(recent);
+
+// Multiple entities (JQ result is an array)
+MemoryQuery query = MemoryQuery
+    .forEntities(entityIds, new MemoryDomain(domain), currentPrincipal.tenancyId())
+    .withLimit(recent);
+```
+
+`MemoryOrder.CHRONOLOGICAL` is the factory default. `question` (semantic search) and `since` (time filter) are not exposed in YAML for this initial integration.
+
+**Recovery:** the `memory` array is persisted in the CASE_STARTED EventLog payload as part of the full panel document. `fromPanelDocument()` reconstructs it from the stored snapshot. `ReactiveCaseMemoryStore` is NOT re-queried on recovery — the stored snapshot is authoritative.
+
+---
+
+## Population Lifecycle
+
+**Order at case start (sequential):**
+
+1. Working panel created (empty, or with `inputData` from call site converted via initial `inputSchema` if declared)
+2. Semantic panel: definition `semanticData` merged, then call-site `semanticData` merged over top. `ReadablePanel` view exposed externally.
+3. Episodic panel — inter-case: if `episodic.memory` declared AND `ReactiveCaseMemoryStore` non-NoOp, evaluate `entityId` JQ against semantic panel, call `ReactiveCaseMemoryStore.query()` as a `Uni` step in the reactive chain, inject `memory` section. `ReadablePanel` view exposed.
+4. Episodic panel — intra-case: rebuild from `EventLog` if recovered case via `fromPanelDocument()`; empty for new cases.
+5. `CaseStartedEventHandler` stores `instance.getCaseContext().asJsonNode()` (full panel document) as CASE_STARTED payload.
+6. First `CONTEXT_CHANGED` fires.
+
+### `CaseHubRuntime.startCase()` — new overloads
+
+```java
+// Existing — unchanged
+CompletionStage<UUID> startCase(CaseDefinition definition);
+CompletionStage<UUID> startCase(CaseDefinition definition, Object inputData);
+CompletionStage<UUID> startCase(CaseDefinition definition, Object inputData,
+    UUID parentCaseId, PropagationContext propagationContext);
+
+// New — with semantic augmentation
+CompletionStage<UUID> startCase(CaseDefinition definition, Object inputData,
+    Map<String, Object> semanticData);
+CompletionStage<UUID> startCase(CaseDefinition definition, Object inputData,
+    Map<String, Object> semanticData,
+    UUID parentCaseId, PropagationContext propagationContext);
+```
+
+`semanticData` is `Map<String, Object>`, nullable — null is treated as empty (no call-site augmentation).
+
+**Sub-case semantic isolation:** child cases started via `SubCase` bindings use only their own case definition's `semanticData` defaults. If a parent needs to pass semantic context to a child, it does so via `SubCase.inputMapping` (JQ expression targeting the child's `inputData`), and the child's definition maps that `inputData` into its own `semanticData` via a YAML `semanticData` block referencing `inputData`. Semantic panels are not automatically inherited across sub-case boundaries.
+
+### Recovery — panel-aware reconstruction
+
+`DefaultWorkerExecutionRecoveryService.rebuildStateContext()` currently does:
+
+```java
+caseContext = new CaseContextImpl(payloadAsMap(caseStartedEvent.getPayload()));
+```
+
+After the change, the CASE_STARTED payload is a panel document. This line becomes:
+
+```java
+caseContext = CaseContextImpl.fromPanelDocument(caseStartedEvent.getPayload());
+```
+
+`fromPanelDocument()` reads `{"working":{...},"semantic":{...},"episodic":{...}}` and reconstructs each panel. The semantic panel is reconstructed as read-only. The episodic panel is reconstructed as read-only. Subsequent event replays (signals, worker output, milestones) use the flat API which targets the working panel — no changes needed in those paths.
+
+Signal patches (`SIGNAL_RECEIVED` events) stored in EventLog contain working-panel-relative JSON Patches (`/result`, not `/working/result`). `applyDiff()` during recovery applies these to the working panel. Old patches remain valid — format is not changed.
+
+### Episodic panel updates during execution
+
+Engine writes to the episodic panel after:
+- `WORKER_EXECUTION_FINISHED` — updates the worker's entry in `episodic.workers`
+- `MILESTONE_REACHED` — appends to `episodic.milestones`
+- `GOAL_REACHED` — appends to `episodic.goals`
+
+These publish `casehub.context.changed.episodic` only — not `CONTEXT_CHANGED`. No binding re-evaluation on episodic updates.
+
+---
+
+## User-Defined Panels (#81)
+
+### Panel declaration in `CaseDefinition`
+
+**YAML:**
+```yaml
+panels:
+  - name: "raw"
+  - name: "extracted"
+  - name: "inferences"
+  - name: "conclusions"
+```
+
+**DSL builder:**
+```java
+CaseDefinition.builder()
+    .panel("raw")
+    .panel("extracted")
+    .panel("inferences")
+    .panel("conclusions")
+```
+
+All user-defined panels are read-write by default. No `abstractionLevel` — the engine provides named panels as named key-value stores and imposes no ordering semantics.
+
+### Panel-scoped change events
+
+```java
+public final class EventBusAddresses {
+    public static final String CONTEXT_CHANGED = "casehub.context.changed";
+
+    public static String panelChanged(String panelName) {
+        return "casehub.context.changed." + panelName;
+    }
+}
+```
+
+Firing rules by panel type:
+
+| Panel | Fires `CONTEXT_CHANGED` | Fires `casehub.context.changed.{name}` |
+|---|---|---|
+| Working | Yes | Yes (`casehub.context.changed.working`) |
+| User-defined | Yes | Yes (`casehub.context.changed.{name}`) |
+| Semantic | No | Yes, on initialisation only |
+| Episodic | No | Yes, on intra-case updates only |
+
+Working and user-defined panels fire both addresses. Bindings without `listenPanel` subscribe to `CONTEXT_CHANGED` and re-evaluate on any of these. Bindings with `listenPanel` use single-handler filtering (see below).
+
+### `CaseContextChangedEvent` record change
+
+```java
+// Before
+public record CaseContextChangedEvent(CaseInstance instance, JsonNode contextSnapshot)
+
+// After
+public record CaseContextChangedEvent(CaseInstance instance, CaseContext contextSnapshot, String changedPanel)
+```
+
+`contextSnapshot` type changes from `JsonNode` to `CaseContext`. Each construction site passes `instance.getCaseContext().snapshot()` — a deep copy of all panels at that instant. This eliminates the existing asymmetry in `CaseContextChangedEventHandler` where `rules()` uses the snapshot but `milestones()` and `goals()` use the live context directly. With `CaseContext`, the handler passes the snapshot to all three: `expressionEngineRegistry.evaluate(filter, contextSnapshot)` works for both JQ (registry calls `contextSnapshot.asJsonNode()` internally) and Lambda (`Predicate<CaseContext>`) evaluators.
+
+`changedPanel` is `ContextPanel.WORKING` for all current engine events. Panel-scoped addresses (`casehub.context.changed.episodic`) are published directly without going through `CaseContextChangedEvent`.
+
+**All construction sites that break (14 sites — all pass `instance.getCaseContext().snapshot()` as contextSnapshot and `ContextPanel.WORKING` as changedPanel):**
+
+| Class | Line | New argument |
+|---|---|---|
+| `CaseStartedEventHandler` | 80 | `ContextPanel.WORKING` |
+| `SignalReceivedEventHandler` | 119 | `ContextPanel.WORKING` |
+| `CaseStatusChangedHandler` | ~118 | `ContextPanel.WORKING` |
+| `MilestoneActivatedEventHandler` | 141 | `ContextPanel.WORKING` |
+| `MilestoneCompletedEventHandler` | 127 | `ContextPanel.WORKING` |
+| `MilestoneSLAViolatedEventHandler` | 111 | `ContextPanel.WORKING` |
+| `WorkflowExecutionCompletedHandler` | 174 | `ContextPanel.WORKING` |
+| `ActionGateRejectedHandler` | 120 | `ContextPanel.WORKING` |
+| `ActionGateExpiredHandler` | 105 | `ContextPanel.WORKING` |
+| `WorkItemLifecycleAdapter` | 140 | `ContextPanel.WORKING` |
+| `WorkItemLifecycleAdapter` | 216 | `ContextPanel.WORKING` |
+| `PlanItemCompletionApplier` | 99 | `ContextPanel.WORKING` |
+| `CaseContextChangedEventHandlerRoutingTest` | 159, 177, 195, 228 | `ContextPanel.WORKING` |
+| `MilestoneLifecycleTest` | 243 | `ContextPanel.WORKING` |
+
+### Binding panel subscription — single handler with field filtering
+
+`CaseContextChangedEventHandler` keeps a single `@ConsumeEvent(CONTEXT_CHANGED)` handler. `@ConsumeEvent` is a compile-time annotation — dynamic per-panel subscriptions via annotation are impossible.
+
+Instead, the handler reads `event.changedPanel()` and skips bindings whose `listenPanel()` doesn't match:
+
+```java
+for (Binding binding : bindings) {
+    if (binding.getOn() instanceof ContextChangeTrigger cct) {
+        String listenPanel = cct.getListenPanel();
+        if (listenPanel != null && !listenPanel.equals(event.changedPanel())) {
+            continue;   // binding targets a different panel
+        }
+        // evaluate filter expression...
+    }
+}
+```
+
+Panel-scoped addresses (`casehub.context.changed.{name}`) are still published for external consumers (Claudony, monitoring, future Drools rule-firing triggers) but the binding handler does not subscribe to them.
+
+**Design risk:** The panel event model is designed for JQ binding subscription. Issue #446 (Drools/WorkingMemoryBridge) will need to consume panel events for typed fact insertion. Before #446 is implemented, validate that `casehub.context.changed.{name}` addresses serve as adequate Drools re-fire triggers. Tracked as engine#465.
+
+### `ContextChangeTrigger.listenPanel`
+
+```java
+public class ContextChangeTrigger implements Trigger {
+    private final ExpressionEvaluator filter;
+    private final String listenPanel;   // null = all panels (current behaviour)
+}
+```
+
+**YAML:**
+```yaml
+bindings:
+  - name: "run-inference"
+    on:
+      contextChange:
+        filter: ".extracted.featureScore > 0.5"
+        listenPanel: "extracted"
+```
+
+Bindings without `listenPanel` are unchanged — no migration, no behaviour change.
+
+---
+
+## JQ Expression Changes
+
+`asJsonNode()` now returns the full panel document. All callers automatically receive panel-structured JSON — no individual call site changes needed.
+
+**All JQ string expressions that reference working panel keys must be updated:**
+
+```
+# Before
+.result == null and .actionGateRejected == null
+
+# After
+.working.result == null and .working.actionGateRejected == null
+```
+
+**Lambda expressions (`Predicate<CaseContext>`) are not affected.** `context.get("key")` still delegates to working panel.
+
+**Parse-time warning:** `CaseDefinitionYamlMapper` warns (not errors) when a JQ string expression starts with `.` but not with a known panel prefix. Allows staged migration.
+
+### Affected expression locations
+
+| Location | Change |
+|---|---|
+| `ContextChangeTrigger` filter | `.key` → `.working.key` |
+| `Binding.when()` guard | `.key` → `.working.key` |
+| `Worker.inputSchema` | `.key` → `.working.key` |
+| `HumanTaskTarget.inputMapping` | `.key` → `.working.key` |
+| `HumanTaskTarget.outputMapping` | `.key` → `.working.key` |
+| `SubCase.inputMapping` | `.key` → `.working.key` |
+| `Goal` condition (JQ string) | `.key` → `.working.key` |
+| `Milestone` completionCriteria (JQ string) | `.key` → `.working.key` |
+| Milestone state in JQ (e.g. milestone tracking) | `.milestones.{name}.lifecycleStatus` → `.working.milestones.{name}.lifecycleStatus` |
+| Lambda `Predicate<CaseContext>` | No change |
+| `episodic.memory.entityId` | `.semantic.key` (new, no migration) |
+
+---
+
+## Schema Changes Summary
+
+| Field | Location | Required | Default |
+|---|---|---|---|
+| `semanticData` | Case definition top-level | No | — |
+| `episodic.memory.domain` | Case definition top-level | Yes (if `memory` block present) | — |
+| `episodic.memory.entityId` | Case definition top-level | Yes (if `memory` block present; JQ expr against semantic panel) | — |
+| `episodic.memory.recent` | Case definition top-level | No | 10 |
+| `panels[].name` | Case definition top-level | Yes (if block present) | — |
+| `binding.on.contextChange.listenPanel` | Per binding | No | null (all panels) |
+
+All new fields optional. Existing case definitions load unchanged.
+
+---
+
+## Platform Coherence
+
+- **Memory SPI — all types exist, no new dependencies:**
+
+| Type | Package | Jar |
+|---|---|---|
+| `CaseMemoryStore` (blocking SPI) | `io.casehub.platform.api.memory` | `casehub-platform-api` |
+| `GraphCaseMemoryStore extends CaseMemoryStore` | `io.casehub.platform.api.memory` | `casehub-platform-api` |
+| `Memory`, `MemoryQuery`, `MemoryDomain`, `MemoryOrder`, `MemoryAttributeKeys` | `io.casehub.platform.api.memory` | `casehub-platform-api` |
+| `ReactiveCaseMemoryStore` | `io.casehub.platform.memory` | `casehub-platform` |
+| `BlockingToReactiveBridge @DefaultBean` | `io.casehub.platform.memory` | `casehub-platform` |
+| `NoOpCaseMemoryStore @DefaultBean` (implements `GraphCaseMemoryStore`) | `io.casehub.platform.memory` | `casehub-platform` |
+
+  `casehub-platform` is already in the engine's transitive dependency tree (confirmed). CDI no-op chain: `ReactiveCaseMemoryStore` injection → `BlockingToReactiveBridge` → injects `CaseMemoryStore` → resolves to `NoOpCaseMemoryStore` → `query()` returns `List.of()` → `memory` key absent from episodic panel. No engine-side no-op needed.
+- **No Flyway changes** — `CaseContext` is not persisted. `CaseInstanceEntity` unchanged.
+- **EventLog payload format** — CASE_STARTED payload is now a panel document. Signal patch format unchanged (working-panel-relative `/key` paths). All patches replayed against working panel during recovery.
+
+---
+
+## Testing Plan
+
+| Test class | What it covers |
+|---|---|
+| `CaseContextImplTest` (extend) | Panel creation, flat API delegates to working, `asJsonNode()` panel document shape, `getVersion()` = working panel version |
+| `ReadablePanelTest` (new) | Read-only enforcement: no write methods compile or succeed on `ReadablePanel` type |
+| `WritablePanelTest` (new) | Write methods, version tracking, `clear()` scoped to this panel only |
+| `PanelDocumentSnapshotTest` (new) | `snapshot()` on root captures all panels; `MapCaseFile.snapshot()` propagates panels |
+| `ApplyAndDiffPanelTest` (new) | `applyAndDiff()` targets working panel; patch is working-panel-relative; `applyDiff()` replays correctly |
+| `SemanticPanelPopulationTest` (new) | Definition defaults merged with call-site override; read-only after init; order precedence |
+| `EpisodicPanelIntraCaseTest` (new) | Engine updates after worker completion, milestone, goal; EventLog rebuild on recovery |
+| `EpisodicPanelInterCaseTest` (new) | `@QuarkusTest` with `ReactiveCaseMemoryStore @Alternative @Priority(1)` recording mock; query uses `entityId` JQ against semantic panel; `tenantId` = `CurrentPrincipal.tenancyId()`; no `caseId` in query (cross-case by design); string JQ result → `List.of(entityId)`; array JQ result → multi-entity query; `{text, attributes}` projected into panel — no `memoryId`/`tenantId`/`caseId` in panel; `memory` key absent when store returns `List.of()`; memory restored from CASE_STARTED EventLog on recovery — `ReactiveCaseMemoryStore` not called again |
+| `RecoveryPanelAwareTest` (new) | `fromPanelDocument()` reconstructs all panels; recovery replays signal patches to working panel |
+| `PanelScopedEventTest` (new) | `changedPanel` field correct; bindings with `listenPanel` skip non-matching events |
+| `JQExpressionPanelTest` (new) | `.working.key`, `.semantic.key`, `.episodic.workers`, `.working.milestones.{name}.lifecycleStatus` in filter expressions |
+| `CaseDefinitionYamlMapperTest` (extend) | New YAML fields parse; unmigrated expressions produce warning; existing definitions load unchanged |
+| `CaseContextChangedEventTest` (extend) | Three-arg record constructor; `contextSnapshot` is `CaseContext` (not `JsonNode`); `changedPanel` field on all 14 construction sites; snapshot consistency — milestones/goals use snapshot not live context |
+
+---
+
+## Implementation Sequence
+
+**#80 (this branch, first):**
+1. `ReadablePanel` + `WritablePanel` + `UserDefinedPanel` interfaces
+2. `WritablePanelImpl` + `ReadOnlyPanelView` implementations
+3. `CaseContextImpl` internal panel map restructure; `fromPanelDocument()` factory; flat API delegates to working
+4. `asJsonNode()` panel document; `getVersion()` → working panel; `snapshot()` all panels; `applyAndDiff()` working-panel-relative; `clear()` working only; `merge()` working only; `MapCaseFile.snapshot()` fix
+5. `ContextPanel` constants class
+6. `CaseContextChangedEvent` — change `contextSnapshot` from `JsonNode` to `CaseContext`, add `String changedPanel`; update all 14 construction sites to pass `instance.getCaseContext().snapshot()` as contextSnapshot; update `CaseContextChangedEventHandler.rules()/milestones()/goals()` signatures from `JsonNode` to `CaseContext`; use snapshot consistently in all three (eliminates live-context asymmetry in milestones/goals)
+7. `EventBusAddresses.panelChanged()`; panel-scoped event firing in `CaseContextChangedEventHandler` and episodic update paths
+8. Semantic panel: YAML `semanticData` field; DSL builder; `CaseHubRuntime.startCase()` new overloads; population at case start
+9. Episodic panel intra-case: EventLog rebuild + lifecycle updates
+10. Episodic panel inter-case: `episodic.memory` YAML field; `entityId` JQ evaluation + coercion to `List<String>`; `MemoryQuery` via `forEntity()`/`forEntities()` factory methods (no `withCaseId()`); `ReactiveCaseMemoryStore.query()` chained as `Uni` in `buildInstance()`; `{text, attributes}` projection into `episodic.memory[]`
+11. `DefaultWorkerExecutionRecoveryService` — `fromPanelDocument()` for CASE_STARTED reconstruction
+12. JQ expression migration across all engine tests and case definitions
+13. `CaseDefinitionYamlMapper` parse-time warning for unmigrated expressions
+
+**#81 (follow-on, same branch):**
+1. User-defined panel declaration: YAML + DSL builder (no abstractionLevel; user panels are plain `WritablePanel` instances)
+2. `ContextChangeTrigger.listenPanel`: YAML + DSL builder
+3. `CaseContextChangedEventHandler` `listenPanel` field-based filtering
+4. Panel-scoped event address publishing for user-defined panels
+5. Panel-scoped event tests
+
+---
+
+## Open Issues
+
+- engine#464 — revisit "panel" terminology after implementation (candidates: layer, region)
+- engine#465 — validate panel event model (`casehub.context.changed.{name}`) serves Drools re-fire triggers before #446 implementation

--- a/resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueEndToEndTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterQueueEndToEndTest.java
@@ -170,12 +170,16 @@ class DeadLetterQueueEndToEndTest {
     private final Capability capability =
         Capability.builder()
             .name("doWork")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("done")
+            .condition(".working.status == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -199,7 +203,7 @@ class DeadLetterQueueEndToEndTest {
               Binding.builder()
                   .name("trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .on(new ContextChangeTrigger(".working.status == \"start\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))
@@ -213,14 +217,14 @@ class DeadLetterQueueEndToEndTest {
     private final Capability capability =
         Capability.builder()
             .name("fastFail")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
     private final Goal goal =
         Goal.builder()
             .name("fastDone")
-            .condition(".status == \"done\"")
+            .condition(".working.status == \"done\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -246,7 +250,7 @@ class DeadLetterQueueEndToEndTest {
               Binding.builder()
                   .name("fast-trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .on(new ContextChangeTrigger(".working.status == \"start\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/resilience/src/test/java/io/casehub/resilience/it/ResilienceIntegrationTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/it/ResilienceIntegrationTest.java
@@ -216,14 +216,14 @@ class ResilienceIntegrationTest {
     private final Capability capability =
         Capability.builder()
             .name("combinedFail")
-            .inputSchema("{ trigger: .trigger }")
+            .inputSchema("{ trigger: .working.trigger }")
             .outputSchema("{ trigger: .trigger }")
             .build();
 
     private final Goal goal =
         Goal.builder()
             .name("done")
-            .condition(".trigger == \"done\"")
+            .condition(".working.trigger == \"done\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -249,7 +249,7 @@ class ResilienceIntegrationTest {
               Binding.builder()
                   .name("combined-trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/poison/PoisonPillIntegrationTest.java
@@ -157,14 +157,14 @@ class PoisonPillIntegrationTest {
     private final Capability capability =
         Capability.builder()
             .name("checkedWork")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
     private final Goal goal =
         Goal.builder()
             .name("done")
-            .condition(".status == \"complete\"")
+            .condition(".working.status == \"complete\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -190,7 +190,7 @@ class PoisonPillIntegrationTest {
               Binding.builder()
                   .name("trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"run\""))
+                  .on(new ContextChangeTrigger(".working.status == \"run\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerIntegrationTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/timeout/CaseTimeoutEnforcerIntegrationTest.java
@@ -138,14 +138,14 @@ class CaseTimeoutEnforcerIntegrationTest {
     private final Capability capability =
         Capability.builder()
             .name("hang")
-            .inputSchema("{ trigger: .trigger }")
+            .inputSchema("{ trigger: .working.trigger }")
             .outputSchema("{ trigger: .trigger }")
             .build();
 
     private final Goal goal =
         Goal.builder()
             .name("done")
-            .condition(".trigger == \"done\"")
+            .condition(".working.trigger == \"done\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -178,7 +178,7 @@ class CaseTimeoutEnforcerIntegrationTest {
               Binding.builder()
                   .name("hang-trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -40,6 +40,14 @@
             <groupId>io.casehub</groupId>
             <artifactId>casehub-eidos-api</artifactId>
         </dependency>
+        <dependency>
+            <!-- Provides ReactiveCaseMemoryStore (and NoOpCaseMemoryStore @DefaultBean).
+                 BOM pins this as test scope; override here for production injection.
+                 casehub-platform-api (compile) provides Memory/MemoryQuery value types. -->
+            <groupId>io.casehub</groupId>
+            <artifactId>casehub-platform</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/runtime/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
@@ -21,608 +21,311 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.casehub.api.context.CaseContext;
-import io.fabric8.zjsonpatch.JsonDiff;
-import io.fabric8.zjsonpatch.JsonPatch;
-import java.util.ArrayList;
-import java.util.HashSet;
+import io.casehub.api.context.ContextPanel;
+import io.casehub.api.context.ReadablePanel;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 
 @JsonDeserialize(as = CaseContextImpl.class)
 public class CaseContextImpl implements CaseContext {
 
-  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private final Map<String, Object> data = new LinkedHashMap<>();
-  private final ReadWriteLock lock = new ReentrantReadWriteLock();
-  private long version = 0L;
+  private final Map<String, WritablePanelImpl> panels = new LinkedHashMap<>();
 
-  public CaseContextImpl() {}
+  // ── Constructors ────────────────────────────────────────────────────────────
 
-  public CaseContextImpl(Map<String, Object> initial) {
-    if (initial != null) {
-      data.putAll(initial);
-    }
+  public CaseContextImpl() {
+    initBuiltinPanels();
   }
 
-  public CaseContextImpl(Map<String, Object> initial, long version) {
-    if (initial != null) {
-      data.putAll(initial);
-    }
-    this.version = version;
+  public CaseContextImpl(Map<String, Object> initial) {
+    // Use WritablePanelImpl(name, data) constructor which pre-populates without incrementing
+    // version,
+    // preserving the original contract that the map constructor does not increment version.
+    panels.put(
+        ContextPanel.WORKING,
+        new WritablePanelImpl(ContextPanel.WORKING, initial != null ? initial : Map.of()));
+    panels.put(ContextPanel.SEMANTIC, new WritablePanelImpl(ContextPanel.SEMANTIC));
+    panels.put(ContextPanel.EPISODIC, new WritablePanelImpl(ContextPanel.EPISODIC));
+  }
+
+  public CaseContextImpl(Map<String, Object> initial, long ignoredVersion) {
+    // version is per-panel now; the top-level version param is ignored (legacy)
+    this(initial);
   }
 
   public CaseContextImpl(JsonNode asNode) {
-    this(mapper.convertValue(asNode == null ? mapper.createObjectNode() : asNode, Map.class));
+    this(asNode == null ? null : MAPPER.convertValue(asNode, Map.class));
   }
 
-  @JsonAnyGetter
-  @Override
-  public Map<String, Object> getData() {
-    lock.readLock().lock();
-    try {
-      return new LinkedHashMap<>(data);
-    } finally {
-      lock.readLock().unlock();
-    }
+  private void initBuiltinPanels() {
+    panels.put(ContextPanel.WORKING, new WritablePanelImpl(ContextPanel.WORKING));
+    panels.put(ContextPanel.SEMANTIC, new WritablePanelImpl(ContextPanel.SEMANTIC));
+    panels.put(ContextPanel.EPISODIC, new WritablePanelImpl(ContextPanel.EPISODIC));
   }
+
+  private WritablePanelImpl working() {
+    return panels.get(ContextPanel.WORKING);
+  }
+
+  // ── Panel access ────────────────────────────────────────────────────────────
+
+  @Override
+  public ReadablePanel panel(String name) {
+    return panels.computeIfAbsent(name, WritablePanelImpl::new);
+  }
+
+  /** Engine-internal: returns writable view (engine writes to semantic/episodic this way). */
+  public WritablePanelImpl writablePanel(String name) {
+    return panels.computeIfAbsent(name, WritablePanelImpl::new);
+  }
+
+  /** Freezes a panel (makes it read-only). */
+  public void freezePanel(String name) {
+    WritablePanelImpl p = panels.get(name);
+    if (p != null) p.freeze();
+  }
+
+  // ── Flat API — delegates to working panel ──────────────────────────────────
 
   @JsonAnySetter
   @Override
   public CaseContext set(String key, Object value) {
-    lock.writeLock().lock();
-    try {
-      Object prev = data.get(key);
-      if (!Objects.equals(prev, value)) {
-        data.put(key, value);
-        version++;
-      }
-      return this;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    working().set(key, value);
+    return this;
   }
 
   @Override
   public Object get(String key) {
-    lock.readLock().lock();
-    try {
-      return data.get(key);
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().get(key);
   }
 
   @Override
   public <T> T getAs(String key, Class<T> type) {
-    lock.readLock().lock();
-    try {
-      Object value = data.get(key);
-      if (value == null) {
-        return null;
-      }
-      if (type.isInstance(value)) {
-        return type.cast(value);
-      }
-      return mapper.convertValue(value, type);
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().getAs(key, type);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public <T> T getOrDefault(String key, T defaultValue) {
-    lock.readLock().lock();
-    try {
-      Object value = data.get(key);
-      return value != null ? (T) value : defaultValue;
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().getOrDefault(key, defaultValue);
   }
 
   @Override
   public Object computeIfAbsent(String key, Function<String, Object> mappingFunction) {
-    lock.writeLock().lock();
-    try {
-      Object value = data.get(key);
-      if (value == null) {
-        value = mappingFunction.apply(key);
-        if (value != null) {
-          data.put(key, value);
-          version++;
-        }
-      }
-      return value;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    return working().computeIfAbsent(key, mappingFunction);
   }
 
   @Override
   public Object putIfAbsent(String key, Object value) {
-    lock.writeLock().lock();
-    try {
-      Object existing = data.get(key);
-      if (existing == null) {
-        data.put(key, value);
-        version++;
-      }
-      return existing;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    return working().putIfAbsent(key, value);
   }
 
   @Override
   public boolean compareAndSet(String key, Object expected, Object newValue) {
-    lock.writeLock().lock();
-    try {
-      Object current = data.get(key);
-      if (Objects.equals(current, expected)) {
-        if (!Objects.equals(current, newValue)) {
-          data.put(key, newValue);
-          version++;
-        }
-        return true;
-      }
-      return false;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    return working().compareAndSet(key, expected, newValue);
   }
 
   @Override
   public CaseContext update(String key, Function<Object, Object> updateFunction) {
-    lock.writeLock().lock();
-    try {
-      Object current = data.get(key);
-      Object newValue = updateFunction.apply(current);
-      if (newValue != null) {
-        if (!Objects.equals(current, newValue)) {
-          data.put(key, newValue);
-          version++;
-        }
-      } else {
-        if (data.containsKey(key)) {
-          data.remove(key);
-          version++;
-        }
-      }
-      return this;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    working().update(key, updateFunction);
+    return this;
   }
 
   @Override
   public String getString(String key) {
-    Object v = get(key);
-    return v != null ? v.toString() : null;
+    return working().getString(key);
   }
 
   @Override
   public Integer getInt(String key) {
-    Object v = get(key);
-    if (v == null) {
-      return null;
-    }
-    if (v instanceof Number n) {
-      return n.intValue();
-    }
-    return Integer.parseInt(v.toString());
+    return working().getInt(key);
   }
 
   @Override
   public Long getLong(String key) {
-    Object v = get(key);
-    if (v == null) {
-      return null;
-    }
-    if (v instanceof Number n) {
-      return n.longValue();
-    }
-    return Long.parseLong(v.toString());
+    return working().getLong(key);
   }
 
   @Override
   public Double getDouble(String key) {
-    Object v = get(key);
-    if (v == null) {
-      return null;
-    }
-    if (v instanceof Number n) {
-      return n.doubleValue();
-    }
-    return Double.parseDouble(v.toString());
+    return working().getDouble(key);
   }
 
   @Override
   public Boolean getBoolean(String key) {
-    Object v = get(key);
-    if (v == null) {
-      return null;
-    }
-    if (v instanceof Boolean b) {
-      return b;
-    }
-    return Boolean.parseBoolean(v.toString());
+    return working().getBoolean(key);
   }
 
   @Override
   public <T> List<T> getList(String key, Class<T> elementType) {
-    lock.readLock().lock();
-    try {
-      Object v = data.get(key);
-      if (v == null) {
-        return null;
-      }
-      if (v instanceof List<?> list) {
-        return list.stream().map(item -> mapper.convertValue(item, elementType)).toList();
-      }
-      return null;
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().getList(key, elementType);
   }
 
   @Override
   public Object getPath(String path) {
-    lock.readLock().lock();
-    try {
-      return getPathInternal(path);
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().getPath(path);
   }
 
   @Override
   public String getPathAsString(String path) {
-    Object v = getPath(path);
-    return v != null ? v.toString() : null;
+    return working().getPathAsString(path);
   }
 
-  @SuppressWarnings("unchecked")
-  private Object getPathInternal(String path) {
-    String[] parts = path.split("\\.");
-    Object current = data;
-
-    for (String part : parts) {
-      if (current instanceof Map<?, ?> map) {
-        current = map.get(part);
-      } else {
-        return null;
-      }
-      if (current == null) {
-        return null;
-      }
-    }
-    return current;
-  }
-
-  @SuppressWarnings("unchecked")
   @Override
   public CaseContext setPath(String path, Object value) {
-    lock.writeLock().lock();
-    try {
-      String[] parts = path.split("\\.");
-      Map<String, Object> current = data;
-
-      for (int i = 0; i < parts.length - 1; i++) {
-        Object next = current.get(parts[i]);
-        if (next == null) {
-          next = new LinkedHashMap<String, Object>();
-          current.put(parts[i], next);
-        }
-        if (next instanceof Map) {
-          current = (Map<String, Object>) next;
-        } else {
-          throw new IllegalStateException("Cannot set path: " + parts[i] + " is not a Map");
-        }
-      }
-      String leaf = parts[parts.length - 1];
-      Object prev = current.get(leaf);
-      if (!Objects.equals(prev, value)) {
-        current.put(leaf, value);
-        version++;
-      }
-      return this;
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public Optional<JsonNode> applyAndDiff(String path, Object value) {
-    lock.writeLock().lock();
-    try {
-      JsonNode before = mapper.convertValue(data, JsonNode.class);
-
-      String[] parts = path.split("\\.");
-      Map<String, Object> current = data;
-      for (int i = 0; i < parts.length - 1; i++) {
-        Object next = current.get(parts[i]);
-        if (next == null) {
-          next = new LinkedHashMap<String, Object>();
-          current.put(parts[i], next);
-        }
-        if (next instanceof Map) {
-          current = (Map<String, Object>) next;
-        } else {
-          throw new IllegalStateException("Cannot set path: " + parts[i] + " is not a Map");
-        }
-      }
-      String leaf = parts[parts.length - 1];
-      Object prev = current.get(leaf);
-      if (!Objects.equals(prev, value)) {
-        current.put(leaf, value);
-        version++;
-      }
-
-      JsonNode after = mapper.convertValue(data, JsonNode.class);
-      JsonNode diff = JsonDiff.asJson(before, after);
-      return diff.isEmpty() ? Optional.empty() : Optional.of(diff);
-    } finally {
-      lock.writeLock().unlock();
-    }
+    working().setPath(path, value);
+    return this;
   }
 
   @Override
   public CaseContext setAll(Map<String, Object> values) {
-    if (values == null || values.isEmpty()) {
-      return this;
-    }
-    lock.writeLock().lock();
-    try {
-      boolean changed = false;
-      for (Map.Entry<String, Object> e : values.entrySet()) {
-        Object prev = data.get(e.getKey());
-        if (!Objects.equals(prev, e.getValue())) {
-          data.put(e.getKey(), e.getValue());
-          changed = true;
-        }
-      }
-      if (changed) {
-        version++;
-      }
-      return this;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    working().setAll(values);
+    return this;
   }
 
   @Override
   public Map<String, Object> getAll(String... keys) {
-    lock.readLock().lock();
-    try {
-      Map<String, Object> result = new LinkedHashMap<>();
-      for (String key : keys) {
-        Object value = data.get(key);
-        if (value != null) {
-          result.put(key, value);
-        }
-      }
-      return result;
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().getAll(keys);
   }
 
   @Override
   public boolean contains(String key) {
-    lock.readLock().lock();
-    try {
-      return data.containsKey(key);
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().contains(key);
   }
 
   @Override
   public CaseContext remove(String key) {
-    lock.writeLock().lock();
-    try {
-      if (data.containsKey(key)) {
-        data.remove(key);
-        version++;
-      }
-      return this;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    working().remove(key);
+    return this;
   }
 
   @Override
   public CaseContext clear() {
-    lock.writeLock().lock();
-    try {
-      if (!data.isEmpty()) {
-        data.clear();
-        version++;
-      }
-      return this;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    working().clear();
+    return this;
   }
 
   @JsonIgnore
   @Override
   public Set<String> getKeys() {
-    lock.readLock().lock();
-    try {
-      return new HashSet<>(data.keySet());
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().getKeys();
   }
 
   @JsonIgnore
   @Override
   public boolean isEmpty() {
-    lock.readLock().lock();
-    try {
-      return data.isEmpty();
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().isEmpty();
   }
 
   @JsonIgnore
   @Override
   public int size() {
-    lock.readLock().lock();
-    try {
-      return data.size();
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().size();
   }
 
+  @JsonAnyGetter
   @Override
-  public JsonNode asJsonNode() {
-    lock.readLock().lock();
-    try {
-      return mapper.convertValue(data, JsonNode.class);
-    } finally {
-      lock.readLock().unlock();
-    }
+  public Map<String, Object> getData() {
+    return working().getData();
+  }
+
+  // ── Multi-panel operations ─────────────────────────────────────────────────
+
+  @Override
+  public long getVersion() {
+    return working().getVersion();
   }
 
   @Override
   public CaseContext merge(CaseContext other) {
-    if (other == null) {
-      return this;
-    }
-    lock.writeLock().lock();
-    try {
-      Map<String, Object> otherData = other.getData();
-      boolean changed = false;
-      for (Map.Entry<String, Object> e : otherData.entrySet()) {
-        Object prev = data.get(e.getKey());
-        if (!Objects.equals(prev, e.getValue())) {
-          data.put(e.getKey(), e.getValue());
-          changed = true;
-        }
-      }
-      if (changed) {
-        version++;
-      }
-      return this;
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  @Override
-  public CaseContext snapshot() {
-    lock.readLock().lock();
-    try {
-      return new CaseContextImpl(deepCopy(data), version);
-    } finally {
-      lock.readLock().unlock();
-    }
+    if (other == null) return this;
+    working().setAll(other.getData()); // merge working panels only
+    return this;
   }
 
   @Override
   public JsonNode diff(CaseContext other) {
-    lock.readLock().lock();
-    try {
-      JsonNode thisNode = mapper.convertValue(this.data, JsonNode.class);
-      JsonNode otherNode = mapper.convertValue(other.getData(), JsonNode.class);
-      return JsonDiff.asJson(thisNode, otherNode);
-    } finally {
-      lock.readLock().unlock();
-    }
+    return working().diff(other.panel(ContextPanel.WORKING)); // working panels only
   }
 
   @Override
   public void applyDiff(JsonNode diff) {
-    lock.writeLock().lock();
-    try {
-      JsonNode current = mapper.convertValue(data, JsonNode.class);
-      JsonNode patched = JsonPatch.apply(diff, current);
-      Map<String, Object> updated =
-          mapper.convertValue(
-              patched,
-              mapper
-                  .getTypeFactory()
-                  .constructMapType(LinkedHashMap.class, String.class, Object.class));
-      data.clear();
-      data.putAll(updated);
-      version++;
-    } finally {
-      lock.writeLock().unlock();
-    }
+    working().applyDiff(diff); // working panel, working-panel-relative patches
   }
 
   @Override
-  public long getVersion() {
-    lock.readLock().lock();
-    try {
-      return version;
-    } finally {
-      lock.readLock().unlock();
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private Map<String, Object> deepCopy(Map<String, Object> source) {
-    Map<String, Object> copy = new LinkedHashMap<>();
-    for (Map.Entry<String, Object> entry : source.entrySet()) {
-      Object value = entry.getValue();
-      if (value instanceof Map) {
-        value = deepCopy((Map<String, Object>) value);
-      } else if (value instanceof List) {
-        value = new ArrayList<>((List<?>) value);
-      }
-      copy.put(entry.getKey(), value);
-    }
-    return copy;
+  public Optional<JsonNode> applyAndDiff(String path, Object value) {
+    return working().applyAndDiff(path, value); // working panel, path is working-relative
   }
 
   @Override
-  public String toString() {
-    lock.readLock().lock();
-    try {
-      return mapper.writeValueAsString(data);
-    } catch (Exception e) {
-      return data.toString();
-    } finally {
-      lock.readLock().unlock();
+  public CaseContext snapshot() {
+    // Deep-copy ALL panels
+    CaseContextImpl snap = new CaseContextImpl();
+    snap.panels.clear();
+    for (Map.Entry<String, WritablePanelImpl> e : panels.entrySet()) {
+      snap.panels.put(e.getKey(), e.getValue().deepCopy());
     }
+    return snap;
   }
+
+  @Override
+  public JsonNode asJsonNode() {
+    // Returns FULL panel document: {"working":{...},"semantic":{...},"episodic":{...},...}
+    ObjectNode doc = MAPPER.createObjectNode();
+    for (Map.Entry<String, WritablePanelImpl> e : panels.entrySet()) {
+      doc.set(e.getKey(), e.getValue().asJsonNode());
+    }
+    return doc;
+  }
+
+  /**
+   * Factory for recovery — reconstructs from a stored panel document. The panel document is the
+   * output of {@link #asJsonNode()}: a JSON object whose keys are panel names and values are panel
+   * data objects.
+   */
+  public static CaseContextImpl fromPanelDocument(JsonNode panelDoc) {
+    CaseContextImpl ctx = new CaseContextImpl();
+    if (panelDoc == null || panelDoc.isNull()) return ctx;
+    panelDoc
+        .fields()
+        .forEachRemaining(
+            entry -> {
+              String name = entry.getKey();
+              @SuppressWarnings("unchecked")
+              Map<String, Object> data = MAPPER.convertValue(entry.getValue(), Map.class);
+              ctx.panels.put(name, new WritablePanelImpl(name, data));
+            });
+    return ctx;
+  }
+
+  // ── equals / hashCode / toString — working panel data for backward compat ──
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof CaseContextImpl that)) {
-      return false;
-    }
-    Map<String, Object> thisData = this.getData();
-    Map<String, Object> thatData = that.getData();
-    return thisData.equals(thatData);
+    if (this == o) return true;
+    if (!(o instanceof CaseContextImpl that)) return false;
+    return this.getData().equals(that.getData());
   }
 
   @Override
   public int hashCode() {
-    lock.readLock().lock();
+    return getData().hashCode();
+  }
+
+  @Override
+  public String toString() {
     try {
-      return data.hashCode();
-    } finally {
-      lock.readLock().unlock();
+      return MAPPER.writeValueAsString(getData());
+    } catch (Exception e) {
+      return getData().toString();
     }
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
@@ -61,8 +61,17 @@ public class CaseContextImpl implements CaseContext {
     this(initial);
   }
 
+  @SuppressWarnings("unchecked")
   public CaseContextImpl(JsonNode asNode) {
-    this(asNode == null ? null : MAPPER.convertValue(asNode, Map.class));
+    this(
+        asNode == null
+            ? null
+            : (Map<String, Object>)
+                MAPPER.convertValue(
+                    asNode,
+                    MAPPER
+                        .getTypeFactory()
+                        .constructMapType(LinkedHashMap.class, String.class, Object.class)));
   }
 
   private void initBuiltinPanels() {

--- a/runtime/src/main/java/io/casehub/engine/internal/context/EpisodicPanelUpdater.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/EpisodicPanelUpdater.java
@@ -36,66 +36,82 @@ public final class EpisodicPanelUpdater {
 
   /**
    * Updates or creates the worker entry in episodic.workers. Increments the runs counter; sets
-   * lastOutcome and lastTimestamp. Safe to call whether or not the episodic panel is frozen —
-   * writes use {@link WritablePanelImpl#engineSet} which bypasses the frozen check.
+   * lastOutcome and lastTimestamp. Safe to call whether or not the episodic panel is frozen. Uses
+   * {@link WritablePanelImpl#engineUpdate} to hold the write lock across the entire
+   * read-modify-write sequence, preventing lost increments under concurrent worker completions.
    */
-  @SuppressWarnings({"unchecked", "rawtypes"})
+  @SuppressWarnings("unchecked")
   public static void recordWorkerCompletion(
       CaseContextImpl ctx, String workerName, String outcome) {
     WritablePanelImpl episodic = ctx.writablePanel(ContextPanel.EPISODIC);
-    List<Map<String, Object>> workers =
-        (List<Map<String, Object>>) (List) episodic.getList("workers", Map.class);
-    if (workers == null) workers = new ArrayList<>();
-    else workers = new ArrayList<>(workers);
+    episodic.engineUpdate(
+        "workers",
+        currentValue -> {
+          List<Map<String, Object>> workers;
+          if (currentValue instanceof List) {
+            workers = new ArrayList<>((List<Map<String, Object>>) currentValue);
+          } else {
+            workers = new ArrayList<>();
+          }
 
-    Map<String, Object> entry = null;
-    for (Map<String, Object> w : workers) {
-      if (workerName.equals(w.get("name"))) {
-        entry = w;
-        break;
-      }
-    }
+          Map<String, Object> entry = null;
+          for (Map<String, Object> w : workers) {
+            if (workerName.equals(w.get("name"))) {
+              entry = w;
+              break;
+            }
+          }
 
-    if (entry == null) {
-      entry = new LinkedHashMap<>();
-      entry.put("name", workerName);
-      entry.put("runs", 0);
-      workers.add(entry);
-    }
+          if (entry == null) {
+            entry = new LinkedHashMap<>();
+            entry.put("name", workerName);
+            entry.put("runs", 0);
+            workers.add(entry);
+          }
 
-    entry.put("runs", ((Number) entry.getOrDefault("runs", 0)).intValue() + 1);
-    entry.put("lastOutcome", outcome);
-    entry.put("lastTimestamp", Instant.now().toString());
-    episodic.engineSet("workers", workers);
+          entry.put("runs", ((Number) entry.getOrDefault("runs", 0)).intValue() + 1);
+          entry.put("lastOutcome", outcome);
+          entry.put("lastTimestamp", Instant.now().toString());
+          return workers;
+        });
   }
 
   /**
    * Appends a milestone name to episodic.milestones (no duplicates). Safe to call whether or not
-   * the episodic panel is frozen.
+   * the episodic panel is frozen. Uses {@link WritablePanelImpl#engineUpdate} for atomic
+   * read-modify-write.
    */
+  @SuppressWarnings("unchecked")
   public static void recordMilestoneReached(CaseContextImpl ctx, String milestoneName) {
     WritablePanelImpl episodic = ctx.writablePanel(ContextPanel.EPISODIC);
-    List<String> milestones = episodic.getList("milestones", String.class);
-    if (milestones == null) milestones = new ArrayList<>();
-    else milestones = new ArrayList<>(milestones);
-    if (!milestones.contains(milestoneName)) {
-      milestones.add(milestoneName);
-      episodic.engineSet("milestones", milestones);
-    }
+    episodic.engineUpdate(
+        "milestones",
+        currentValue -> {
+          List<String> milestones =
+              currentValue instanceof List
+                  ? new ArrayList<>((List<String>) currentValue)
+                  : new ArrayList<>();
+          if (!milestones.contains(milestoneName)) milestones.add(milestoneName);
+          return milestones;
+        });
   }
 
   /**
    * Appends a goal name to episodic.goals (no duplicates). Safe to call whether or not the episodic
-   * panel is frozen.
+   * panel is frozen. Uses {@link WritablePanelImpl#engineUpdate} for atomic read-modify-write.
    */
+  @SuppressWarnings("unchecked")
   public static void recordGoalReached(CaseContextImpl ctx, String goalName) {
     WritablePanelImpl episodic = ctx.writablePanel(ContextPanel.EPISODIC);
-    List<String> goals = episodic.getList("goals", String.class);
-    if (goals == null) goals = new ArrayList<>();
-    else goals = new ArrayList<>(goals);
-    if (!goals.contains(goalName)) {
-      goals.add(goalName);
-      episodic.engineSet("goals", goals);
-    }
+    episodic.engineUpdate(
+        "goals",
+        currentValue -> {
+          List<String> goals =
+              currentValue instanceof List
+                  ? new ArrayList<>((List<String>) currentValue)
+                  : new ArrayList<>();
+          if (!goals.contains(goalName)) goals.add(goalName);
+          return goals;
+        });
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/context/EpisodicPanelUpdater.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/EpisodicPanelUpdater.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.context;
+
+import io.casehub.api.context.ContextPanel;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class EpisodicPanelUpdater {
+
+  private EpisodicPanelUpdater() {}
+
+  /** Initializes the episodic panel baseline: {workers:[], milestones:[], goals:[]} */
+  public static void initBaseline(CaseContextImpl ctx) {
+    WritablePanelImpl episodic = ctx.writablePanel(ContextPanel.EPISODIC);
+    if (!episodic.contains("workers")) episodic.engineSet("workers", new ArrayList<>());
+    if (!episodic.contains("milestones")) episodic.engineSet("milestones", new ArrayList<>());
+    if (!episodic.contains("goals")) episodic.engineSet("goals", new ArrayList<>());
+  }
+
+  /**
+   * Updates or creates the worker entry in episodic.workers. Increments the runs counter; sets
+   * lastOutcome and lastTimestamp. Safe to call whether or not the episodic panel is frozen —
+   * writes use {@link WritablePanelImpl#engineSet} which bypasses the frozen check.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static void recordWorkerCompletion(
+      CaseContextImpl ctx, String workerName, String outcome) {
+    WritablePanelImpl episodic = ctx.writablePanel(ContextPanel.EPISODIC);
+    List<Map<String, Object>> workers =
+        (List<Map<String, Object>>) (List) episodic.getList("workers", Map.class);
+    if (workers == null) workers = new ArrayList<>();
+    else workers = new ArrayList<>(workers);
+
+    Map<String, Object> entry = null;
+    for (Map<String, Object> w : workers) {
+      if (workerName.equals(w.get("name"))) {
+        entry = w;
+        break;
+      }
+    }
+
+    if (entry == null) {
+      entry = new LinkedHashMap<>();
+      entry.put("name", workerName);
+      entry.put("runs", 0);
+      workers.add(entry);
+    }
+
+    entry.put("runs", ((Number) entry.getOrDefault("runs", 0)).intValue() + 1);
+    entry.put("lastOutcome", outcome);
+    entry.put("lastTimestamp", Instant.now().toString());
+    episodic.engineSet("workers", workers);
+  }
+
+  /**
+   * Appends a milestone name to episodic.milestones (no duplicates). Safe to call whether or not
+   * the episodic panel is frozen.
+   */
+  public static void recordMilestoneReached(CaseContextImpl ctx, String milestoneName) {
+    WritablePanelImpl episodic = ctx.writablePanel(ContextPanel.EPISODIC);
+    List<String> milestones = episodic.getList("milestones", String.class);
+    if (milestones == null) milestones = new ArrayList<>();
+    else milestones = new ArrayList<>(milestones);
+    if (!milestones.contains(milestoneName)) {
+      milestones.add(milestoneName);
+      episodic.engineSet("milestones", milestones);
+    }
+  }
+
+  /**
+   * Appends a goal name to episodic.goals (no duplicates). Safe to call whether or not the episodic
+   * panel is frozen.
+   */
+  public static void recordGoalReached(CaseContextImpl ctx, String goalName) {
+    WritablePanelImpl episodic = ctx.writablePanel(ContextPanel.EPISODIC);
+    List<String> goals = episodic.getList("goals", String.class);
+    if (goals == null) goals = new ArrayList<>();
+    else goals = new ArrayList<>(goals);
+    if (!goals.contains(goalName)) {
+      goals.add(goalName);
+      episodic.engineSet("goals", goals);
+    }
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/context/MapCaseFile.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/MapCaseFile.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.engine.internal.context;
 
-import io.casehub.api.context.CaseContext;
 import java.util.Map;
 import java.util.Set;
 
@@ -61,15 +60,5 @@ public class MapCaseFile extends CaseContextImpl {
   /** poc-compatible alias for {@link #getKeys()}. */
   public Set<String> keys() {
     return getKeys();
-  }
-
-  /**
-   * Overrides {@link CaseContextImpl#snapshot()} to return a {@code MapCaseFile}, preserving the
-   * poc-compatible {@code put/get/keys} aliases on the snapshot.
-   */
-  @Override
-  public CaseContext snapshot() {
-    final CaseContext base = super.snapshot();
-    return new MapCaseFile(base.getData());
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/context/WritablePanelImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/WritablePanelImpl.java
@@ -586,6 +586,11 @@ public class WritablePanelImpl implements WritablePanel {
     }
   }
 
+  @Override
+  public ReadablePanel snapshot() {
+    return deepCopy();
+  }
+
   /**
    * Returns a deep copy of this panel, detached from the original. The copy shares the same
    * panelName but has an independent data map.

--- a/runtime/src/main/java/io/casehub/engine/internal/context/WritablePanelImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/WritablePanelImpl.java
@@ -568,6 +568,25 @@ public class WritablePanelImpl implements WritablePanel {
   // ── Public helpers ─────────────────────────────────────────────────────────
 
   /**
+   * Engine-internal write that bypasses the frozen check. Used by {@code EpisodicPanelUpdater} to
+   * update engine-managed panels (episodic) without exposing an unfreeze/refreeze cycle.
+   */
+  public WritablePanelImpl engineSet(String key, Object value) {
+    lock.writeLock().lock();
+    try {
+      Object prev = data.get(key);
+      if (!Objects.equals(prev, value)) {
+        data.put(key, value);
+        // Intentionally does NOT increment version — episodic writes are engine-managed and must
+        // not trigger working-panel version bumps observed by trigger evaluation.
+      }
+      return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  /**
    * Returns a deep copy of this panel, detached from the original. The copy shares the same
    * panelName but has an independent data map.
    */

--- a/runtime/src/main/java/io/casehub/engine/internal/context/WritablePanelImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/WritablePanelImpl.java
@@ -1,0 +1,631 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.context;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.api.context.ReadOnlyPanelException;
+import io.casehub.api.context.ReadablePanel;
+import io.casehub.api.context.WritablePanel;
+import io.fabric8.zjsonpatch.JsonDiff;
+import io.fabric8.zjsonpatch.JsonPatch;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+
+/** Thread-safe, versioned data store for a single CaseFile panel. */
+public class WritablePanelImpl implements WritablePanel {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final String panelName;
+  private final Map<String, Object> data = new LinkedHashMap<>();
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
+  private long version = 0L;
+  private volatile boolean frozen = false;
+
+  public WritablePanelImpl(String panelName) {
+    this.panelName = panelName;
+  }
+
+  public WritablePanelImpl(String panelName, Map<String, Object> initial) {
+    this.panelName = panelName;
+    if (initial != null) {
+      data.putAll(initial);
+    }
+  }
+
+  // ── ReadablePanel ─────────────────────────────────────────────────────────
+
+  @Override
+  public String panelName() {
+    return panelName;
+  }
+
+  @Override
+  public boolean isReadOnly() {
+    return frozen;
+  }
+
+  public WritablePanelImpl freeze() {
+    this.frozen = true;
+    return this;
+  }
+
+  @Override
+  public Object get(String key) {
+    lock.readLock().lock();
+    try {
+      return data.get(key);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public <T> T getAs(String key, Class<T> type) {
+    lock.readLock().lock();
+    try {
+      Object value = data.get(key);
+      if (value == null) {
+        return null;
+      }
+      if (type.isInstance(value)) {
+        return type.cast(value);
+      }
+      return MAPPER.convertValue(value, type);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T getOrDefault(String key, T defaultValue) {
+    lock.readLock().lock();
+    try {
+      Object value = data.get(key);
+      return value != null ? (T) value : defaultValue;
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public String getString(String key) {
+    Object v = get(key);
+    return v != null ? v.toString() : null;
+  }
+
+  @Override
+  public Integer getInt(String key) {
+    Object v = get(key);
+    if (v == null) {
+      return null;
+    }
+    if (v instanceof Number n) {
+      return n.intValue();
+    }
+    return Integer.parseInt(v.toString());
+  }
+
+  @Override
+  public Long getLong(String key) {
+    Object v = get(key);
+    if (v == null) {
+      return null;
+    }
+    if (v instanceof Number n) {
+      return n.longValue();
+    }
+    return Long.parseLong(v.toString());
+  }
+
+  @Override
+  public Double getDouble(String key) {
+    Object v = get(key);
+    if (v == null) {
+      return null;
+    }
+    if (v instanceof Number n) {
+      return n.doubleValue();
+    }
+    return Double.parseDouble(v.toString());
+  }
+
+  @Override
+  public Boolean getBoolean(String key) {
+    Object v = get(key);
+    if (v == null) {
+      return null;
+    }
+    if (v instanceof Boolean b) {
+      return b;
+    }
+    return Boolean.parseBoolean(v.toString());
+  }
+
+  @Override
+  public <T> List<T> getList(String key, Class<T> elementType) {
+    lock.readLock().lock();
+    try {
+      Object v = data.get(key);
+      if (v == null) {
+        return null;
+      }
+      if (v instanceof List<?> list) {
+        return list.stream().map(item -> MAPPER.convertValue(item, elementType)).toList();
+      }
+      return null;
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public boolean contains(String key) {
+    lock.readLock().lock();
+    try {
+      return data.containsKey(key);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Set<String> getKeys() {
+    lock.readLock().lock();
+    try {
+      return new HashSet<>(data.keySet());
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<String, Object> getData() {
+    lock.readLock().lock();
+    try {
+      return new LinkedHashMap<>(data);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Map<String, Object> getAll(String... keys) {
+    lock.readLock().lock();
+    try {
+      Map<String, Object> result = new LinkedHashMap<>();
+      for (String key : keys) {
+        Object value = data.get(key);
+        if (value != null) {
+          result.put(key, value);
+        }
+      }
+      return result;
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Object getPath(String path) {
+    lock.readLock().lock();
+    try {
+      return getPathInternal(path);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public String getPathAsString(String path) {
+    Object v = getPath(path);
+    return v != null ? v.toString() : null;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    lock.readLock().lock();
+    try {
+      return data.isEmpty();
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public int size() {
+    lock.readLock().lock();
+    try {
+      return data.size();
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public long getVersion() {
+    lock.readLock().lock();
+    try {
+      return version;
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public JsonNode asJsonNode() {
+    lock.readLock().lock();
+    try {
+      return MAPPER.convertValue(data, JsonNode.class);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  // ── WritablePanel ──────────────────────────────────────────────────────────
+
+  @Override
+  public WritablePanel set(String key, Object value) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      Object prev = data.get(key);
+      if (!Objects.equals(prev, value)) {
+        data.put(key, value);
+        version++;
+      }
+      return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public WritablePanel setAll(Map<String, Object> values) {
+    checkWritable();
+    if (values == null || values.isEmpty()) {
+      return this;
+    }
+    lock.writeLock().lock();
+    try {
+      boolean changed = false;
+      for (Map.Entry<String, Object> e : values.entrySet()) {
+        Object prev = data.get(e.getKey());
+        if (!Objects.equals(prev, e.getValue())) {
+          data.put(e.getKey(), e.getValue());
+          changed = true;
+        }
+      }
+      if (changed) {
+        version++;
+      }
+      return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public WritablePanel setPath(String path, Object value) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      String[] parts = path.split("\\.");
+      Map<String, Object> current = data;
+      for (int i = 0; i < parts.length - 1; i++) {
+        Object next = current.get(parts[i]);
+        if (next == null) {
+          next = new LinkedHashMap<String, Object>();
+          current.put(parts[i], next);
+        }
+        if (next instanceof Map) {
+          current = (Map<String, Object>) next;
+        } else {
+          throw new IllegalStateException("Cannot set path: " + parts[i] + " is not a Map");
+        }
+      }
+      String leaf = parts[parts.length - 1];
+      Object prev = current.get(leaf);
+      if (!Objects.equals(prev, value)) {
+        current.put(leaf, value);
+        version++;
+      }
+      return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public WritablePanel remove(String key) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      if (data.containsKey(key)) {
+        data.remove(key);
+        version++;
+      }
+      return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public WritablePanel clear() {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      if (!data.isEmpty()) {
+        data.clear();
+        version++;
+      }
+      return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public WritablePanel merge(ReadablePanel other) {
+    checkWritable();
+    if (other == null) {
+      return this;
+    }
+    lock.writeLock().lock();
+    try {
+      Map<String, Object> otherData = other.getData();
+      boolean changed = false;
+      for (Map.Entry<String, Object> e : otherData.entrySet()) {
+        Object prev = data.get(e.getKey());
+        if (!Objects.equals(prev, e.getValue())) {
+          data.put(e.getKey(), e.getValue());
+          changed = true;
+        }
+      }
+      if (changed) {
+        version++;
+      }
+      return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public Object computeIfAbsent(String key, Function<String, Object> mappingFunction) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      Object value = data.get(key);
+      if (value == null) {
+        value = mappingFunction.apply(key);
+        if (value != null) {
+          data.put(key, value);
+          version++;
+        }
+      }
+      return value;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public Object putIfAbsent(String key, Object value) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      Object existing = data.get(key);
+      if (existing == null) {
+        data.put(key, value);
+        version++;
+      }
+      return existing;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public boolean compareAndSet(String key, Object expected, Object newValue) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      Object current = data.get(key);
+      if (Objects.equals(current, expected)) {
+        if (!Objects.equals(current, newValue)) {
+          data.put(key, newValue);
+          version++;
+        }
+        return true;
+      }
+      return false;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public WritablePanel update(String key, Function<Object, Object> updateFunction) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      Object current = data.get(key);
+      Object newValue = updateFunction.apply(current);
+      if (newValue != null) {
+        if (!Objects.equals(current, newValue)) {
+          data.put(key, newValue);
+          version++;
+        }
+      } else {
+        if (data.containsKey(key)) {
+          data.remove(key);
+          version++;
+        }
+      }
+      return this;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Optional<JsonNode> applyAndDiff(String path, Object value) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      JsonNode before = MAPPER.convertValue(data, JsonNode.class);
+
+      String[] parts = path.split("\\.");
+      Map<String, Object> current = data;
+      for (int i = 0; i < parts.length - 1; i++) {
+        Object next = current.get(parts[i]);
+        if (next == null) {
+          next = new LinkedHashMap<String, Object>();
+          current.put(parts[i], next);
+        }
+        if (next instanceof Map) {
+          current = (Map<String, Object>) next;
+        } else {
+          throw new IllegalStateException("Cannot set path: " + parts[i] + " is not a Map");
+        }
+      }
+      String leaf = parts[parts.length - 1];
+      Object prev = current.get(leaf);
+      if (!Objects.equals(prev, value)) {
+        current.put(leaf, value);
+        version++;
+      }
+
+      JsonNode after = MAPPER.convertValue(data, JsonNode.class);
+      JsonNode diff = JsonDiff.asJson(before, after);
+      return diff.isEmpty() ? Optional.empty() : Optional.of(diff);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public void applyDiff(JsonNode diff) {
+    checkWritable();
+    lock.writeLock().lock();
+    try {
+      JsonNode current = MAPPER.convertValue(data, JsonNode.class);
+      JsonNode patched = JsonPatch.apply(diff, current);
+      Map<String, Object> updated =
+          MAPPER.convertValue(
+              patched,
+              MAPPER
+                  .getTypeFactory()
+                  .constructMapType(LinkedHashMap.class, String.class, Object.class));
+      data.clear();
+      data.putAll(updated);
+      version++;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public JsonNode diff(ReadablePanel other) {
+    lock.readLock().lock();
+    try {
+      JsonNode thisNode = MAPPER.convertValue(this.data, JsonNode.class);
+      JsonNode otherNode = MAPPER.convertValue(other.getData(), JsonNode.class);
+      return JsonDiff.asJson(thisNode, otherNode);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  // ── Public helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Returns a deep copy of this panel, detached from the original. The copy shares the same
+   * panelName but has an independent data map.
+   */
+  public WritablePanelImpl deepCopy() {
+    lock.readLock().lock();
+    try {
+      return new WritablePanelImpl(panelName, deepCopyMap(data));
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private void checkWritable() {
+    if (frozen) throw new ReadOnlyPanelException(panelName);
+  }
+
+  private Object getPathInternal(String path) {
+    String[] parts = path.split("\\.");
+    Object current = data;
+    for (String part : parts) {
+      if (current instanceof Map<?, ?> map) {
+        current = map.get(part);
+      } else {
+        return null;
+      }
+      if (current == null) {
+        return null;
+      }
+    }
+    return current;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> deepCopyMap(Map<String, Object> source) {
+    Map<String, Object> copy = new LinkedHashMap<>();
+    for (Map.Entry<String, Object> e : source.entrySet()) {
+      Object v = e.getValue();
+      if (v instanceof Map) {
+        v = deepCopyMap((Map<String, Object>) v);
+      } else if (v instanceof List) {
+        v = new ArrayList<>((List<?>) v);
+      }
+      copy.put(e.getKey(), v);
+    }
+    return copy;
+  }
+
+  @Override
+  public String toString() {
+    lock.readLock().lock();
+    try {
+      return MAPPER.writeValueAsString(data);
+    } catch (Exception e) {
+      return data.toString();
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+}

--- a/runtime/src/main/java/io/casehub/engine/internal/context/WritablePanelImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/WritablePanelImpl.java
@@ -586,6 +586,26 @@ public class WritablePanelImpl implements WritablePanel {
     }
   }
 
+  /**
+   * Engine-internal atomic read-modify-write that bypasses the frozen check. Holds the write lock
+   * for the entire read-modify-write sequence, preventing lost updates under concurrent writes.
+   * Does NOT increment version — engine-internal, must not trigger binding re-evaluation.
+   */
+  public void engineUpdate(String key, java.util.function.UnaryOperator<Object> updater) {
+    lock.writeLock().lock();
+    try {
+      Object current = data.get(key);
+      Object updated = updater.apply(current);
+      if (updated != null) {
+        data.put(key, updated);
+      } else if (data.containsKey(key)) {
+        data.remove(key);
+      }
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
   @Override
   public ReadablePanel snapshot() {
     return deepCopy();
@@ -629,12 +649,21 @@ public class WritablePanelImpl implements WritablePanel {
   @SuppressWarnings("unchecked")
   private static Map<String, Object> deepCopyMap(Map<String, Object> source) {
     Map<String, Object> copy = new LinkedHashMap<>();
-    for (Map.Entry<String, Object> e : source.entrySet()) {
+    for (var e : source.entrySet()) {
       Object v = e.getValue();
       if (v instanceof Map) {
         v = deepCopyMap((Map<String, Object>) v);
       } else if (v instanceof List) {
-        v = new ArrayList<>((List<?>) v);
+        List<?> original = (List<?>) v;
+        List<Object> listCopy = new ArrayList<>(original.size());
+        for (Object item : original) {
+          if (item instanceof Map) {
+            listCopy.add(deepCopyMap((Map<String, Object>) item));
+          } else {
+            listCopy.add(item);
+          }
+        }
+        v = listCopy;
       }
       copy.put(e.getKey(), v);
     }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -37,6 +37,7 @@ import io.casehub.engine.common.spi.CaseInstanceRepository;
 import io.casehub.engine.common.spi.EventLogRepository;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.casehub.engine.internal.context.CaseContextImpl;
+import io.casehub.engine.internal.context.EpisodicPanelUpdater;
 import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.smallrye.mutiny.Uni;
@@ -162,6 +163,7 @@ class CaseHubReactor {
         ctx.writablePanel(ContextPanel.SEMANTIC).setAll(semanticData);
       }
       ctx.freezePanel(ContextPanel.SEMANTIC);
+      EpisodicPanelUpdater.initBaseline(ctx);
       ctx.freezePanel(ContextPanel.EPISODIC); // episodic is engine-managed
     }
 

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -218,6 +218,17 @@ class CaseHubReactor {
             ctx.freezePanel(ContextPanel.EPISODIC);
           }
 
+          // Pre-create user-defined panels declared in the case definition (eager init so
+          // asJsonNode() and snapshot() include them even before any worker writes to them)
+          List<String> declaredPanels = definition.getPanelNames();
+          if (declaredPanels != null
+              && !declaredPanels.isEmpty()
+              && context instanceof CaseContextImpl ctx) {
+            for (String panelName : declaredPanels) {
+              ctx.writablePanel(panelName);
+            }
+          }
+
           CaseInstance instance = new CaseInstance();
           instance.setUuid(UUID.randomUUID());
           instance.setCaseMetaModel(model);

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -24,12 +24,15 @@ import io.casehub.api.context.ContextPanel;
 import io.casehub.api.context.PropagationContext;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.EpisodicMemoryConfig;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.engine.common.internal.event.CaseStartedEvent;
 import io.casehub.engine.common.internal.event.CaseStatusChanged;
 import io.casehub.engine.common.internal.event.SignalReceivedEvent;
 import io.casehub.engine.common.internal.history.EventLog;
+import io.casehub.engine.common.internal.jq.JQEvaluator;
+import io.casehub.engine.common.internal.jq.ValidationResult;
 import io.casehub.engine.common.internal.model.CaseInstance;
 import io.casehub.engine.common.internal.model.CaseMetaModel;
 import io.casehub.engine.common.spi.CaseDefinitionRegistry;
@@ -40,12 +43,18 @@ import io.casehub.engine.internal.context.CaseContextImpl;
 import io.casehub.engine.internal.context.EpisodicPanelUpdater;
 import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.casehub.platform.api.identity.CurrentPrincipal;
+import io.casehub.platform.api.memory.Memory;
+import io.casehub.platform.api.memory.MemoryDomain;
+import io.casehub.platform.api.memory.MemoryQuery;
+import io.casehub.platform.memory.ReactiveCaseMemoryStore;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -76,6 +85,10 @@ class CaseHubReactor {
   @Inject EventLogRepository eventLogRepository;
 
   @Inject CurrentPrincipal currentPrincipal;
+
+  @Inject ReactiveCaseMemoryStore reactiveCaseMemoryStore;
+
+  @Inject JQEvaluator jqEvaluator;
 
   CompletionStage<UUID> startCase(CaseDefinition definition, CaseContext context) {
     return startCaseInternal(definition, context, null, null, null);
@@ -135,7 +148,7 @@ class CaseHubReactor {
       Map<String, Object> semanticData) {
     CaseMetaModel model = caseDefinitionRegistry.getCaseMetaModel(definition);
 
-    PropagationContext propagationContext;
+    final PropagationContext propagationContext;
     if (parentPropCtx != null) {
       propagationContext = parentPropCtx.createChild();
     } else {
@@ -153,7 +166,8 @@ class CaseHubReactor {
               .orElse(PropagationContext.createRoot(traceId));
     }
 
-    // Populate semantic panel: definition defaults first, call-site overrides second
+    // Populate semantic panel: definition defaults first, call-site overrides second.
+    // Semantic must be frozen before the inter-case memory query (entityId JQ needs it).
     if (context instanceof CaseContextImpl ctx) {
       Map<String, Object> defSemanticData = definition.getSemanticData();
       if (defSemanticData != null && !defSemanticData.isEmpty()) {
@@ -163,21 +177,110 @@ class CaseHubReactor {
         ctx.writablePanel(ContextPanel.SEMANTIC).setAll(semanticData);
       }
       ctx.freezePanel(ContextPanel.SEMANTIC);
+      // Initialize episodic baseline before the inter-case query and before freeze
       EpisodicPanelUpdater.initBaseline(ctx);
-      ctx.freezePanel(ContextPanel.EPISODIC); // episodic is engine-managed
     }
 
-    CaseInstance instance = new CaseInstance();
-    instance.setUuid(UUID.randomUUID());
-    instance.setCaseMetaModel(model);
-    instance.setVersion(0L);
-    instance.setState(CaseStatus.RUNNING);
-    instance.setCaseContext(context);
-    instance.setPropagationContext(propagationContext);
-    instance.setParentCaseId(parentCaseId);
+    // Inter-case memory query — async, runs before episodic panel is frozen
+    EpisodicMemoryConfig memCfg = definition.getEpisodicMemoryConfig();
+    final Uni<Void> memoryQueryStep;
 
-    caseInstanceCache.put(instance);
-    return caseInstanceRepository.save(instance, currentPrincipal.tenancyId());
+    if (memCfg != null && context instanceof CaseContextImpl ctxForMem) {
+      memoryQueryStep =
+          queryEpisodicMemory(ctxForMem, memCfg)
+              .invoke(
+                  memories -> {
+                    if (!memories.isEmpty()) {
+                      List<Map<String, Object>> projected =
+                          memories.stream()
+                              .map(
+                                  m -> {
+                                    Map<String, Object> p = new LinkedHashMap<>();
+                                    p.put("text", m.text());
+                                    if (m.attributes() != null && !m.attributes().isEmpty()) {
+                                      p.put("attributes", new LinkedHashMap<>(m.attributes()));
+                                    }
+                                    return p;
+                                  })
+                              .toList();
+                      ctxForMem.writablePanel(ContextPanel.EPISODIC).engineSet("memory", projected);
+                    }
+                  })
+              .replaceWithVoid();
+    } else {
+      memoryQueryStep = Uni.createFrom().voidItem();
+    }
+
+    return memoryQueryStep.chain(
+        () -> {
+          // Freeze episodic after memory injection — episodic is engine-managed
+          if (context instanceof CaseContextImpl ctx) {
+            ctx.freezePanel(ContextPanel.EPISODIC);
+          }
+
+          CaseInstance instance = new CaseInstance();
+          instance.setUuid(UUID.randomUUID());
+          instance.setCaseMetaModel(model);
+          instance.setVersion(0L);
+          instance.setState(CaseStatus.RUNNING);
+          instance.setCaseContext(context);
+          instance.setPropagationContext(propagationContext);
+          instance.setParentCaseId(parentCaseId);
+
+          caseInstanceCache.put(instance);
+          return caseInstanceRepository.save(instance, currentPrincipal.tenancyId());
+        });
+  }
+
+  private Uni<List<Memory>> queryEpisodicMemory(CaseContextImpl ctx, EpisodicMemoryConfig cfg) {
+    try {
+      // Evaluate entityId JQ against frozen semantic panel
+      var semNode = ctx.panel(ContextPanel.SEMANTIC).asJsonNode();
+      ValidationResult vr = jqEvaluator.eval(cfg.entityId(), semNode);
+      if (!vr.ok() || vr.output() == null || vr.output().isEmpty()) {
+        LOG.warnf("episodic.memory.entityId JQ evaluation failed: %s", vr.error());
+        return Uni.createFrom().item(List.of());
+      }
+
+      var result = vr.output().get(0);
+      List<String> entityIds;
+      if (result.isTextual()) {
+        entityIds = List.of(result.asText());
+      } else if (result.isArray()) {
+        entityIds = new ArrayList<>();
+        result.forEach(n -> entityIds.add(n.asText()));
+      } else {
+        LOG.warnf("episodic.memory.entityId JQ result is neither string nor array: %s", result);
+        return Uni.createFrom().item(List.of());
+      }
+
+      if (entityIds.isEmpty()) {
+        return Uni.createFrom().item(List.of());
+      }
+
+      var domain = new MemoryDomain(cfg.domain());
+      var tenantId = currentPrincipal.tenancyId();
+
+      // No withCaseId() — inter-case query is cross-case by design
+      MemoryQuery query =
+          entityIds.size() == 1
+              ? MemoryQuery.forEntity(entityIds.get(0), domain, tenantId).withLimit(cfg.recent())
+              : MemoryQuery.forEntities(entityIds, domain, tenantId).withLimit(cfg.recent());
+
+      return reactiveCaseMemoryStore
+          .query(query)
+          .onFailure()
+          .recoverWithItem(
+              t -> {
+                LOG.warnf(
+                    t, "EpisodicMemoryStore query failed — continuing without inter-case memory");
+                return List.of();
+              });
+
+    } catch (Exception e) {
+      LOG.warnf(e, "Failed to build episodic MemoryQuery");
+      return Uni.createFrom().item(List.of());
+    }
   }
 
   void signal(UUID caseId, String path, Object value) {

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -20,6 +20,7 @@ import static io.casehub.engine.common.internal.event.EventBusAddresses.CASE_STA
 import static io.casehub.engine.common.internal.event.EventBusAddresses.SIGNAL_RECEIVED;
 
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.context.PropagationContext;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.model.CaseStatus;
@@ -35,6 +36,7 @@ import io.casehub.engine.common.spi.CaseDefinitionRegistry;
 import io.casehub.engine.common.spi.CaseInstanceRepository;
 import io.casehub.engine.common.spi.EventLogRepository;
 import io.casehub.engine.common.spi.cache.CaseInstanceCache;
+import io.casehub.engine.internal.context.CaseContextImpl;
 import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.smallrye.mutiny.Uni;
@@ -75,7 +77,7 @@ class CaseHubReactor {
   @Inject CurrentPrincipal currentPrincipal;
 
   CompletionStage<UUID> startCase(CaseDefinition definition, CaseContext context) {
-    return startCaseInternal(definition, context, null, null);
+    return startCaseInternal(definition, context, null, null, null);
   }
 
   CompletionStage<UUID> startCase(
@@ -83,15 +85,30 @@ class CaseHubReactor {
       CaseContext context,
       UUID parentCaseId,
       PropagationContext propagationContext) {
-    return startCaseInternal(definition, context, parentCaseId, propagationContext);
+    return startCaseInternal(definition, context, parentCaseId, propagationContext, null);
+  }
+
+  CompletionStage<UUID> startCase(
+      CaseDefinition definition, CaseContext context, Map<String, Object> semanticData) {
+    return startCaseInternal(definition, context, null, null, semanticData);
+  }
+
+  CompletionStage<UUID> startCase(
+      CaseDefinition definition,
+      CaseContext context,
+      Map<String, Object> semanticData,
+      UUID parentCaseId,
+      PropagationContext propagationContext) {
+    return startCaseInternal(definition, context, parentCaseId, propagationContext, semanticData);
   }
 
   private CompletionStage<UUID> startCaseInternal(
       CaseDefinition definition,
       CaseContext context,
       UUID parentCaseId,
-      PropagationContext parentPropCtx) {
-    return buildInstance(definition, context, parentCaseId, parentPropCtx)
+      PropagationContext parentPropCtx,
+      Map<String, Object> semanticData) {
+    return buildInstance(definition, context, parentCaseId, parentPropCtx, semanticData)
         .chain(
             instance -> {
               LOG.info("Case started with caseId: " + instance.getUuid());
@@ -113,7 +130,8 @@ class CaseHubReactor {
       CaseDefinition definition,
       CaseContext context,
       UUID parentCaseId,
-      PropagationContext parentPropCtx) {
+      PropagationContext parentPropCtx,
+      Map<String, Object> semanticData) {
     CaseMetaModel model = caseDefinitionRegistry.getCaseMetaModel(definition);
 
     PropagationContext propagationContext;
@@ -132,6 +150,19 @@ class CaseHubReactor {
                   budget ->
                       PropagationContext.createRoot(traceId, Map.<String, String>of(), budget))
               .orElse(PropagationContext.createRoot(traceId));
+    }
+
+    // Populate semantic panel: definition defaults first, call-site overrides second
+    if (context instanceof CaseContextImpl ctx) {
+      Map<String, Object> defSemanticData = definition.getSemanticData();
+      if (defSemanticData != null && !defSemanticData.isEmpty()) {
+        ctx.writablePanel(ContextPanel.SEMANTIC).setAll(defSemanticData);
+      }
+      if (semanticData != null && !semanticData.isEmpty()) {
+        ctx.writablePanel(ContextPanel.SEMANTIC).setAll(semanticData);
+      }
+      ctx.freezePanel(ContextPanel.SEMANTIC);
+      ctx.freezePanel(ContextPanel.EPISODIC); // episodic is engine-managed
     }
 
     CaseInstance instance = new CaseInstance();

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
@@ -60,6 +60,28 @@ class CaseHubRuntimeImpl implements CaseHubRuntime {
         definition, new CaseContextImpl(toContextMap(inputData)), parentCaseId, propagationContext);
   }
 
+  @Override
+  public CompletionStage<UUID> startCase(
+      CaseDefinition definition, Object inputData, Map<String, Object> semanticData) {
+    return reactor.startCase(
+        definition, new CaseContextImpl(toContextMap(inputData)), semanticData);
+  }
+
+  @Override
+  public CompletionStage<UUID> startCase(
+      CaseDefinition definition,
+      Object inputData,
+      Map<String, Object> semanticData,
+      UUID parentCaseId,
+      PropagationContext propagationContext) {
+    return reactor.startCase(
+        definition,
+        new CaseContextImpl(toContextMap(inputData)),
+        semanticData,
+        parentCaseId,
+        propagationContext);
+  }
+
   @SuppressWarnings("unchecked")
   private Map<String, Object> toContextMap(Object inputData) {
     if (inputData == null) return Map.of();

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.event.CaseHubEventType;
@@ -102,7 +103,8 @@ public class ActionGateExpiredHandler {
 
     eventBus.publish(
         EventBusAddresses.CONTEXT_CHANGED,
-        new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+        new CaseContextChangedEvent(
+            instance, instance.getCaseContext().snapshot(), ContextPanel.WORKING));
 
     // Notify the blackboard to mark the PlanItem FAULTED (gate-specific event, not
     // WORKER_RETRIES_EXHAUSTED)

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.CaseStatus;
 import io.casehub.api.model.WorkResult;
 import io.casehub.api.model.event.CaseHubEventType;
@@ -117,7 +118,8 @@ public class ActionGateRejectedHandler {
     // Fire CONTEXT_CHANGED immediately — gate is already cleared and signal written
     eventBus.publish(
         EventBusAddresses.CONTEXT_CHANGED,
-        new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+        new CaseContextChangedEvent(
+            instance, instance.getCaseContext().snapshot(), ContextPanel.WORKING));
 
     // Notify the blackboard (if active) to mark the PlanItem FAULTED so stage autocomplete fires.
     // Uses ACTION_GATE_WORKER_FAULTED (not WORKER_RETRIES_EXHAUSTED) to avoid case-fault

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -18,6 +18,8 @@ package io.casehub.engine.internal.engine.handler;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.context.PropagationContext;
 import io.casehub.api.engine.ExpressionEngineRegistry;
 import io.casehub.api.engine.LoopControl;
@@ -121,7 +123,13 @@ public class CaseContextChangedEventHandler {
       return Uni.createFrom().voidItem();
     }
 
-    final JsonNode contextSnapshot = event.contextSnapshot();
+    final CaseContext contextSnapshot = event.contextSnapshot();
+    final String changedPanel = event.changedPanel();
+
+    // Skip binding evaluation for episodic panel updates
+    if (ContextPanel.EPISODIC.equals(changedPanel)) {
+      return Uni.createFrom().voidItem();
+    }
 
     final CaseMetaModel caseMetaModel = caseInstance.getCaseMetaModel();
     final CaseDefinition caseDefinition =
@@ -152,7 +160,7 @@ public class CaseContextChangedEventHandler {
 
   private Uni<Void> rules(
       final CaseInstance caseInstance,
-      final JsonNode contextSnapshot,
+      final CaseContext contextSnapshot,
       final CaseDefinition definition) {
     final List<Binding> bindings = definition.getBindings();
     if (bindings == null || bindings.isEmpty()) {
@@ -199,7 +207,7 @@ public class CaseContextChangedEventHandler {
 
   private Uni<Void> milestones(
       final CaseInstance caseInstance,
-      final JsonNode contextSnapshot,
+      final CaseContext contextSnapshot,
       final CaseDefinition definition) {
     final List<Milestone> milestones = definition.getMilestones();
     if (milestones == null || milestones.isEmpty()) {
@@ -207,8 +215,8 @@ public class CaseContextChangedEventHandler {
     }
 
     for (final Milestone milestone : milestones) {
-      if (!expressionEngineRegistry.evaluate(
-          milestone.getCompletionCriteria(), caseInstance.getCaseContext())) continue;
+      if (!expressionEngineRegistry.evaluate(milestone.getCompletionCriteria(), contextSnapshot))
+        continue;
 
       LOG.infof("Milestone '%s' REACHED! Publishing MilestoneReachedEvent", milestone.getName());
       eventBus.publish(
@@ -220,7 +228,7 @@ public class CaseContextChangedEventHandler {
 
   private Uni<Void> goals(
       final CaseInstance caseInstance,
-      final JsonNode contextSnapshot,
+      final CaseContext contextSnapshot,
       final CaseDefinition definition) {
     final List<Goal> goals = definition.getGoals();
     if (goals == null || goals.isEmpty()) {
@@ -228,8 +236,7 @@ public class CaseContextChangedEventHandler {
     }
 
     for (final Goal goal : goals) {
-      if (!expressionEngineRegistry.evaluate(goal.getCondition(), caseInstance.getCaseContext()))
-        continue;
+      if (!expressionEngineRegistry.evaluate(goal.getCondition(), contextSnapshot)) continue;
 
       LOG.infof("Goal '%s' REACHED! Publishing GoalReachedEvent", goal.getName());
       eventBus.publish(EventBusAddresses.GOAL_REACHED, new GoalReachedEvent(caseInstance, goal));

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -126,6 +126,11 @@ public class CaseContextChangedEventHandler {
     final CaseContext contextSnapshot = event.contextSnapshot();
     final String changedPanel = event.changedPanel();
 
+    // Fire panel-scoped event for external subscribers (Claudony, monitoring, Drools)
+    if (changedPanel != null) {
+      eventBus.publish(EventBusAddresses.panelChanged(changedPanel), event);
+    }
+
     // Skip binding evaluation for episodic panel updates
     if (ContextPanel.EPISODIC.equals(changedPanel)) {
       return Uni.createFrom().voidItem();

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -149,7 +149,7 @@ public class CaseContextChangedEventHandler {
 
     LOG.infof("Handling CaseStateContextChangedEvent for caseId: %s", caseInstance.getUuid());
 
-    return rules(caseInstance, contextSnapshot, caseDefinition)
+    return rules(caseInstance, contextSnapshot, caseDefinition, changedPanel)
         .chain(() -> milestones(caseInstance, contextSnapshot, caseDefinition))
         .chain(() -> goals(caseInstance, contextSnapshot, caseDefinition))
         .invoke(
@@ -166,7 +166,8 @@ public class CaseContextChangedEventHandler {
   private Uni<Void> rules(
       final CaseInstance caseInstance,
       final CaseContext contextSnapshot,
-      final CaseDefinition definition) {
+      final CaseDefinition definition,
+      final String changedPanel) {
     final List<Binding> bindings = definition.getBindings();
     if (bindings == null || bindings.isEmpty()) {
       return Uni.createFrom().voidItem();
@@ -177,6 +178,11 @@ public class CaseContextChangedEventHandler {
     final List<Binding> eligible = new ArrayList<>();
     for (final Binding binding : bindings) {
       if (!(binding.getOn() instanceof ContextChangeTrigger cct)) {
+        continue;
+      }
+      // listenPanel filter: skip binding if it declares a specific panel that doesn't match
+      final String listenPanel = cct.getListenPanel();
+      if (listenPanel != null && !listenPanel.equals(changedPanel)) {
         continue;
       }
       if (!expressionEngineRegistry.evaluate(cct.getFilter(), contextSnapshot)) {

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
@@ -15,7 +15,6 @@
  */
 package io.casehub.engine.internal.engine.handler;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.api.spi.CaseChannelProvider;
@@ -59,14 +58,13 @@ public class CaseStartedEventHandler {
   public Uni<Void> onCaseStarted(CaseStartedEvent event) {
     final String traceId = traceIdProvider.currentTraceId().orElse(null);
     final CaseInstance instance = event.instance();
-    final JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
 
     EventLog eventLog = new EventLog();
     eventLog.setCaseId(instance.getUuid());
     eventLog.setEventType(CaseHubEventType.CASE_STARTED);
     eventLog.setStreamType(EventStreamType.CASE);
     eventLog.setTimestamp(Instant.now());
-    eventLog.setPayload(contextSnapshot);
+    eventLog.setPayload(instance.getCaseContext().asJsonNode());
 
     caseChannelProvider.openChannel(instance.getUuid(), "coordination");
 
@@ -77,7 +75,8 @@ public class CaseStartedEventHandler {
             () ->
                 eventBus.publish(
                     EventBusAddresses.CONTEXT_CHANGED,
-                    new CaseContextChangedEvent(instance, contextSnapshot)))
+                    new CaseContextChangedEvent(
+                        instance, instance.getCaseContext().snapshot(), null)))
         .chain(
             () ->
                 Uni.createFrom()

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStatusChangedHandler.java
@@ -116,7 +116,7 @@ public class CaseStatusChangedHandler {
                 eventBus.publish(
                     EventBusAddresses.CONTEXT_CHANGED,
                     new CaseContextChangedEvent(
-                        caseInstance, caseInstance.getCaseContext().asJsonNode()));
+                        caseInstance, caseInstance.getCaseContext().snapshot(), null));
               }
             })
         .chain(

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/MilestoneActivatedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/MilestoneActivatedEventHandler.java
@@ -18,9 +18,9 @@ package io.casehub.engine.internal.engine.handler;
 import static io.casehub.api.model.event.CaseHubEventType.MILESTONE_ACTIVATED;
 import static io.casehub.engine.common.internal.event.EventBusAddresses.CONTEXT_CHANGED;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.MilestoneLifecycleStatus;
 import io.casehub.api.model.SlaStatus;
@@ -137,8 +137,10 @@ public class MilestoneActivatedEventHandler {
         caseInstance.getUuid(), milestone.getName(), milestoneState);
 
     // Publish CONTEXT_CHANGED event to notify other components (I3)
-    JsonNode contextSnapshot = context.asJsonNode();
-    eventBus.publish(CONTEXT_CHANGED, new CaseContextChangedEvent(caseInstance, contextSnapshot));
+    eventBus.publish(
+        CONTEXT_CHANGED,
+        new CaseContextChangedEvent(
+            caseInstance, caseInstance.getCaseContext().snapshot(), ContextPanel.WORKING));
 
     return Uni.createFrom().voidItem();
   }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/MilestoneCompletedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/MilestoneCompletedEventHandler.java
@@ -18,9 +18,9 @@ package io.casehub.engine.internal.engine.handler;
 import static io.casehub.api.model.event.CaseHubEventType.MILESTONE_COMPLETED;
 import static io.casehub.engine.common.internal.event.EventBusAddresses.CONTEXT_CHANGED;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.Milestone;
 import io.casehub.api.model.MilestoneLifecycleStatus;
 import io.casehub.api.model.SlaStatus;
@@ -123,8 +123,10 @@ public class MilestoneCompletedEventHandler {
         caseInstance.getUuid(), milestone.getName(), completedAt);
 
     // Publish CONTEXT_CHANGED event to notify other components
-    JsonNode contextSnapshot = context.asJsonNode();
-    eventBus.publish(CONTEXT_CHANGED, new CaseContextChangedEvent(caseInstance, contextSnapshot));
+    eventBus.publish(
+        CONTEXT_CHANGED,
+        new CaseContextChangedEvent(
+            caseInstance, caseInstance.getCaseContext().snapshot(), ContextPanel.WORKING));
 
     return Uni.createFrom().voidItem();
   }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/MilestoneSLAViolatedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/MilestoneSLAViolatedEventHandler.java
@@ -18,9 +18,9 @@ package io.casehub.engine.internal.engine.handler;
 import static io.casehub.api.model.event.CaseHubEventType.MILESTONE_SLA_VIOLATED;
 import static io.casehub.engine.common.internal.event.EventBusAddresses.CONTEXT_CHANGED;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.SlaStatus;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
@@ -107,8 +107,10 @@ public class MilestoneSLAViolatedEventHandler {
         caseInstance.getUuid(), milestoneName, violatedAt);
 
     // Publish CONTEXT_CHANGED event to notify other components
-    JsonNode contextSnapshot = context.asJsonNode();
-    eventBus.publish(CONTEXT_CHANGED, new CaseContextChangedEvent(caseInstance, contextSnapshot));
+    eventBus.publish(
+        CONTEXT_CHANGED,
+        new CaseContextChangedEvent(
+            caseInstance, caseInstance.getCaseContext().snapshot(), ContextPanel.WORKING));
 
     return Uni.createFrom().voidItem();
   }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
@@ -19,6 +19,7 @@ import static io.casehub.engine.common.internal.event.EventBusAddresses.CONTEXT_
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.api.model.event.EventStreamType;
 import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
@@ -108,7 +109,6 @@ public class SignalReceivedEventHandler {
     }
 
     JsonNode diff = maybeDiff.get();
-    JsonNode contextSnapshot = instance.getCaseContext().asJsonNode();
     EventLog eventLog = buildSignalEventLog(instance, diff);
 
     return eventLogRepository
@@ -116,7 +116,9 @@ public class SignalReceivedEventHandler {
         .invoke(
             () ->
                 eventBus.publish(
-                    CONTEXT_CHANGED, new CaseContextChangedEvent(instance, contextSnapshot)))
+                    CONTEXT_CHANGED,
+                    new CaseContextChangedEvent(
+                        instance, instance.getCaseContext().snapshot(), ContextPanel.WORKING)))
         .chain(
             () ->
                 Uni.createFrom()

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -44,6 +44,8 @@ import io.casehub.engine.common.spi.CaseInstanceRepository;
 import io.casehub.engine.common.spi.EventLogRepository;
 import io.casehub.engine.common.spi.event.CaseLifecycleEvent;
 import io.casehub.engine.common.spi.event.WorkerDecisionEvent;
+import io.casehub.engine.internal.context.CaseContextImpl;
+import io.casehub.engine.internal.context.EpisodicPanelUpdater;
 import io.casehub.engine.internal.work.CaseResumptionService;
 import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
 import io.quarkus.vertx.ConsumeEvent;
@@ -94,6 +96,9 @@ public class WorkflowExecutionCompletedHandler {
 
     JsonNode contextBefore = caseInstance.getCaseContext().snapshot().asJsonNode();
     applyOutputWithConflictResolution(caseInstance, worker, rawOutput);
+    if (caseInstance.getCaseContext() instanceof CaseContextImpl ctx) {
+      EpisodicPanelUpdater.recordWorkerCompletion(ctx, worker.getName(), "COMPLETED");
+    }
     JsonNode contextAfter = caseInstance.getCaseContext().asJsonNode();
     JsonNode diff = contextDiffStrategy.compute(contextBefore, contextAfter);
 

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.Binding;
 import io.casehub.api.model.CapabilityTarget;
 import io.casehub.api.model.CaseDefinition;
@@ -171,7 +172,10 @@ public class WorkflowExecutionCompletedHandler {
             () ->
                 eventBus.publish(
                     EventBusAddresses.CONTEXT_CHANGED,
-                    new CaseContextChangedEvent(caseInstance, contextAfter)))
+                    new CaseContextChangedEvent(
+                        caseInstance,
+                        caseInstance.getCaseContext().snapshot(),
+                        ContextPanel.WORKING)))
         .replaceWithVoid()
         .onFailure()
         .invoke(

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java
@@ -327,6 +327,13 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
    * "after" nodes. Missing "after" means removal.
    */
   private void applyTopLevelChanges(CaseContext caseContext, JsonNode changes) {
+    // After the panels migration, top-level keys in the diff are panel names (working, semantic,
+    // episodic). Each changeNode has "before"/"after" for the panel's full contents — not a
+    // single flat key. We must update the named panel rather than setting the panel name as a key
+    // inside the working panel (which is what CaseContext.set() would do via the flat API).
+    CaseContextImpl ctxImpl =
+        caseContext instanceof CaseContextImpl c ? c : null;
+
     changes
         .fieldNames()
         .forEachRemaining(
@@ -337,10 +344,16 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
               }
               JsonNode afterNode = changeNode.get("after");
               if (afterNode == null || afterNode.isNull()) {
-                // Removal
+                // Removal — panel cleared; call remove on flat API (no-op for panels but safe)
                 caseContext.remove(key);
+              } else if (ctxImpl != null && afterNode.isObject()) {
+                // Panel-level diff: afterNode is the panel's FULL new contents — replace, not merge.
+                // clear() then setAll() ensures removed keys are not left behind.
+                @SuppressWarnings("unchecked")
+                Map<String, Object> afterMap = OBJECT_MAPPER.convertValue(afterNode, Map.class);
+                ctxImpl.writablePanel(key).clear().setAll(afterMap);
               } else {
-                // Update/addition
+                // Flat scalar (rare/legacy): fall back to flat set
                 Object value = OBJECT_MAPPER.convertValue(afterNode, Object.class);
                 caseContext.set(key, value);
               }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java
@@ -18,6 +18,7 @@ package io.casehub.engine.internal.engine.recovery;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.event.CaseHubEventType;
 import io.casehub.engine.common.internal.history.EventLog;
 import io.casehub.engine.common.internal.model.CaseInstance;
@@ -29,6 +30,7 @@ import io.casehub.engine.common.spi.cache.CaseInstanceCache;
 import io.casehub.engine.common.spi.recovery.WorkerExecutionRecoveryService;
 import io.casehub.engine.common.spi.scheduler.WorkerExecutionManager;
 import io.casehub.engine.internal.context.CaseContextImpl;
+import io.casehub.engine.internal.context.EpisodicPanelUpdater;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -148,7 +150,7 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
                         CaseHubEventType.MILESTONE_SLA_VIOLATED)))
         .map(
             eventLogs -> {
-              CaseContext caseContext = new CaseContextImpl();
+              CaseContextImpl caseContext = new CaseContextImpl();
               EventLog caseStartedEvent =
                   eventLogs.stream()
                       .filter(e -> e.getEventType() == CaseHubEventType.CASE_STARTED)
@@ -156,7 +158,9 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
                       .orElse(null);
 
               if (caseStartedEvent != null) {
-                caseContext = new CaseContextImpl(payloadAsMap(caseStartedEvent.getPayload()));
+                // CASE_STARTED payload is now a panel document
+                // {"working":{...},"semantic":{...},...}
+                caseContext = CaseContextImpl.fromPanelDocument(caseStartedEvent.getPayload());
               }
 
               for (EventLog eventLog : eventLogs) {
@@ -181,12 +185,25 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
                   } else {
                     caseContext.setAll(payloadAsMap(eventLog.getPayload()));
                   }
+                  // Update episodic panel
+                  String workerId = eventLog.getWorkerId();
+                  if (workerId != null) {
+                    EpisodicPanelUpdater.recordWorkerCompletion(caseContext, workerId, "COMPLETED");
+                  }
                 } else if (eventLog.getEventType() == CaseHubEventType.SUBCASE_COMPLETED) {
                   caseContext.setAll(payloadAsMap(eventLog.getPayload()));
                 } else if (eventLog.getEventType() == CaseHubEventType.MILESTONE_ACTIVATED) {
                   applyMilestoneActivatedEvent(caseContext, eventLog);
                 } else if (eventLog.getEventType() == CaseHubEventType.MILESTONE_COMPLETED) {
                   applyMilestoneCompletedEvent(caseContext, eventLog);
+                  // Update episodic panel
+                  JsonNode payload = eventLog.getPayload();
+                  if (payload != null) {
+                    String milestoneName = payload.path("milestoneName").asText(null);
+                    if (milestoneName != null) {
+                      EpisodicPanelUpdater.recordMilestoneReached(caseContext, milestoneName);
+                    }
+                  }
                 } else if (eventLog.getEventType() == CaseHubEventType.MILESTONE_SLA_VIOLATED) {
                   applyMilestoneSLAViolatedEvent(caseContext, eventLog);
                 } else {
@@ -194,6 +211,9 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
                       "Unexpected event type in rebuildStateContext: %s", eventLog.getEventType());
                 }
               }
+              // Re-freeze semantic and episodic panels (they were frozen at case start)
+              caseContext.freezePanel(ContextPanel.SEMANTIC);
+              caseContext.freezePanel(ContextPanel.EPISODIC);
               return caseContext;
             });
   }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/recovery/DefaultWorkerExecutionRecoveryService.java
@@ -183,6 +183,10 @@ public class DefaultWorkerExecutionRecoveryService implements WorkerExecutionRec
                       applyTopLevelChanges(caseContext, contextChanges);
                     }
                   } else {
+                    LOG.warnf(
+                        "WORKER_EXECUTION_COMPLETED has no contextChanges metadata — "
+                            + "falling back to payload merge for caseId=%s seq=%s",
+                        caseId, eventLog.getSeq());
                     caseContext.setAll(payloadAsMap(eventLog.getPayload()));
                   }
                   // Update episodic panel

--- a/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ActionGateIntegrationTest.java
@@ -280,14 +280,14 @@ class ActionGateIntegrationTest {
       final Capability cap =
           Capability.builder()
               .name("file-sar-gate-test")
-              .inputSchema(".")
+              .inputSchema(".working")
               .outputSchema(".")
               .build();
       final Goal goal =
           Goal.builder()
               .name("filed")
               .kind(GoalKind.SUCCESS)
-              .condition(".filingResult != null")
+              .condition(".working.filingResult != null")
               .build();
       return CaseDefinition.builder()
           .namespace("test-action-gate")
@@ -316,9 +316,9 @@ class ActionGateIntegrationTest {
                   // Prevent re-triggering while gate is pending (deferred output not applied)
                   .on(
                       new ContextChangeTrigger(
-                          ".filingResult == null and .actionGateApproved == null"
-                              + " and .actionGateRejected == null"
-                              + " and .actionGateExpired == null"))
+                          ".working.filingResult == null and .working.actionGateApproved == null"
+                              + " and .working.actionGateRejected == null"
+                              + " and .working.actionGateExpired == null"))
                   .target(new CapabilityTarget(cap))
                   .build())
           .goals(goal)

--- a/runtime/src/test/java/io/casehub/engine/ActionGateResolutionTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ActionGateResolutionTest.java
@@ -221,14 +221,14 @@ class ActionGateResolutionTest {
       final Capability cap =
           Capability.builder()
               .name("resolution-gate-cap")
-              .inputSchema(".")
+              .inputSchema(".working")
               .outputSchema(".")
               .build();
       final Goal goal =
           Goal.builder()
               .name("complete")
               .kind(GoalKind.SUCCESS)
-              .condition(".gateWorkerOutput != null")
+              .condition(".working.gateWorkerOutput != null")
               .build();
       return CaseDefinition.builder()
           .namespace("test-gate-resolution")
@@ -257,9 +257,9 @@ class ActionGateResolutionTest {
                   // pendingActionGate is set (deferred output not yet applied to context)
                   .on(
                       new ContextChangeTrigger(
-                          ".gateWorkerOutput == null and .actionGateRejected == null"
-                              + " and .actionGateApproved == null"
-                              + " and .actionGateExpired == null"))
+                          ".working.gateWorkerOutput == null and .working.actionGateRejected == null"
+                              + " and .working.actionGateApproved == null"
+                              + " and .working.actionGateExpired == null"))
                   .target(new CapabilityTarget(cap))
                   .build())
           .goals(goal)

--- a/runtime/src/test/java/io/casehub/engine/AgentPipelineBean.java
+++ b/runtime/src/test/java/io/casehub/engine/AgentPipelineBean.java
@@ -52,7 +52,7 @@ public class AgentPipelineBean extends CaseHub {
     Capability fetchCap =
         Capability.builder()
             .name("fetchDocument")
-            .inputSchema("{ documentId: .documentId }")
+            .inputSchema("{ documentId: .working.documentId }")
             .outputSchema("{ data: .data, step: .step }")
             .description("Fetch document data from external API")
             .build();
@@ -60,7 +60,7 @@ public class AgentPipelineBean extends CaseHub {
     Capability sentimentCap =
         Capability.builder()
             .name("analyzeSentiment")
-            .inputSchema("{ documentId: .documentId, content: .data.content }")
+            .inputSchema("{ documentId: .working.documentId, content: .working.data.content }")
             .outputSchema("{ sentiment: .sentiment, step: .step }")
             .description("Analyze document sentiment using LLM agent")
             .build();
@@ -68,7 +68,7 @@ public class AgentPipelineBean extends CaseHub {
     Capability summaryCap =
         Capability.builder()
             .name("summarizeContent")
-            .inputSchema("{ documentId: .documentId, content: .data.content }")
+            .inputSchema("{ documentId: .working.documentId, content: .working.data.content }")
             .outputSchema("{ summary: .summary, step: .step }")
             .description("Summarize document content using LLM agent")
             .build();
@@ -76,7 +76,7 @@ public class AgentPipelineBean extends CaseHub {
     Goal goal =
         Goal.builder()
             .name("reviewComplete")
-            .condition(".step == \"summarized\"")
+            .condition(".working.step == \"summarized\"")
             .kind(GoalKind.SUCCESS)
             .description("Document review is complete with sentiment and summary")
             .build();
@@ -128,32 +128,32 @@ public class AgentPipelineBean extends CaseHub {
             Binding.builder()
                 .name("trigger-on-submitted")
                 .capability(fetchCap)
-                .on(new ContextChangeTrigger(".step == \"submitted\""))
+                .on(new ContextChangeTrigger(".working.step == \"submitted\""))
                 .build(),
             Binding.builder()
                 .name("trigger-on-fetched")
                 .capability(sentimentCap)
-                .on(new ContextChangeTrigger(".step == \"fetched\""))
+                .on(new ContextChangeTrigger(".working.step == \"fetched\""))
                 .build(),
             Binding.builder()
                 .name("trigger-on-analyzed")
                 .capability(summaryCap)
-                .on(new ContextChangeTrigger(".step == \"analyzed\""))
+                .on(new ContextChangeTrigger(".working.step == \"analyzed\""))
                 .build())
         .milestones(
             Milestone.builder()
                 .name("documentFetched")
-                .completionCriteria(".step == \"fetched\"")
+                .completionCriteria(".working.step == \"fetched\"")
                 .description("Document data has been fetched from API")
                 .build(),
             Milestone.builder()
                 .name("sentimentAnalyzed")
-                .completionCriteria(".step == \"analyzed\"")
+                .completionCriteria(".working.step == \"analyzed\"")
                 .description("Document sentiment has been analyzed")
                 .build(),
             Milestone.builder()
                 .name("contentSummarized")
-                .completionCriteria(".step == \"summarized\"")
+                .completionCriteria(".working.step == \"summarized\"")
                 .description("Document content has been summarized")
                 .build())
         .goals(goal)

--- a/runtime/src/test/java/io/casehub/engine/AgentWorkerExecutionTest.java
+++ b/runtime/src/test/java/io/casehub/engine/AgentWorkerExecutionTest.java
@@ -135,7 +135,7 @@ public class AgentWorkerExecutionTest {
           Agent.builder()
               .systemPrompt(
                   "You are a sentiment analyzer. Analyze the text and return POSITIVE, NEGATIVE, or NEUTRAL.")
-              .inputSchema("{ text: .text }")
+              .inputSchema("{ text: .working.text }")
               .outputSchema("{ sentiment: .sentiment }")
               .model(mockProvider)
               .build();
@@ -161,14 +161,16 @@ public class AgentWorkerExecutionTest {
           Binding.builder()
               .name("trigger-sentiment-analysis")
               .capability(sentimentCapability)
-              .on(new ContextChangeTrigger(new JQExpressionEvaluator(".status == \"pending\"")))
+              .on(
+                  new ContextChangeTrigger(
+                      new JQExpressionEvaluator(".working.status == \"pending\"")))
               .build();
 
       // Create goal
       Goal analysisComplete =
           new Goal(
               "analysisComplete",
-              new JQExpressionEvaluator(".status == \"analyzed\""),
+              new JQExpressionEvaluator(".working.status == \"analyzed\""),
               GoalKind.SUCCESS);
 
       // Create case definition

--- a/runtime/src/test/java/io/casehub/engine/CaseCancelSuspendResumeTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseCancelSuspendResumeTest.java
@@ -356,7 +356,7 @@ class CaseCancelSuspendResumeTest {
     private final Capability capability =
         Capability.builder()
             .name("suspendableCapability")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ result: .status }")
             .build();
 
@@ -381,7 +381,7 @@ class CaseCancelSuspendResumeTest {
               Binding.builder()
                   .name("trigger-on-active")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"active\""))
+                  .on(new ContextChangeTrigger(".working.status == \"active\""))
                   .build())
           .build();
     }

--- a/runtime/src/test/java/io/casehub/engine/CaseFaultedStateTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseFaultedStateTest.java
@@ -215,7 +215,7 @@ class CaseFaultedStateTest {
     private final Capability capability =
         Capability.builder()
             .name("alwaysFailCapability")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
@@ -242,7 +242,7 @@ class CaseFaultedStateTest {
               Binding.builder()
                   .name("trigger-on-processing")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"processing\""))
+                  .on(new ContextChangeTrigger(".working.status == \"processing\""))
                   .build())
           .build();
     }
@@ -258,21 +258,21 @@ class CaseFaultedStateTest {
     private final Capability capability =
         Capability.builder()
             .name("failureGoalCapability")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
     private final Goal failureGoal =
         Goal.builder()
             .name("processingFailed")
-            .condition(".status == \"error\"")
+            .condition(".working.status == \"error\"")
             .kind(GoalKind.FAILURE)
             .build();
 
     private final Goal successGoal =
         Goal.builder()
             .name("processingSucceeded")
-            .condition(".status == \"ok\"")
+            .condition(".working.status == \"ok\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -294,7 +294,7 @@ class CaseFaultedStateTest {
               Binding.builder()
                   .name("trigger-on-processing")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"processing\""))
+                  .on(new ContextChangeTrigger(".working.status == \"processing\""))
                   .build())
           .goals(failureGoal, successGoal)
           .completion(GoalExpression.allOf(successGoal), GoalExpression.allOf(failureGoal))

--- a/runtime/src/test/java/io/casehub/engine/CaseLifecycleCdiEventTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseLifecycleCdiEventTest.java
@@ -159,12 +159,16 @@ class CaseLifecycleCdiEventTest {
     private final Capability capability =
         Capability.builder()
             .name("do-work")
-            .inputSchema(".")
+            .inputSchema(".working")
             .outputSchema("{ done: true }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("all-done").condition(".done == true").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("all-done")
+            .condition(".working.done == true")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -185,7 +189,9 @@ class CaseLifecycleCdiEventTest {
               Binding.builder()
                   .name("fire-when-triggered")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".trigger == true and .done != true"))
+                  .on(
+                      new ContextChangeTrigger(
+                          ".working.trigger == true and .working.done != true"))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/runtime/src/test/java/io/casehub/engine/CaseLifecycleStateTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseLifecycleStateTest.java
@@ -197,7 +197,7 @@ class CaseLifecycleStateTest {
     private final Capability capability =
         Capability.builder()
             .name("idleCapability")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
@@ -218,7 +218,9 @@ class CaseLifecycleStateTest {
               Binding.builder()
                   .name("trigger-when-active")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"active\"")) // never matches "idle"
+                  .on(
+                      new ContextChangeTrigger(
+                          ".working.status == \"active\"")) // never matches "idle"
                   .build())
           .build();
     }
@@ -231,14 +233,14 @@ class CaseLifecycleStateTest {
     private final Capability capability =
         Capability.builder()
             .name("processDocumentLifecycle")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
     private final Goal successGoal =
         Goal.builder()
             .name("processingComplete")
-            .condition(".status == \"done\"")
+            .condition(".working.status == \"done\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -259,7 +261,7 @@ class CaseLifecycleStateTest {
               Binding.builder()
                   .name("trigger-on-processing")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"processing\""))
+                  .on(new ContextChangeTrigger(".working.status == \"processing\""))
                   .build())
           .goals(successGoal)
           .completion(GoalExpression.allOf(successGoal))

--- a/runtime/src/test/java/io/casehub/engine/CaseWaitingResumeTest.java
+++ b/runtime/src/test/java/io/casehub/engine/CaseWaitingResumeTest.java
@@ -122,12 +122,16 @@ class CaseWaitingResumeTest {
     private final Capability cap =
         Capability.builder()
             .name("analyse")
-            .inputSchema("{ doc: .doc }")
+            .inputSchema("{ doc: .working.doc }")
             .outputSchema("{ result: .result }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("done").condition(".result == \"done\"").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("done")
+            .condition(".working.result == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -146,7 +150,7 @@ class CaseWaitingResumeTest {
               Binding.builder()
                   .name("start")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".trigger == \"start\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"start\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/runtime/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ChoreographySelectionTest.java
@@ -116,12 +116,16 @@ class ChoreographySelectionTest {
         Capability.builder()
             .name("do-work")
             // runId flows through so workers can record their invocation against the right key
-            .inputSchema("{ trigger: .trigger, runId: .runId }")
+            .inputSchema("{ trigger: .working.trigger, runId: .working.runId }")
             .outputSchema("{ result: \"done\" }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("done").condition(".result == \"done\"").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("done")
+            .condition(".working.result == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -156,7 +160,9 @@ class ChoreographySelectionTest {
                   // Guard on .result == null: prevents re-firing after worker writes output.
                   // Without this, CONTEXT_CHANGED fires again post-completion and the binding
                   // re-evaluates while the case is still transitioning, scheduling a second worker.
-                  .on(new ContextChangeTrigger(".trigger == \"go\" and .result == null"))
+                  .on(
+                      new ContextChangeTrigger(
+                          ".working.trigger == \"go\" and .working.result == null"))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/runtime/src/test/java/io/casehub/engine/ContextChangeWhenFilterTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ContextChangeWhenFilterTest.java
@@ -115,19 +115,23 @@ class ContextChangeWhenFilterTest {
     private final Capability guardedCap =
         Capability.builder()
             .name("guarded-work")
-            .inputSchema("{ flag: .flag }")
+            .inputSchema("{ flag: .working.flag }")
             .outputSchema("{ guardedRan: true }")
             .build();
 
     private final Capability finishCap =
         Capability.builder()
             .name("finish")
-            .inputSchema("{ flag: .flag }")
+            .inputSchema("{ flag: .working.flag }")
             .outputSchema("{ done: true }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("done").condition(".done == true").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("done")
+            .condition(".working.done == true")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -162,7 +166,7 @@ class ContextChangeWhenFilterTest {
                   .on(
                       new io.casehub.api.model.ContextChangeTrigger(
                           (io.casehub.api.model.evaluator.ExpressionEvaluator) null))
-                  .when(".flag == true")
+                  .when(".working.flag == true")
                   .build(),
               Binding.builder()
                   .name("finish")

--- a/runtime/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
@@ -189,12 +189,16 @@ class ContextDiffEndToEndTest {
     private final Capability capability =
         Capability.builder()
             .name("doWork")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status, result: .result }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("done")
+            .condition(".working.status == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -213,7 +217,7 @@ class ContextDiffEndToEndTest {
               Binding.builder()
                   .name("trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .on(new ContextChangeTrigger(".working.status == \"start\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))
@@ -228,12 +232,16 @@ class ContextDiffEndToEndTest {
     private final Capability capability =
         Capability.builder()
             .name("partialUpdate")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("done")
+            .condition(".working.status == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -252,7 +260,7 @@ class ContextDiffEndToEndTest {
               Binding.builder()
                   .name("trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .on(new ContextChangeTrigger(".working.status == \"start\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/runtime/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ContextDiffEndToEndTest.java
@@ -95,15 +95,18 @@ class ContextDiffEndToEndTest {
 
     var changes = metadata.get("contextChanges");
 
-    // "status" was updated: before="start", after="done"
-    assertThat(changes.has("status")).isTrue();
-    assertThat(changes.get("status").get("before").asText()).isEqualTo("start");
-    assertThat(changes.get("status").get("after").asText()).isEqualTo("done");
+    // After panels migration, top-level diff key is "working" (the panel name).
+    // Before = working panel before worker ran; after = working panel after worker ran.
+    assertThat(changes.has("working")).isTrue();
+    var workingDiff = changes.get("working");
 
-    // "result" was added: no before, after="ok"
-    assertThat(changes.has("result")).isTrue();
-    assertThat(changes.get("result").has("before")).isFalse();
-    assertThat(changes.get("result").get("after").asText()).isEqualTo("ok");
+    // "status" was updated: before="start", after="done"
+    assertThat(workingDiff.get("before").get("status").asText()).isEqualTo("start");
+    assertThat(workingDiff.get("after").get("status").asText()).isEqualTo("done");
+
+    // "result" was added: not present before, present after
+    assertThat(workingDiff.get("before").has("result")).isFalse();
+    assertThat(workingDiff.get("after").get("result").asText()).isEqualTo("ok");
   }
 
   /**
@@ -135,7 +138,8 @@ class ContextDiffEndToEndTest {
     EventLog completedEvent = fetchCompletedEvent(caseId);
     var changes = completedEvent.getMetadata().get("contextChanges");
 
-    assertThat(changes.has("status")).isTrue();
+    // After panels, "working" panel changed (status updated); no top-level "unchanged" key.
+    assertThat(changes.has("working")).isTrue();
     assertThat(changes.has("unchanged")).isFalse();
   }
 

--- a/runtime/src/test/java/io/casehub/engine/ContextDiffNoneStrategyTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ContextDiffNoneStrategyTest.java
@@ -102,12 +102,16 @@ class ContextDiffNoneStrategyTest {
     private final Capability capability =
         Capability.builder()
             .name("doWork")
-            .inputSchema("{ status: .status }")
+            .inputSchema("{ status: .working.status }")
             .outputSchema("{ status: .status }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("done").condition(".status == \"done\"").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("done")
+            .condition(".working.status == \"done\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -126,7 +130,7 @@ class ContextDiffNoneStrategyTest {
               Binding.builder()
                   .name("trigger")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"start\""))
+                  .on(new ContextChangeTrigger(".working.status == \"start\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/runtime/src/test/java/io/casehub/engine/HumanTaskTargetDispatchTest.java
+++ b/runtime/src/test/java/io/casehub/engine/HumanTaskTargetDispatchTest.java
@@ -144,7 +144,7 @@ class HumanTaskTargetDispatchTest {
     public CaseDefinition getDefinition() {
       HumanTaskTarget target =
           HumanTaskTarget.template("irb-review-template")
-              .inputMapping("{ applicantId: .applicantId }")
+              .inputMapping("{ applicantId: .working.applicantId }")
               .build();
 
       return CaseDefinition.builder()
@@ -155,7 +155,7 @@ class HumanTaskTargetDispatchTest {
               Binding.builder()
                   .name("review-binding")
                   .humanTask(target)
-                  .on(new ContextChangeTrigger(".stage == \"review\""))
+                  .on(new ContextChangeTrigger(".working.stage == \"review\""))
                   .build())
           .build();
     }
@@ -180,7 +180,7 @@ class HumanTaskTargetDispatchTest {
               Binding.builder()
                   .name("review-binding")
                   .humanTask(target)
-                  .on(new ContextChangeTrigger(".stage == \"review\""))
+                  .on(new ContextChangeTrigger(".working.stage == \"review\""))
                   .build())
           .build();
     }
@@ -205,7 +205,7 @@ class HumanTaskTargetDispatchTest {
               Binding.builder()
                   .name("bad-binding")
                   .humanTask(target)
-                  .on(new ContextChangeTrigger(".stage == \"review\""))
+                  .on(new ContextChangeTrigger(".working.stage == \"review\""))
                   .build())
           .build();
     }
@@ -231,7 +231,7 @@ class HumanTaskTargetDispatchTest {
               Binding.builder()
                   .name("conjunction-binding")
                   .humanTask(target)
-                  .on(new ContextChangeTrigger(".stage == \"review\""))
+                  .on(new ContextChangeTrigger(".working.stage == \"review\""))
                   .build())
           .build();
     }

--- a/runtime/src/test/java/io/casehub/engine/HumanTaskTargetDispatchTest.java
+++ b/runtime/src/test/java/io/casehub/engine/HumanTaskTargetDispatchTest.java
@@ -169,7 +169,7 @@ class HumanTaskTargetDispatchTest {
       HumanTaskTarget target =
           HumanTaskTarget.inline()
               .title("IRB Review")
-              .candidateGroupsExpression(".irb.candidateGroups")
+              .candidateGroupsExpression(".working.irb.candidateGroups")
               .build();
 
       return CaseDefinition.builder()
@@ -194,7 +194,7 @@ class HumanTaskTargetDispatchTest {
       HumanTaskTarget target =
           HumanTaskTarget.inline()
               .title("Bad Groups")
-              .candidateGroupsExpression(".routing")
+              .candidateGroupsExpression(".working.routing")
               .build();
 
       return CaseDefinition.builder()
@@ -219,8 +219,8 @@ class HumanTaskTargetDispatchTest {
       HumanTaskTarget target =
           HumanTaskTarget.inline()
               .title("Conjunction")
-              .candidateGroupsExpression(".groups")
-              .candidateUsersExpression(".users")
+              .candidateGroupsExpression(".working.groups")
+              .candidateUsersExpression(".working.users")
               .build();
 
       return CaseDefinition.builder()

--- a/runtime/src/test/java/io/casehub/engine/MilestoneLifecycleTest.java
+++ b/runtime/src/test/java/io/casehub/engine/MilestoneLifecycleTest.java
@@ -279,7 +279,7 @@ class MilestoneLifecycleTest {
               Milestone.builder()
                   .name("approval")
                   .entryCriteria(".requestSubmitted == true")
-                  .completionCriteria(".approved == true")
+                  .completionCriteria(".working.approved == true")
                   .build())
           .build();
     }
@@ -296,7 +296,7 @@ class MilestoneLifecycleTest {
           .milestones(
               Milestone.builder()
                   .name("approval")
-                  .completionCriteria(".approved == true")
+                  .completionCriteria(".working.approved == true")
                   .slaDuration(java.time.Duration.ofSeconds(2))
                   .build())
           .build();
@@ -314,7 +314,7 @@ class MilestoneLifecycleTest {
           .milestones(
               Milestone.builder()
                   .name("approval")
-                  .completionCriteria(".approved == true")
+                  .completionCriteria(".working.approved == true")
                   .slaDuration(java.time.Duration.ofSeconds(2))
                   .build())
           .build();
@@ -332,7 +332,7 @@ class MilestoneLifecycleTest {
           .milestones(
               Milestone.builder()
                   .name("approval")
-                  .completionCriteria(".approved == true")
+                  .completionCriteria(".working.approved == true")
                   .slaDuration(java.time.Duration.ofHours(24))
                   .build())
           .build();
@@ -351,7 +351,7 @@ class MilestoneLifecycleTest {
               Milestone.builder()
                   .name("review")
                   .entryCriteria(".stage == \"review\"")
-                  .completionCriteria(".reviewComplete == true")
+                  .completionCriteria(".working.reviewComplete == true")
                   .build())
           .build();
     }
@@ -368,7 +368,7 @@ class MilestoneLifecycleTest {
           .milestones(
               Milestone.builder()
                   .name("approval")
-                  .completionCriteria(".approved == true")
+                  .completionCriteria(".working.approved == true")
                   .slaDuration(java.time.Duration.ofSeconds(5))
                   .build())
           .build();

--- a/runtime/src/test/java/io/casehub/engine/MilestoneLifecycleTest.java
+++ b/runtime/src/test/java/io/casehub/engine/MilestoneLifecycleTest.java
@@ -238,9 +238,11 @@ class MilestoneLifecycleTest {
     instance.getCaseContext().set(key, value);
 
     // Publish context changed event to trigger milestone evaluation
-    com.fasterxml.jackson.databind.JsonNode contextSnapshot =
-        instance.getCaseContext().asJsonNode();
-    CaseContextChangedEvent event = new CaseContextChangedEvent(instance, contextSnapshot);
+    CaseContextChangedEvent event =
+        new CaseContextChangedEvent(
+            instance,
+            instance.getCaseContext().snapshot(),
+            io.casehub.api.context.ContextPanel.WORKING);
     eventBus.publish(EventBusAddresses.CONTEXT_CHANGED, event);
   }
 

--- a/runtime/src/test/java/io/casehub/engine/MilestoneLifecycleTest.java
+++ b/runtime/src/test/java/io/casehub/engine/MilestoneLifecycleTest.java
@@ -278,7 +278,7 @@ class MilestoneLifecycleTest {
           .milestones(
               Milestone.builder()
                   .name("approval")
-                  .entryCriteria(".requestSubmitted == true")
+                  .entryCriteria(".working.requestSubmitted == true")
                   .completionCriteria(".working.approved == true")
                   .build())
           .build();
@@ -350,7 +350,7 @@ class MilestoneLifecycleTest {
           .milestones(
               Milestone.builder()
                   .name("review")
-                  .entryCriteria(".stage == \"review\"")
+                  .entryCriteria(".working.stage == \"review\"")
                   .completionCriteria(".working.reviewComplete == true")
                   .build())
           .build();

--- a/runtime/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
+++ b/runtime/src/test/java/io/casehub/engine/MultiWorkerPipelineBean.java
@@ -41,7 +41,7 @@ public class MultiWorkerPipelineBean extends CaseHub {
     Capability validateCap =
         Capability.builder()
             .name("validateDocument")
-            .inputSchema("{ documentId: .documentId, step: .step }")
+            .inputSchema("{ documentId: .working.documentId, step: .working.step }")
             .outputSchema("{ valid: .valid, step: .step }")
             .description("Validate a received document")
             .build();
@@ -49,7 +49,7 @@ public class MultiWorkerPipelineBean extends CaseHub {
     Capability enrichCap =
         Capability.builder()
             .name("enrichDocument")
-            .inputSchema("{ documentId: .documentId, valid: .valid }")
+            .inputSchema("{ documentId: .working.documentId, valid: .working.valid }")
             .outputSchema("{ enrichedData: .enrichedData, step: .step }")
             .description("Enrich a validated document with metadata")
             .build();
@@ -57,7 +57,7 @@ public class MultiWorkerPipelineBean extends CaseHub {
     Capability publishCap =
         Capability.builder()
             .name("publishDocument")
-            .inputSchema("{ documentId: .documentId, enrichedData: .enrichedData }")
+            .inputSchema("{ documentId: .working.documentId, enrichedData: .working.enrichedData }")
             .outputSchema("{ publishedUrl: .publishedUrl, step: .step }")
             .description("Publish an enriched document")
             .build();
@@ -65,7 +65,7 @@ public class MultiWorkerPipelineBean extends CaseHub {
     Goal goal =
         Goal.builder()
             .name("pipelineComplete")
-            .condition(".step == \"published\"")
+            .condition(".working.step == \"published\"")
             .kind(GoalKind.SUCCESS)
             .description("All pipeline steps completed successfully")
             .build();
@@ -146,32 +146,34 @@ public class MultiWorkerPipelineBean extends CaseHub {
             Binding.builder()
                 .name("trigger-on-received")
                 .capability(validateCap)
-                .on(new ContextChangeTrigger(".step == \"received\""))
+                .on(new ContextChangeTrigger(".working.step == \"received\""))
                 .build(),
             Binding.builder()
                 .name("trigger-on-validated")
                 .capability(enrichCap)
-                .on(new ContextChangeTrigger(".step == \"validated\" and .valid == true"))
+                .on(
+                    new ContextChangeTrigger(
+                        ".working.step == \"validated\" and .working.valid == true"))
                 .build(),
             Binding.builder()
                 .name("trigger-on-enriched")
                 .capability(publishCap)
-                .on(new ContextChangeTrigger(".step == \"enriched\""))
+                .on(new ContextChangeTrigger(".working.step == \"enriched\""))
                 .build())
         .milestones(
             Milestone.builder()
                 .name("documentValidated")
-                .completionCriteria(".step == \"validated\"")
+                .completionCriteria(".working.step == \"validated\"")
                 .description("Document has been validated")
                 .build(),
             Milestone.builder()
                 .name("documentEnriched")
-                .completionCriteria(".step == \"enriched\"")
+                .completionCriteria(".working.step == \"enriched\"")
                 .description("Document has been enriched")
                 .build(),
             Milestone.builder()
                 .name("documentPublished")
-                .completionCriteria(".step == \"published\"")
+                .completionCriteria(".working.step == \"published\"")
                 .description("Document has been published")
                 .build())
         .goals(goal)

--- a/runtime/src/test/java/io/casehub/engine/OrchestrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/OrchestrationTest.java
@@ -128,14 +128,14 @@ class OrchestrationTest {
     private final Capability cap =
         Capability.builder()
             .name("analyse")
-            .inputSchema("{ doc: .doc }")
+            .inputSchema("{ doc: .working.doc }")
             .outputSchema("{ analysis: \"complete\" }")
             .build();
 
     private final Goal goal =
         Goal.builder()
             .name("done")
-            .condition(".trigger == \"ready\"")
+            .condition(".working.trigger == \"ready\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -156,7 +156,7 @@ class OrchestrationTest {
               Binding.builder()
                   .name("start")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".trigger == \"go\""))
+                  .on(new ContextChangeTrigger(".working.trigger == \"go\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/runtime/src/test/java/io/casehub/engine/ScheduleTriggerSimpleTest.java
+++ b/runtime/src/test/java/io/casehub/engine/ScheduleTriggerSimpleTest.java
@@ -348,7 +348,7 @@ class ScheduleTriggerSimpleTest {
               .name("conditional-work")
               .capability(cap)
               .on(ScheduleTrigger.delay(Duration.ofSeconds(2)))
-              .when(new JQExpressionEvaluator(".status == \"ready\""))
+              .when(new JQExpressionEvaluator(".working.status == \"ready\""))
               .build();
 
       return CaseDefinition.builder()
@@ -391,7 +391,7 @@ class ScheduleTriggerSimpleTest {
               .name("conditional-not-met-work")
               .capability(cap)
               .on(ScheduleTrigger.delay(Duration.ofSeconds(2)))
-              .when(new JQExpressionEvaluator(".status == \"ready\""))
+              .when(new JQExpressionEvaluator(".working.status == \"ready\""))
               .build();
 
       return CaseDefinition.builder()
@@ -434,7 +434,7 @@ class ScheduleTriggerSimpleTest {
               .name("conditional-becomes-ready-work")
               .capability(cap)
               .on(ScheduleTrigger.delay(Duration.ofSeconds(2)))
-              .when(new JQExpressionEvaluator(".status == \"ready\""))
+              .when(new JQExpressionEvaluator(".working.status == \"ready\""))
               .build();
 
       return CaseDefinition.builder()
@@ -477,7 +477,7 @@ class ScheduleTriggerSimpleTest {
               .name("conditional-becomes-blocked-work")
               .capability(cap)
               .on(ScheduleTrigger.delay(Duration.ofSeconds(2)))
-              .when(new JQExpressionEvaluator(".status == \"ready\""))
+              .when(new JQExpressionEvaluator(".working.status == \"ready\""))
               .build();
 
       return CaseDefinition.builder()
@@ -594,7 +594,7 @@ class ScheduleTriggerSimpleTest {
           Goal.builder()
               .name("complete")
               .kind(GoalKind.SUCCESS)
-              .condition(new JQExpressionEvaluator(".workDone == true"))
+              .condition(new JQExpressionEvaluator(".working.workDone == true"))
               .build();
 
       return CaseDefinition.builder()

--- a/runtime/src/test/java/io/casehub/engine/SignalDedupExtendedTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SignalDedupExtendedTest.java
@@ -332,7 +332,7 @@ public class SignalDedupExtendedTest {
     private final Capability eventCapability =
         Capability.builder()
             .name("processEventDedup")
-            .inputSchema("{ event: .event, id: .id }")
+            .inputSchema("{ event: .working.event, id: .working.id }")
             .outputSchema("{ eventResult: .eventResult }")
             .build();
 
@@ -363,7 +363,7 @@ public class SignalDedupExtendedTest {
               Binding.builder()
                   .name("on-event-dedup")
                   .capability(eventCapability)
-                  .on(new ContextChangeTrigger(".event != null"))
+                  .on(new ContextChangeTrigger(".working.event != null"))
                   .build())
           .build();
     }
@@ -379,14 +379,14 @@ public class SignalDedupExtendedTest {
     private final Capability eventCapability =
         Capability.builder()
             .name("processEventDedupGoal")
-            .inputSchema("{ event: .event, id: .id }")
+            .inputSchema("{ event: .working.event, id: .working.id }")
             .outputSchema("{ eventResult: .eventResult }")
             .build();
 
     private final Goal doneGoal =
         Goal.builder()
             .name("eventProcessedGoal")
-            .condition(".eventResult == \"processed\"")
+            .condition(".working.eventResult == \"processed\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -417,7 +417,7 @@ public class SignalDedupExtendedTest {
               Binding.builder()
                   .name("on-event-dedup-goal")
                   .capability(eventCapability)
-                  .on(new ContextChangeTrigger(".event != null"))
+                  .on(new ContextChangeTrigger(".working.event != null"))
                   .build())
           .goals(doneGoal)
           .completion(GoalExpression.allOf(doneGoal))

--- a/runtime/src/test/java/io/casehub/engine/SignalPersistenceAndDedupTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SignalPersistenceAndDedupTest.java
@@ -271,7 +271,7 @@ public class SignalPersistenceAndDedupTest {
     private final Capability paymentCapability =
         Capability.builder()
             .name("processPayment")
-            .inputSchema("{ payment: .payment }")
+            .inputSchema("{ payment: .working.payment }")
             .outputSchema("{ status: .status, lastProcessedAmount: .lastProcessedAmount }")
             .build();
 
@@ -300,7 +300,7 @@ public class SignalPersistenceAndDedupTest {
               Binding.builder()
                   .name("on-payment-received")
                   .capability(paymentCapability)
-                  .on(new ContextChangeTrigger(".payment != null"))
+                  .on(new ContextChangeTrigger(".working.payment != null"))
                   .build())
           .build();
     }

--- a/runtime/src/test/java/io/casehub/engine/SignalTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SignalTest.java
@@ -232,14 +232,14 @@ public class SignalTest {
     private final Capability paymentCapability =
         Capability.builder()
             .name("processPayment")
-            .inputSchema("{ payment: .payment, orderId: .orderId }")
+            .inputSchema("{ payment: .working.payment, orderId: .working.orderId }")
             .outputSchema("{ status: .status }")
             .build();
 
     private final Goal paidGoal =
         Goal.builder()
             .name("paymentProcessed")
-            .condition(".status == \"paid\"")
+            .condition(".working.status == \"paid\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -271,7 +271,7 @@ public class SignalTest {
               Binding.builder()
                   .name("on-payment-received")
                   .capability(paymentCapability)
-                  .on(new ContextChangeTrigger(".payment != null"))
+                  .on(new ContextChangeTrigger(".working.payment != null"))
                   .build())
           .goals(paidGoal)
           .completion(GoalExpression.allOf(paidGoal))
@@ -292,21 +292,21 @@ public class SignalTest {
     private final Capability paymentCapability =
         Capability.builder()
             .name("processPayment2")
-            .inputSchema("{ paymentApproved: .paymentApproved }")
+            .inputSchema("{ paymentApproved: .working.paymentApproved }")
             .outputSchema("{ paymentProcessed: .paymentProcessed }")
             .build();
 
     private final Capability documentCapability =
         Capability.builder()
             .name("processDocument2")
-            .inputSchema("{ documentUploaded: .documentUploaded }")
+            .inputSchema("{ documentUploaded: .working.documentUploaded }")
             .outputSchema("{ documentProcessed: .documentProcessed }")
             .build();
 
     private final Goal allDoneGoal =
         Goal.builder()
             .name("allDone")
-            .condition(".paymentProcessed == true and .documentProcessed == true")
+            .condition(".working.paymentProcessed == true and .working.documentProcessed == true")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -340,12 +340,12 @@ public class SignalTest {
               Binding.builder()
                   .name("on-payment-approved")
                   .capability(paymentCapability)
-                  .on(new ContextChangeTrigger(".paymentApproved != null"))
+                  .on(new ContextChangeTrigger(".working.paymentApproved != null"))
                   .build(),
               Binding.builder()
                   .name("on-document-uploaded")
                   .capability(documentCapability)
-                  .on(new ContextChangeTrigger(".documentUploaded != null"))
+                  .on(new ContextChangeTrigger(".working.documentUploaded != null"))
                   .build())
           .goals(allDoneGoal)
           .completion(GoalExpression.allOf(allDoneGoal))

--- a/runtime/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
+++ b/runtime/src/test/java/io/casehub/engine/SimpleCaseHubBean.java
@@ -40,7 +40,7 @@ public class SimpleCaseHubBean extends CaseHub {
     Capability capability =
         Capability.builder()
             .name("processDocument")
-            .inputSchema("{ documentId: .documentId, status: .status }")
+            .inputSchema("{ documentId: .working.documentId, status: .working.status }")
             .outputSchema("{ processedDocument: ., status: .status }")
             .description("Process a document from the case context")
             .build();
@@ -48,7 +48,7 @@ public class SimpleCaseHubBean extends CaseHub {
     Goal goal =
         Goal.builder()
             .name("documentProcessingComplete")
-            .condition(".status == \"processed\"")
+            .condition(".working.status == \"processed\"")
             .kind(GoalKind.SUCCESS)
             .description("Goal achieved when document processing is complete")
             .build();
@@ -94,12 +94,12 @@ public class SimpleCaseHubBean extends CaseHub {
             Binding.builder()
                 .name("trigger-on-processing-status")
                 .capability(capability)
-                .on(new ContextChangeTrigger(".status == \"processing\""))
+                .on(new ContextChangeTrigger(".working.status == \"processing\""))
                 .build())
         .milestones(
             Milestone.builder()
                 .name("documentProcessed")
-                .completionCriteria(".status == \"processed\"")
+                .completionCriteria(".working.status == \"processed\"")
                 .description("Milestone reached when document is processed")
                 .build())
         .goals(goal)

--- a/runtime/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SpiWiringIntegrationTest.java
@@ -545,7 +545,7 @@ class SpiWiringIntegrationTest {
       Capability capability =
           Capability.builder()
               .name("external-task")
-              .inputSchema("{ taskId: .taskId }")
+              .inputSchema("{ taskId: .working.taskId }")
               .outputSchema("{ result: . }")
               .build();
 
@@ -558,7 +558,7 @@ class SpiWiringIntegrationTest {
               Binding.builder()
                   .name("trigger-on-pending")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"pending\""))
+                  .on(new ContextChangeTrigger(".working.status == \"pending\""))
                   .build())
           .build();
     }
@@ -581,7 +581,7 @@ class SpiWiringIntegrationTest {
       Capability capability =
           Capability.builder()
               .name("recordContext")
-              .inputSchema("{ documentId: .documentId }")
+              .inputSchema("{ documentId: .working.documentId }")
               .outputSchema("{ recorded: true }")
               .build();
 
@@ -609,7 +609,7 @@ class SpiWiringIntegrationTest {
               Binding.builder()
                   .name("trigger-on-processing")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"processing\""))
+                  .on(new ContextChangeTrigger(".working.status == \"processing\""))
                   .build())
           .build();
     }

--- a/runtime/src/test/java/io/casehub/engine/SubCaseOutputMappingRecoveryTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SubCaseOutputMappingRecoveryTest.java
@@ -108,7 +108,8 @@ public class SubCaseOutputMappingRecoveryTest {
     final UUID childId = createChildCase(parentId, "approved", Map.of("key", "value", "score", 95));
 
     // 3. Write SUBCASE_STARTED event
-    String outputMapping = "{ approval: .result, data: .processedData }";
+    // After panels migration, outputMapping evaluates against child's panel document
+    String outputMapping = "{ approval: .working.result, data: .working.processedData }";
     writeSubCaseStartedEvent(parentId, childId, outputMapping);
 
     // 4. Apply outputMapping to parent IN MEMORY (simulating SubCaseCompletionListener)
@@ -204,7 +205,9 @@ public class SubCaseOutputMappingRecoveryTest {
     caseStarted.setEventType(CaseHubEventType.CASE_STARTED);
     caseStarted.setStreamType(EventStreamType.CASE);
     caseStarted.setTimestamp(Instant.now());
-    caseStarted.setPayload(OBJECT_MAPPER.valueToTree(Map.of("orderId", orderId)));
+    // After panels migration, CASE_STARTED payload is a panel document
+    caseStarted.setPayload(OBJECT_MAPPER.valueToTree(
+        Map.of("working", Map.of("orderId", orderId), "semantic", Map.of(), "episodic", Map.of())));
     run(() -> eventLogRepository.append(caseStarted, TenancyConstants.DEFAULT_TENANT_ID));
 
     caseInstanceCache.put(savedParent);
@@ -390,8 +393,10 @@ public class SubCaseOutputMappingRecoveryTest {
     caseStarted.setEventType(CaseHubEventType.CASE_STARTED);
     caseStarted.setStreamType(EventStreamType.CASE);
     caseStarted.setTimestamp(Instant.now());
-    caseStarted.setPayload(
-        OBJECT_MAPPER.valueToTree(Map.of("orderId", orderId, "temp", tempValue)));
+    // After panels migration, CASE_STARTED payload is a panel document
+    caseStarted.setPayload(OBJECT_MAPPER.valueToTree(
+        Map.of("working", Map.of("orderId", orderId, "temp", tempValue),
+               "semantic", Map.of(), "episodic", Map.of())));
     run(() -> eventLogRepository.append(caseStarted, TenancyConstants.DEFAULT_TENANT_ID));
 
     caseInstanceCache.put(saved);

--- a/runtime/src/test/java/io/casehub/engine/WorkBrokerEndToEndTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkBrokerEndToEndTest.java
@@ -97,19 +97,23 @@ class WorkBrokerEndToEndTest {
     private final Capability stage1Cap =
         Capability.builder()
             .name("process")
-            .inputSchema("{ stage: .stage }")
+            .inputSchema("{ stage: .working.stage }")
             .outputSchema("{ stage: \"processed\" }")
             .build();
 
     private final Capability stage2Cap =
         Capability.builder()
             .name("finalise")
-            .inputSchema("{ stage: .stage }")
+            .inputSchema("{ stage: .working.stage }")
             .outputSchema("{ stage: \"final\" }")
             .build();
 
     private final Goal goal =
-        Goal.builder().name("done").condition(".stage == \"final\"").kind(GoalKind.SUCCESS).build();
+        Goal.builder()
+            .name("done")
+            .condition(".working.stage == \"final\"")
+            .kind(GoalKind.SUCCESS)
+            .build();
 
     @Override
     public CaseDefinition getDefinition() {
@@ -142,12 +146,12 @@ class WorkBrokerEndToEndTest {
               Binding.builder()
                   .name("start-process")
                   .capability(stage1Cap)
-                  .on(new ContextChangeTrigger(".stage == \"raw\""))
+                  .on(new ContextChangeTrigger(".working.stage == \"raw\""))
                   .build(),
               Binding.builder()
                   .name("start-finalise")
                   .capability(stage2Cap)
-                  .on(new ContextChangeTrigger(".stage == \"processed\""))
+                  .on(new ContextChangeTrigger(".working.stage == \"processed\""))
                   .build())
           .goals(goal)
           .completion(GoalExpression.allOf(goal))

--- a/runtime/src/test/java/io/casehub/engine/WorkerIdempotencyTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerIdempotencyTest.java
@@ -619,7 +619,7 @@ public class WorkerIdempotencyTest {
     private final Capability capability =
         Capability.builder()
             .name("idempotencyCapability")
-            .inputSchema("{ task: .task, taskId: .taskId }")
+            .inputSchema("{ task: .working.task, taskId: .working.taskId }")
             .outputSchema("{ taskResult: .taskResult }")
             .build();
 
@@ -652,7 +652,7 @@ public class WorkerIdempotencyTest {
               Binding.builder()
                   .name("on-task")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".task != null"))
+                  .on(new ContextChangeTrigger(".working.task != null"))
                   .build())
           .build();
     }
@@ -675,14 +675,14 @@ public class WorkerIdempotencyTest {
     private final Capability alphaCapability =
         Capability.builder()
             .name("alphaCapability")
-            .inputSchema("{ alpha: .alpha }")
+            .inputSchema("{ alpha: .working.alpha }")
             .outputSchema("{ alphaResult: .alphaResult }")
             .build();
 
     private final Capability betaCapability =
         Capability.builder()
             .name("betaCapability")
-            .inputSchema("{ beta: .beta }")
+            .inputSchema("{ beta: .working.beta }")
             .outputSchema("{ betaResult: .betaResult }")
             .build();
 
@@ -716,12 +716,12 @@ public class WorkerIdempotencyTest {
               Binding.builder()
                   .name("on-alpha")
                   .capability(alphaCapability)
-                  .on(new ContextChangeTrigger(".alpha != null"))
+                  .on(new ContextChangeTrigger(".working.alpha != null"))
                   .build(),
               Binding.builder()
                   .name("on-beta")
                   .capability(betaCapability)
-                  .on(new ContextChangeTrigger(".beta != null"))
+                  .on(new ContextChangeTrigger(".working.beta != null"))
                   .build())
           .build();
     }

--- a/runtime/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerRetryExtendedTest.java
@@ -455,14 +455,14 @@ public class WorkerRetryExtendedTest {
     private final Capability capability =
         Capability.builder()
             .name("flexibleRetryCapability")
-            .inputSchema("{ taskId: .taskId, status: .status }")
+            .inputSchema("{ taskId: .working.taskId, status: .working.status }")
             .outputSchema("{ status: .status, taskId: .taskId }")
             .build();
 
     private final Goal doneGoal =
         Goal.builder()
             .name("flexRetryDone")
-            .condition(".status == \"processed\"")
+            .condition(".working.status == \"processed\"")
             .kind(GoalKind.SUCCESS)
             .build();
 
@@ -498,7 +498,7 @@ public class WorkerRetryExtendedTest {
               Binding.builder()
                   .name("on-pending")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"pending\""))
+                  .on(new ContextChangeTrigger(".working.status == \"pending\""))
                   .build())
           .goals(doneGoal)
           .completion(GoalExpression.allOf(doneGoal))
@@ -519,7 +519,7 @@ public class WorkerRetryExtendedTest {
     private final Capability capability =
         Capability.builder()
             .name("signalRetryCapability")
-            .inputSchema("{ request: .request, taskId: .taskId }")
+            .inputSchema("{ request: .working.request, taskId: .working.taskId }")
             .outputSchema("{ status: .status }")
             .build();
 
@@ -554,7 +554,7 @@ public class WorkerRetryExtendedTest {
               Binding.builder()
                   .name("on-request")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".request != null"))
+                  .on(new ContextChangeTrigger(".working.request != null"))
                   .build())
           .build();
     }
@@ -575,14 +575,14 @@ public class WorkerRetryExtendedTest {
     private final Capability alphaCapability =
         Capability.builder()
             .name("alphaRetryCapability")
-            .inputSchema("{ alpha: .alpha }")
+            .inputSchema("{ alpha: .working.alpha }")
             .outputSchema("{ alphaResult: .alphaResult }")
             .build();
 
     private final Capability betaCapability =
         Capability.builder()
             .name("betaRetryCapability")
-            .inputSchema("{ beta: .beta }")
+            .inputSchema("{ beta: .working.beta }")
             .outputSchema("{ betaResult: .betaResult }")
             .build();
 
@@ -621,12 +621,12 @@ public class WorkerRetryExtendedTest {
               Binding.builder()
                   .name("on-alpha-ready")
                   .capability(alphaCapability)
-                  .on(new ContextChangeTrigger(".alpha == \"ready\""))
+                  .on(new ContextChangeTrigger(".working.alpha == \"ready\""))
                   .build(),
               Binding.builder()
                   .name("on-beta-ready")
                   .capability(betaCapability)
-                  .on(new ContextChangeTrigger(".beta == \"ready\""))
+                  .on(new ContextChangeTrigger(".working.beta == \"ready\""))
                   .build())
           .build();
     }

--- a/runtime/src/test/java/io/casehub/engine/WorkerRetryTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerRetryTest.java
@@ -93,7 +93,7 @@ public class WorkerRetryTest {
     Capability capability =
         Capability.builder()
             .name("processDocument")
-            .inputSchema("{ documentId: .documentId, status: .status }")
+            .inputSchema("{ documentId: .working.documentId, status: .working.status }")
             .outputSchema("{ processedDocument: ., status: .status }")
             .description("Process a document from the case context")
             .build();
@@ -101,7 +101,7 @@ public class WorkerRetryTest {
     Goal goal =
         Goal.builder()
             .name("documentProcessingComplete")
-            .condition(".status == \"processed\"")
+            .condition(".working.status == \"processed\"")
             .kind(GoalKind.SUCCESS)
             .description("Goal achieved when document processing is complete")
             .build();
@@ -146,12 +146,12 @@ public class WorkerRetryTest {
               Binding.builder()
                   .name("trigger-on-processing-status")
                   .capability(capability)
-                  .on(new ContextChangeTrigger(".status == \"processing\""))
+                  .on(new ContextChangeTrigger(".working.status == \"processing\""))
                   .build())
           .milestones(
               Milestone.builder()
                   .name("documentProcessed")
-                  .completionCriteria(".status == \"processed\"")
+                  .completionCriteria(".working.status == \"processed\"")
                   .description("Milestone reached when document is processed")
                   .build())
           .goals(goal)

--- a/runtime/src/test/java/io/casehub/engine/WorkerScheduleDedupTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerScheduleDedupTest.java
@@ -283,7 +283,7 @@ public class WorkerScheduleDedupTest {
     private final Capability capability =
         Capability.builder()
             .name("dedupCapability")
-            .inputSchema("{ documentId: .documentId, status: .status }")
+            .inputSchema("{ documentId: .working.documentId, status: .working.status }")
             .outputSchema("{ status: .status, processedDocument: .processedDocument }")
             .build();
 

--- a/runtime/src/test/java/io/casehub/engine/WorkerTimeoutTest.java
+++ b/runtime/src/test/java/io/casehub/engine/WorkerTimeoutTest.java
@@ -192,7 +192,7 @@ class WorkerTimeoutTest {
               Binding.builder()
                   .name("trigger-fast-worker")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".input != null"))
+                  .on(new ContextChangeTrigger(".working.input != null"))
                   .build())
           .build();
     }
@@ -245,7 +245,7 @@ class WorkerTimeoutTest {
               Binding.builder()
                   .name("trigger-slow-worker-default")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".input != null"))
+                  .on(new ContextChangeTrigger(".working.input != null"))
                   .build())
           .build();
     }
@@ -295,7 +295,7 @@ class WorkerTimeoutTest {
               Binding.builder()
                   .name("trigger-slow-worker-custom")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".input != null"))
+                  .on(new ContextChangeTrigger(".working.input != null"))
                   .build())
           .build();
     }
@@ -348,7 +348,7 @@ class WorkerTimeoutTest {
               Binding.builder()
                   .name("trigger-fast-worker-short")
                   .capability(cap)
-                  .on(new ContextChangeTrigger(".input != null"))
+                  .on(new ContextChangeTrigger(".working.input != null"))
                   .build())
           .build();
     }

--- a/runtime/src/test/java/io/casehub/engine/context/MapCaseFileTest.java
+++ b/runtime/src/test/java/io/casehub/engine/context/MapCaseFileTest.java
@@ -150,15 +150,14 @@ class MapCaseFileTest {
     }
 
     @Test
-    @DisplayName("snapshot is an independent copy and preserves MapCaseFile type")
-    void snapshot_isIndependentAndPreservesType() {
+    @DisplayName("snapshot is an independent copy")
+    void snapshot_isIndependentCopy() {
       final var map = new MapCaseFile();
       map.put("k", "v1");
       final var snap = map.snapshot();
       map.put("k", "v2");
       assertThat(snap.getString("k")).isEqualTo("v1");
       assertThat(map.getString("k")).isEqualTo("v2");
-      assertThat(snap).isInstanceOf(MapCaseFile.class);
     }
 
     @Test

--- a/runtime/src/test/java/io/casehub/engine/internal/context/CaseContextImplTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/context/CaseContextImplTest.java
@@ -22,6 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
+import io.casehub.api.context.ReadablePanel;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -743,13 +747,16 @@ class CaseContextImplTest {
   class JsonNodeTests {
 
     @Test
-    @DisplayName("asJsonNode returns an object node with all entries")
+    @DisplayName("asJsonNode returns an object node with working panel present")
     void asJsonNode_returnsObjectNode() {
       final var ctx = new CaseContextImpl(Map.of("status", "active", "count", 3));
       final var node = ctx.asJsonNode();
       assertNotNull(node);
-      assertEquals("active", node.get("status").asText());
-      assertEquals(3, node.get("count").asInt());
+      // After panel restructure, values are under the "working" key
+      final var working = node.get("working");
+      assertNotNull(working, "working panel must be present in asJsonNode()");
+      assertEquals("active", working.get("status").asText());
+      assertEquals(3, working.get("count").asInt());
     }
 
     @Test
@@ -818,6 +825,127 @@ class CaseContextImplTest {
       assertNotNull(json);
       assertTrue(json.contains("status"), "toString should contain the key");
       assertTrue(json.contains("ok"), "toString should contain the value");
+    }
+  }
+
+  // ================================================================== //
+  //  Panel API                                                          //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("panel API")
+  class PanelApiTests {
+
+    @Test
+    @DisplayName("panel() returns working panel with flat-API values")
+    void panel_returnsWorkingPanel() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      ctx.set("result", "done");
+      ReadablePanel p = ctx.panel(ContextPanel.WORKING);
+      assertEquals("done", p.get("result"));
+      assertEquals(ContextPanel.WORKING, p.panelName());
+    }
+
+    @Test
+    @DisplayName("flat API delegates to working panel")
+    void flatApi_delegatesToWorkingPanel() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      ctx.set("key", "value");
+      assertEquals("value", ctx.panel(ContextPanel.WORKING).get("key"));
+    }
+
+    @Test
+    @DisplayName("asJsonNode() returns full panel document with working/semantic/episodic keys")
+    void asJsonNode_returnsPanelDocument() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      ctx.set("result", "done");
+      JsonNode doc = ctx.asJsonNode();
+      assertNotNull(doc.get("working"), "working panel must be present");
+      assertEquals("done", doc.get("working").get("result").asText());
+      assertNotNull(doc.get("semantic"), "semantic panel must be present");
+      assertNotNull(doc.get("episodic"), "episodic panel must be present");
+    }
+
+    @Test
+    @DisplayName("snapshot() includes all panels")
+    void snapshot_includesAllPanels() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      ctx.set("result", "done");
+      ctx.writablePanel(ContextPanel.SEMANTIC).set("threshold", 0.8);
+      CaseContext snap = ctx.snapshot();
+      assertNotNull(snap.asJsonNode().get("semantic"));
+      assertNotNull(snap.asJsonNode().get("episodic"));
+      assertEquals("done", snap.asJsonNode().get("working").get("result").asText());
+      assertEquals(0.8, snap.asJsonNode().get("semantic").get("threshold").asDouble());
+    }
+
+    @Test
+    @DisplayName("getVersion() delegates to working panel")
+    void getVersion_delegatesToWorkingPanel() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      long before = ctx.getVersion();
+      ctx.set("k", "v");
+      assertEquals(before + 1, ctx.getVersion());
+    }
+
+    @Test
+    @DisplayName("clear() only clears working panel; other panels unchanged")
+    void clear_onlyClearsWorkingPanel() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      ctx.set("k", "v");
+      ctx.writablePanel(ContextPanel.SEMANTIC).set("x", 1);
+      ctx.clear();
+      assertTrue(ctx.isEmpty()); // working is clear
+      assertEquals(
+          1, ctx.panel(ContextPanel.SEMANTIC).getAs("x", Integer.class)); // semantic unchanged
+    }
+
+    @Test
+    @DisplayName("applyAndDiff path is working-panel-relative (not panel-prefixed)")
+    void applyAndDiff_isWorkingPanelRelative() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      ctx.set("score", 10);
+      var diff = ctx.applyAndDiff("score", 20);
+      assertTrue(diff.isPresent());
+      String patchStr = diff.get().toString();
+      // Patch path should be /score not /working/score
+      assertTrue(patchStr.contains("/score"), "patch path should be working-panel-relative");
+      assertFalse(patchStr.contains("/working/score"), "patch path must not be panel-prefixed");
+    }
+
+    @Test
+    @DisplayName("fromPanelDocument() reconstructs working and semantic panels")
+    void fromPanelDocument_reconstructsWorkingAndSemanticPanels() throws Exception {
+      CaseContextImpl original = new CaseContextImpl();
+      original.set("result", "done");
+      original.writablePanel(ContextPanel.SEMANTIC).set("domain", "fraud");
+      JsonNode doc = original.asJsonNode();
+
+      CaseContextImpl recovered = CaseContextImpl.fromPanelDocument(doc);
+      assertEquals("done", recovered.get("result"));
+      assertEquals("fraud", recovered.panel(ContextPanel.SEMANTIC).getString("domain"));
+    }
+
+    @Test
+    @DisplayName("writablePanel() returns unfrozen panel that accepts writes")
+    void writablePanel_returnsUnfrozenPanel() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      WritablePanelImpl p = ctx.writablePanel(ContextPanel.EPISODIC);
+      assertFalse(p.isReadOnly());
+      p.set("workers", java.util.List.of());
+      assertEquals(java.util.List.of(), p.getList("workers", Object.class));
+    }
+
+    @Test
+    @DisplayName("freezePanel() makes the named panel read-only")
+    void freezePanel_makesSemanticReadOnly() {
+      CaseContextImpl ctx = new CaseContextImpl();
+      ctx.writablePanel(ContextPanel.SEMANTIC).set("key", "val");
+      ctx.freezePanel(ContextPanel.SEMANTIC);
+      assertTrue(ctx.panel(ContextPanel.SEMANTIC).isReadOnly());
+      assertThrows(
+          io.casehub.api.context.ReadOnlyPanelException.class,
+          () -> ctx.writablePanel(ContextPanel.SEMANTIC).set("key", "other"));
     }
   }
 }

--- a/runtime/src/test/java/io/casehub/engine/internal/context/EpisodicPanelIntraCaseTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/context/EpisodicPanelIntraCaseTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.context.ContextPanel;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EpisodicPanelIntraCaseTest {
+
+  @Test
+  void initBaseline_setsEmptyLists() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    EpisodicPanelUpdater.initBaseline(ctx);
+
+    var workers = ctx.writablePanel(ContextPanel.EPISODIC).getList("workers", Map.class);
+    var milestones = ctx.writablePanel(ContextPanel.EPISODIC).getList("milestones", String.class);
+    var goals = ctx.writablePanel(ContextPanel.EPISODIC).getList("goals", String.class);
+    assertNotNull(workers);
+    assertEquals(0, workers.size());
+    assertNotNull(milestones);
+    assertEquals(0, milestones.size());
+    assertNotNull(goals);
+    assertEquals(0, goals.size());
+  }
+
+  @Test
+  void recordWorkerCompletion_addsEntry() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    EpisodicPanelUpdater.initBaseline(ctx);
+
+    EpisodicPanelUpdater.recordWorkerCompletion(ctx, "extractor", "COMPLETED");
+
+    var workers = ctx.writablePanel(ContextPanel.EPISODIC).getList("workers", Map.class);
+    assertEquals(1, workers.size());
+    assertEquals("extractor", workers.get(0).get("name"));
+    assertEquals("COMPLETED", workers.get(0).get("lastOutcome"));
+    assertEquals(1, ((Number) workers.get(0).get("runs")).intValue());
+  }
+
+  @Test
+  void recordWorkerCompletion_incrementsRuns() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    EpisodicPanelUpdater.initBaseline(ctx);
+
+    EpisodicPanelUpdater.recordWorkerCompletion(ctx, "extractor", "COMPLETED");
+    EpisodicPanelUpdater.recordWorkerCompletion(ctx, "extractor", "COMPLETED");
+
+    var workers = ctx.writablePanel(ContextPanel.EPISODIC).getList("workers", Map.class);
+    assertEquals(1, workers.size()); // same worker, not duplicated
+    assertEquals(2, ((Number) workers.get(0).get("runs")).intValue());
+  }
+
+  @Test
+  void recordMilestoneReached_appendsName() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    EpisodicPanelUpdater.initBaseline(ctx);
+
+    EpisodicPanelUpdater.recordMilestoneReached(ctx, "data-ready");
+
+    var milestones = ctx.writablePanel(ContextPanel.EPISODIC).getList("milestones", String.class);
+    assertTrue(milestones.contains("data-ready"));
+  }
+
+  @Test
+  void recordMilestoneReached_notDuplicated() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    EpisodicPanelUpdater.initBaseline(ctx);
+
+    EpisodicPanelUpdater.recordMilestoneReached(ctx, "data-ready");
+    EpisodicPanelUpdater.recordMilestoneReached(ctx, "data-ready");
+
+    var milestones = ctx.writablePanel(ContextPanel.EPISODIC).getList("milestones", String.class);
+    assertEquals(1, milestones.stream().filter("data-ready"::equals).count());
+  }
+
+  @Test
+  void episodicUpdates_doNotBumpWorkingVersion() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    ctx.set("result", "done");
+    long workingVersionBefore = ctx.getVersion();
+
+    EpisodicPanelUpdater.initBaseline(ctx);
+    EpisodicPanelUpdater.recordWorkerCompletion(ctx, "worker1", "COMPLETED");
+
+    assertEquals(workingVersionBefore, ctx.getVersion()); // working version unchanged
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/context/PanelTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/context/PanelTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.context.ContextPanel;
+import io.casehub.api.context.ReadOnlyPanelException;
+import io.casehub.api.context.WritablePanel;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PanelTest {
+
+  @Test
+  void panelName_returnsConstructedName() {
+    WritablePanel p = new WritablePanelImpl(ContextPanel.WORKING);
+    assertEquals("working", p.panelName());
+  }
+
+  @Test
+  void isReadOnly_falseByDefault() {
+    assertFalse(new WritablePanelImpl("custom").isReadOnly());
+  }
+
+  @Test
+  void setAndGet_roundTrip() {
+    WritablePanel p = new WritablePanelImpl(ContextPanel.WORKING);
+    p.set("score", 42);
+    assertEquals(42, p.get("score"));
+  }
+
+  @Test
+  void getVersion_incrementsOnWrite() {
+    WritablePanel p = new WritablePanelImpl(ContextPanel.WORKING);
+    long before = p.getVersion();
+    p.set("key", "val");
+    assertEquals(before + 1, p.getVersion());
+  }
+
+  @Test
+  void getVersion_noIncrementOnNoOp() {
+    WritablePanel p = new WritablePanelImpl(ContextPanel.WORKING);
+    p.set("key", "val");
+    long before = p.getVersion();
+    p.set("key", "val"); // same value
+    assertEquals(before, p.getVersion());
+  }
+
+  @Test
+  void clear_removesAllKeys() {
+    WritablePanel p = new WritablePanelImpl(ContextPanel.WORKING);
+    p.set("a", 1).set("b", 2);
+    p.clear();
+    assertTrue(p.isEmpty());
+  }
+
+  @Test
+  void asJsonNode_representsData() {
+    WritablePanel p = new WritablePanelImpl(ContextPanel.WORKING);
+    p.set("result", "done");
+    assertEquals("done", p.asJsonNode().get("result").asText());
+  }
+
+  @Test
+  void applyAndDiff_returnsNonEmptyOnChange() {
+    WritablePanel p = new WritablePanelImpl(ContextPanel.WORKING);
+    p.set("score", 10);
+    var diff = p.applyAndDiff("score", 20);
+    assertTrue(diff.isPresent());
+  }
+
+  @Test
+  void applyAndDiff_returnsEmptyOnNoChange() {
+    WritablePanel p = new WritablePanelImpl(ContextPanel.WORKING);
+    p.set("score", 10);
+    var diff = p.applyAndDiff("score", 10);
+    assertTrue(diff.isEmpty());
+  }
+
+  @Test
+  void deepCopy_isDetached() {
+    WritablePanelImpl original = new WritablePanelImpl(ContextPanel.WORKING);
+    original.set("key", "value");
+    WritablePanelImpl copy = original.deepCopy();
+    copy.set("key", "modified");
+    assertEquals("value", original.get("key")); // original unchanged
+  }
+
+  @Test
+  void merge_copiesFromOtherPanel() {
+    WritablePanelImpl p1 = new WritablePanelImpl(ContextPanel.WORKING);
+    p1.set("a", 1);
+    WritablePanelImpl p2 = new WritablePanelImpl(ContextPanel.WORKING);
+    p2.set("b", 2);
+    p1.merge(p2);
+    assertEquals(1, p1.getAs("a", Integer.class));
+    assertEquals(2, p1.getAs("b", Integer.class));
+  }
+
+  @Test
+  void frozen_throwsOnSet() {
+    WritablePanelImpl p = new WritablePanelImpl(ContextPanel.SEMANTIC);
+    p.freeze();
+    assertThrows(ReadOnlyPanelException.class, () -> p.set("key", "val"));
+  }
+
+  @Test
+  void frozen_throwsOnSetAll() {
+    WritablePanelImpl p = new WritablePanelImpl(ContextPanel.SEMANTIC);
+    p.freeze();
+    assertThrows(ReadOnlyPanelException.class, () -> p.setAll(Map.of("k", "v")));
+  }
+
+  @Test
+  void frozen_throwsOnClear() {
+    WritablePanelImpl p = new WritablePanelImpl(ContextPanel.SEMANTIC);
+    p.freeze();
+    assertThrows(ReadOnlyPanelException.class, p::clear);
+  }
+
+  @Test
+  void frozen_allowsGet() {
+    WritablePanelImpl p = new WritablePanelImpl(ContextPanel.SEMANTIC);
+    p.set("key", "val");
+    p.freeze();
+    assertEquals("val", p.get("key")); // reads still work
+  }
+
+  @Test
+  void frozen_isReadOnlyTrue() {
+    WritablePanelImpl p = new WritablePanelImpl(ContextPanel.SEMANTIC);
+    assertFalse(p.isReadOnly());
+    p.freeze();
+    assertTrue(p.isReadOnly());
+  }
+
+  @Test
+  void notFrozen_isReadOnlyFalse() {
+    assertFalse(new WritablePanelImpl(ContextPanel.WORKING).isReadOnly());
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/context/PanelTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/context/PanelTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.casehub.api.context.ContextPanel;
 import io.casehub.api.context.ReadOnlyPanelException;
+import io.casehub.api.context.ReadablePanel;
 import io.casehub.api.context.WritablePanel;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -154,5 +155,21 @@ class PanelTest {
   @Test
   void notFrozen_isReadOnlyFalse() {
     assertFalse(new WritablePanelImpl(ContextPanel.WORKING).isReadOnly());
+  }
+
+  @Test
+  void snapshot_isDetached() {
+    WritablePanelImpl p = new WritablePanelImpl(ContextPanel.WORKING);
+    p.set("key", "original");
+    ReadablePanel snap = p.snapshot();
+    p.set("key", "modified");
+    assertEquals("original", snap.get("key")); // snapshot is unaffected
+  }
+
+  @Test
+  void snapshot_preservesPanelName() {
+    WritablePanelImpl p = new WritablePanelImpl(ContextPanel.SEMANTIC);
+    ReadablePanel snap = p.snapshot();
+    assertEquals(ContextPanel.SEMANTIC, snap.panelName());
   }
 }

--- a/runtime/src/test/java/io/casehub/engine/internal/context/PanelTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/context/PanelTest.java
@@ -172,4 +172,26 @@ class PanelTest {
     ReadablePanel snap = p.snapshot();
     assertEquals(ContextPanel.SEMANTIC, snap.panelName());
   }
+
+  @Test
+  void deepCopy_deepCopiesListsContainingMaps() {
+    WritablePanelImpl p = new WritablePanelImpl(ContextPanel.WORKING);
+    java.util.List<java.util.Map<String, Object>> workers = new java.util.ArrayList<>();
+    java.util.Map<String, Object> entry = new java.util.LinkedHashMap<>();
+    entry.put("name", "extractor");
+    entry.put("runs", 1);
+    workers.add(entry);
+    p.set("workers", workers);
+
+    WritablePanelImpl copy = p.deepCopy();
+    // Mutate original entry
+    ((java.util.Map<String, Object>) ((java.util.List<?>) p.get("workers")).get(0)).put("runs", 99);
+    // Copy should be unaffected
+    assertEquals(
+        1,
+        ((Number)
+                ((java.util.Map<?, ?>) ((java.util.List<?>) copy.get("workers")).get(0))
+                    .get("runs"))
+            .intValue());
+  }
 }

--- a/runtime/src/test/java/io/casehub/engine/internal/context/SemanticPanelTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/context/SemanticPanelTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.casehub.api.context.ContextPanel;
+import io.casehub.api.context.ReadOnlyPanelException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SemanticPanelTest {
+
+  @Test
+  void semanticPanel_populatedFromMap() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    ctx.writablePanel(ContextPanel.SEMANTIC).set("threshold", 0.8).set("domain", "fraud-check");
+    ctx.freezePanel(ContextPanel.SEMANTIC);
+
+    assertEquals(0.8, ctx.panel(ContextPanel.SEMANTIC).getAs("threshold", Double.class));
+    assertEquals("fraud-check", ctx.panel(ContextPanel.SEMANTIC).getString("domain"));
+  }
+
+  @Test
+  void semanticPanel_readOnlyAfterFreeze() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    ctx.writablePanel(ContextPanel.SEMANTIC).set("key", "val");
+    ctx.freezePanel(ContextPanel.SEMANTIC);
+
+    assertTrue(ctx.panel(ContextPanel.SEMANTIC).isReadOnly());
+    // Read still works
+    assertEquals("val", ctx.panel(ContextPanel.SEMANTIC).get("key"));
+    // Write via writablePanel throws
+    assertThrows(
+        ReadOnlyPanelException.class, () -> ctx.writablePanel(ContextPanel.SEMANTIC).set("k", "v"));
+  }
+
+  @Test
+  void semanticPanel_inAsJsonNode() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    ctx.writablePanel(ContextPanel.SEMANTIC).set("domain", "fraud-check");
+    ctx.freezePanel(ContextPanel.SEMANTIC);
+
+    var doc = ctx.asJsonNode();
+    assertEquals("fraud-check", doc.get("semantic").get("domain").asText());
+  }
+
+  @Test
+  void callSiteSemanticData_overridesDefinitionDefaults() {
+    CaseContextImpl ctx = new CaseContextImpl();
+    // Definition defaults first
+    ctx.writablePanel(ContextPanel.SEMANTIC).setAll(Map.of("threshold", 0.8, "domain", "fraud"));
+    // Call-site overrides second
+    ctx.writablePanel(ContextPanel.SEMANTIC).setAll(Map.of("threshold", 0.9));
+    ctx.freezePanel(ContextPanel.SEMANTIC);
+
+    assertEquals(0.9, ctx.panel(ContextPanel.SEMANTIC).getAs("threshold", Double.class));
+    assertEquals("fraud", ctx.panel(ContextPanel.SEMANTIC).getString("domain")); // from definition
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/ExpressionEngineRegistryTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/ExpressionEngineRegistryTest.java
@@ -56,7 +56,7 @@ class ExpressionEngineRegistryTest {
     @DisplayName("JQ — returns true when expression matches context")
     void jq_returnsTrueOnMatch() {
       final var context = new CaseContextImpl(Map.of("status", "ready"));
-      final var evaluator = new JQExpressionEvaluator(".status == \"ready\"");
+      final var evaluator = new JQExpressionEvaluator(".working.status == \"ready\"");
       assertTrue(registry.evaluate(evaluator, context));
     }
 
@@ -64,7 +64,7 @@ class ExpressionEngineRegistryTest {
     @DisplayName("JQ — returns false when expression does not match context")
     void jq_returnsFalseOnNoMatch() {
       final var context = new CaseContextImpl(Map.of("status", "pending"));
-      final var evaluator = new JQExpressionEvaluator(".status == \"ready\"");
+      final var evaluator = new JQExpressionEvaluator(".working.status == \"ready\"");
       assertFalse(registry.evaluate(evaluator, context));
     }
 

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.node.NullNode;
 import io.casehub.api.context.CaseContext;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.engine.ExpressionEngineRegistry;
 import io.casehub.api.engine.LoopControl;
 import io.casehub.api.model.Binding;
@@ -129,15 +129,15 @@ class CaseContextChangedEventHandlerRoutingTest {
 
     when(caseDefinitionRegistry.getCaseDefinition(metaModel)).thenReturn(definition);
     when(expressionEngineRegistry.evaluate(
-            any(io.casehub.api.model.evaluator.ExpressionEvaluator.class),
-            any(com.fasterxml.jackson.databind.JsonNode.class)))
+            any(io.casehub.api.model.evaluator.ExpressionEvaluator.class), any(CaseContext.class)))
         .thenReturn(true);
     when(executionManager.getActiveWorkCount(any())).thenReturn(0);
     when(capabilityHealth.probe(any(), any(), any()))
         .thenReturn(new CapabilityHealth.CapabilityStatus.Ready());
 
     final CaseContext ctx = mock(CaseContext.class);
-    when(ctx.asJsonNode()).thenReturn(NullNode.instance);
+    when(ctx.asJsonNode()).thenReturn(com.fasterxml.jackson.databind.node.NullNode.instance);
+    when(ctx.snapshot()).thenReturn(ctx);
 
     caseInstance = new CaseInstance();
     caseInstance.setUuid(UUID.randomUUID());
@@ -156,7 +156,8 @@ class CaseContextChangedEventHandlerRoutingTest {
 
     handler
         .onCaseStateContextChangedEventHandler(
-            new CaseContextChangedEvent(caseInstance, NullNode.instance))
+            new CaseContextChangedEvent(
+                caseInstance, caseInstance.getCaseContext(), ContextPanel.WORKING))
         .await()
         .indefinitely();
 
@@ -174,7 +175,8 @@ class CaseContextChangedEventHandlerRoutingTest {
 
     handler
         .onCaseStateContextChangedEventHandler(
-            new CaseContextChangedEvent(caseInstance, NullNode.instance))
+            new CaseContextChangedEvent(
+                caseInstance, caseInstance.getCaseContext(), ContextPanel.WORKING))
         .await()
         .indefinitely();
 
@@ -192,7 +194,8 @@ class CaseContextChangedEventHandlerRoutingTest {
 
     handler
         .onCaseStateContextChangedEventHandler(
-            new CaseContextChangedEvent(caseInstance, NullNode.instance))
+            new CaseContextChangedEvent(
+                caseInstance, caseInstance.getCaseContext(), ContextPanel.WORKING))
         .await()
         .indefinitely();
 
@@ -225,7 +228,8 @@ class CaseContextChangedEventHandlerRoutingTest {
 
     handler
         .onCaseStateContextChangedEventHandler(
-            new CaseContextChangedEvent(caseInstance, NullNode.instance))
+            new CaseContextChangedEvent(
+                caseInstance, caseInstance.getCaseContext(), ContextPanel.WORKING))
         .await()
         .indefinitely();
 

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandlerRoutingTest.java
@@ -207,6 +207,127 @@ class CaseContextChangedEventHandlerRoutingTest {
   }
 
   @Test
+  void listenPanel_matching_allowsBindingToFire() {
+    // Binding with listenPanel="extracted" fires when changedPanel is "extracted"
+    final Capability cap =
+        Capability.builder()
+            .name("research")
+            .inputSchema("{ q: .q }")
+            .outputSchema("{ r: .r }")
+            .build();
+    final ContextChangeTrigger panelTrigger =
+        new ContextChangeTrigger(
+            new io.casehub.api.model.evaluator.JQExpressionEvaluator("."), "extracted");
+    final Binding panelBinding =
+        Binding.builder()
+            .name("panel-binding")
+            .on(panelTrigger)
+            .target(new CapabilityTarget(cap))
+            .build();
+    final Worker worker =
+        Worker.builder()
+            .name("analyst-worker")
+            .capabilities(cap)
+            .function(input -> WorkerResult.of(java.util.Map.of()))
+            .build();
+
+    final io.casehub.engine.common.internal.model.CaseMetaModel metaModel =
+        mock(io.casehub.engine.common.internal.model.CaseMetaModel.class);
+    final CaseDefinition panelDef =
+        CaseDefinition.builder()
+            .namespace("test")
+            .name("PanelTest")
+            .version("1.0")
+            .capabilities(cap)
+            .workers(worker)
+            .bindings(panelBinding)
+            .build();
+
+    when(caseDefinitionRegistry.getCaseDefinition(metaModel)).thenReturn(panelDef);
+    when(loopControl.select(any(), any())).thenReturn(Uni.createFrom().item(List.of(panelBinding)));
+    when(agentRoutingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(AgentAssignment.assign("analyst-worker")));
+
+    final CaseContext ctx = mock(CaseContext.class);
+    when(ctx.asJsonNode()).thenReturn(com.fasterxml.jackson.databind.node.NullNode.instance);
+    when(ctx.snapshot()).thenReturn(ctx);
+
+    final CaseInstance inst = new CaseInstance();
+    inst.setUuid(UUID.randomUUID());
+    inst.setState(CaseStatus.RUNNING);
+    inst.setCaseMetaModel(metaModel);
+    inst.setCaseContext(ctx);
+
+    handler
+        .onCaseStateContextChangedEventHandler(new CaseContextChangedEvent(inst, ctx, "extracted"))
+        .await()
+        .indefinitely();
+
+    verify(eventBus).publish(eq(EventBusAddresses.WORKER_SCHEDULE), any(WorkerScheduleEvent.class));
+  }
+
+  @Test
+  void listenPanel_nonMatching_suppressesBinding() {
+    // Binding with listenPanel="extracted" must NOT fire when changedPanel is "working"
+    final Capability cap =
+        Capability.builder()
+            .name("research")
+            .inputSchema("{ q: .q }")
+            .outputSchema("{ r: .r }")
+            .build();
+    final ContextChangeTrigger panelTrigger =
+        new ContextChangeTrigger(
+            new io.casehub.api.model.evaluator.JQExpressionEvaluator("."), "extracted");
+    final Binding panelBinding =
+        Binding.builder()
+            .name("panel-binding")
+            .on(panelTrigger)
+            .target(new CapabilityTarget(cap))
+            .build();
+    final Worker worker =
+        Worker.builder()
+            .name("analyst-worker")
+            .capabilities(cap)
+            .function(input -> WorkerResult.of(java.util.Map.of()))
+            .build();
+
+    final io.casehub.engine.common.internal.model.CaseMetaModel metaModel =
+        mock(io.casehub.engine.common.internal.model.CaseMetaModel.class);
+    final CaseDefinition panelDef =
+        CaseDefinition.builder()
+            .namespace("test")
+            .name("PanelTest")
+            .version("1.0")
+            .capabilities(cap)
+            .workers(worker)
+            .bindings(panelBinding)
+            .build();
+
+    when(caseDefinitionRegistry.getCaseDefinition(metaModel)).thenReturn(panelDef);
+    // loopControl.select is never reached because the binding is filtered out before it
+    when(loopControl.select(any(), any())).thenReturn(Uni.createFrom().item(List.of()));
+
+    final CaseContext ctx = mock(CaseContext.class);
+    when(ctx.asJsonNode()).thenReturn(com.fasterxml.jackson.databind.node.NullNode.instance);
+    when(ctx.snapshot()).thenReturn(ctx);
+
+    final CaseInstance inst = new CaseInstance();
+    inst.setUuid(UUID.randomUUID());
+    inst.setState(CaseStatus.RUNNING);
+    inst.setCaseMetaModel(metaModel);
+    inst.setCaseContext(ctx);
+
+    handler
+        .onCaseStateContextChangedEventHandler(
+            new CaseContextChangedEvent(inst, ctx, ContextPanel.WORKING))
+        .await()
+        .indefinitely();
+
+    verify(eventBus, never())
+        .publish(eq(EventBusAddresses.WORKER_SCHEDULE), any(WorkerScheduleEvent.class));
+  }
+
+  @Test
   void tryProvision_provisionerHasCapability_firesWorkerStartedLifecycleEvent() {
     when(agentRoutingStrategy.select(any(), any()))
         .thenReturn(Uni.createFrom().item(AgentAssignment.unresolvable()));

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/recovery/RecoveryPanelAwareTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/recovery/RecoveryPanelAwareTest.java
@@ -15,7 +15,8 @@
  */
 package io.casehub.engine.internal.engine.recovery;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.casehub.api.context.ContextPanel;
 import io.casehub.engine.internal.context.CaseContextImpl;

--- a/runtime/src/test/java/io/casehub/engine/internal/engine/recovery/RecoveryPanelAwareTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/engine/recovery/RecoveryPanelAwareTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.engine.recovery;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.casehub.api.context.ContextPanel;
+import io.casehub.engine.internal.context.CaseContextImpl;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RecoveryPanelAwareTest {
+
+  @Test
+  void fromPanelDocument_reconstructsWorkingPanel() {
+    CaseContextImpl original = new CaseContextImpl();
+    original.set("result", "done");
+    original.set("score", 42);
+
+    var doc = original.asJsonNode();
+    CaseContextImpl recovered = CaseContextImpl.fromPanelDocument(doc);
+
+    assertEquals("done", recovered.get("result"));
+    assertEquals(42, recovered.getAs("score", Integer.class));
+  }
+
+  @Test
+  void fromPanelDocument_reconstructsSemanticPanel() {
+    CaseContextImpl original = new CaseContextImpl();
+    original.writablePanel(ContextPanel.SEMANTIC).set("threshold", 0.8);
+    original.freezePanel(ContextPanel.SEMANTIC);
+
+    var doc = original.asJsonNode();
+    CaseContextImpl recovered = CaseContextImpl.fromPanelDocument(doc);
+
+    assertEquals(0.8, recovered.panel(ContextPanel.SEMANTIC).getAs("threshold", Double.class));
+  }
+
+  @Test
+  void fromPanelDocument_reconstructsEpisodicPanel() {
+    CaseContextImpl original = new CaseContextImpl();
+    original.writablePanel(ContextPanel.EPISODIC).set("milestones", List.of("data-ready"));
+
+    var doc = original.asJsonNode();
+    CaseContextImpl recovered = CaseContextImpl.fromPanelDocument(doc);
+
+    var milestones = recovered.panel(ContextPanel.EPISODIC).getList("milestones", String.class);
+    assertTrue(milestones.contains("data-ready"));
+  }
+
+  @Test
+  void fromPanelDocument_nullPayload_returnsEmptyContext() {
+    CaseContextImpl ctx = CaseContextImpl.fromPanelDocument(null);
+    assertTrue(ctx.isEmpty()); // working panel is empty
+  }
+
+  @Test
+  void fromPanelDocument_presentsWorkingKeysThroughFlatApi() {
+    CaseContextImpl original = new CaseContextImpl();
+    original.set("result", "done");
+
+    CaseContextImpl recovered = CaseContextImpl.fromPanelDocument(original.asJsonNode());
+    // Flat API should work — delegates to working panel
+    assertEquals("done", recovered.get("result"));
+    assertEquals("done", recovered.getString("result"));
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/model/ModelBuilderTest.java
+++ b/runtime/src/test/java/io/casehub/engine/model/ModelBuilderTest.java
@@ -160,12 +160,13 @@ class ModelBuilderTest {
               .namespace("ns")
               .name("test")
               .version("1.0")
-              .completion(".status == \"done\"")
+              .completion(".working.status == \"done\"")
               .build();
       assertInstanceOf(PredicateBasedCompletion.class, def.getCompletion());
       final var pbc = (PredicateBasedCompletion) def.getCompletion();
       assertInstanceOf(JQExpressionEvaluator.class, pbc.getDoneWhen());
-      assertEquals(".status == \"done\"", ((JQExpressionEvaluator) pbc.getDoneWhen()).expression());
+      assertEquals(
+          ".working.status == \"done\"", ((JQExpressionEvaluator) pbc.getDoneWhen()).expression());
     }
 
     @Test
@@ -259,9 +260,15 @@ class ModelBuilderTest {
     @DisplayName("when(String) creates JQExpressionEvaluator")
     void whenString_createsJQEvaluator() {
       final var binding =
-          Binding.builder().name("b").capability(cap).on(trigger).when(".flag == true").build();
+          Binding.builder()
+              .name("b")
+              .capability(cap)
+              .on(trigger)
+              .when(".working.flag == true")
+              .build();
       assertInstanceOf(JQExpressionEvaluator.class, binding.getWhen());
-      assertEquals(".flag == true", ((JQExpressionEvaluator) binding.getWhen()).expression());
+      assertEquals(
+          ".working.flag == true", ((JQExpressionEvaluator) binding.getWhen()).expression());
     }
   }
 
@@ -301,10 +308,12 @@ class ModelBuilderTest {
     @Test
     @DisplayName("condition(String) creates JQExpressionEvaluator")
     void conditionString_createsJQEvaluator() {
-      final var m = Milestone.builder().name("m").completionCriteria(".done == true").build();
+      final var m =
+          Milestone.builder().name("m").completionCriteria(".working.done == true").build();
       assertInstanceOf(JQExpressionEvaluator.class, m.getCompletionCriteria());
       assertEquals(
-          ".done == true", ((JQExpressionEvaluator) m.getCompletionCriteria()).expression());
+          ".working.done == true",
+          ((JQExpressionEvaluator) m.getCompletionCriteria()).expression());
     }
 
     @Test
@@ -431,9 +440,14 @@ class ModelBuilderTest {
     @DisplayName("condition(String) creates JQExpressionEvaluator")
     void conditionString_createsJQEvaluator() {
       final var g =
-          Goal.builder().name("g").condition(".done == true").kind(GoalKind.SUCCESS).build();
+          Goal.builder()
+              .name("g")
+              .condition(".working.done == true")
+              .kind(GoalKind.SUCCESS)
+              .build();
       assertInstanceOf(JQExpressionEvaluator.class, g.getCondition());
-      assertEquals(".done == true", ((JQExpressionEvaluator) g.getCondition()).expression());
+      assertEquals(
+          ".working.done == true", ((JQExpressionEvaluator) g.getCondition()).expression());
     }
 
     @Test
@@ -650,10 +664,11 @@ class ModelBuilderTest {
     @Test
     @DisplayName("String constructor wraps expression in JQExpressionEvaluator")
     void stringConstructor_wrapsInJQEvaluator() {
-      final var trigger = new ContextChangeTrigger(".status == \"active\"");
+      final var trigger = new ContextChangeTrigger(".working.status == \"active\"");
       assertInstanceOf(JQExpressionEvaluator.class, trigger.getFilter());
       assertEquals(
-          ".status == \"active\"", ((JQExpressionEvaluator) trigger.getFilter()).expression());
+          ".working.status == \"active\"",
+          ((JQExpressionEvaluator) trigger.getFilter()).expression());
     }
 
     @Test

--- a/runtime/src/test/java/io/casehub/engine/model/ModelBuilderTest.java
+++ b/runtime/src/test/java/io/casehub/engine/model/ModelBuilderTest.java
@@ -678,6 +678,81 @@ class ModelBuilderTest {
       final var trigger = new ContextChangeTrigger(evaluator);
       assertEquals(evaluator, trigger.getFilter());
     }
+
+    @Test
+    @DisplayName("listenPanel is null when constructed without a panel name")
+    void listenPanel_nullByDefault() {
+      final var trigger = new ContextChangeTrigger(".working.result != null");
+      assertNull(trigger.getListenPanel());
+    }
+
+    @Test
+    @DisplayName("listenPanel is stored when constructed with evaluator + panel name")
+    void listenPanel_storedWhenProvided() {
+      final var evaluator = new JQExpressionEvaluator(".working.result != null");
+      final var trigger = new ContextChangeTrigger(evaluator, "extracted");
+      assertEquals("extracted", trigger.getListenPanel());
+      assertEquals(evaluator, trigger.getFilter());
+    }
+  }
+
+  // ================================================================== //
+  //  CaseDefinition panel builder                                       //
+  // ================================================================== //
+
+  @Nested
+  @DisplayName("CaseDefinition panel builder")
+  class PanelBuilderTests {
+
+    @Test
+    @DisplayName("panel(String) accumulates panel names in order")
+    void panel_accumulatesNames() {
+      final var def =
+          CaseDefinition.builder()
+              .namespace("test")
+              .name("n")
+              .version("1.0")
+              .panel("raw")
+              .panel("extracted")
+              .panel("conclusions")
+              .build();
+      assertEquals(java.util.List.of("raw", "extracted", "conclusions"), def.getPanelNames());
+    }
+
+    @Test
+    @DisplayName("panels(String...) adds multiple names in one call")
+    void panels_varargs_addsAll() {
+      final var def =
+          CaseDefinition.builder()
+              .namespace("test")
+              .name("n")
+              .version("1.0")
+              .panels("alpha", "beta", "gamma")
+              .build();
+      assertEquals(java.util.List.of("alpha", "beta", "gamma"), def.getPanelNames());
+    }
+
+    @Test
+    @DisplayName("panel() and panels() can be mixed in the same builder chain")
+    void panel_and_panels_mixed() {
+      final var def =
+          CaseDefinition.builder()
+              .namespace("test")
+              .name("n")
+              .version("1.0")
+              .panel("first")
+              .panels("second", "third")
+              .panel("fourth")
+              .build();
+      assertEquals(java.util.List.of("first", "second", "third", "fourth"), def.getPanelNames());
+    }
+
+    @Test
+    @DisplayName("panelNames is null when no panel methods are called")
+    void panelNames_nullByDefault() {
+      final var def = CaseDefinition.builder().namespace("ns").name("test").version("1.0").build();
+      assertNull(def.getPanelNames());
+    }
   }
 
   // ================================================================== //

--- a/runtime/src/test/resources/application.properties
+++ b/runtime/src/test/resources/application.properties
@@ -50,8 +50,11 @@ quarkus.index-dependency.scheduler-quartz.artifact-id=casehub-engine-scheduler-q
 
 # casehub-work-core is on the classpath (direct dep). RoundRobinStrategy requires a
 # RoutingCursorStore which has no provider in engine tests — exclude it from CDI discovery.
-# The proper fix is a @DefaultBean no-op RoutingCursorStore in casehub-work-core (casehubio/work#214).
-quarkus.arc.exclude-types=io.casehub.work.core.strategy.RoundRobinStrategy
+# casehub-platform (compile dep) pulls in MockCurrentPrincipal (@DefaultBean CurrentPrincipal).
+# casehub-engine-persistence-memory (test dep) provides DefaultTestPrincipal (@DefaultBean).
+# Both are @DefaultBean — ARC cannot resolve the ambiguity. Exclude MockCurrentPrincipal so
+# DefaultTestPrincipal wins in all test profiles.
+quarkus.arc.exclude-types=io.casehub.work.core.strategy.RoundRobinStrategy,io.casehub.platform.mock.MockCurrentPrincipal
 
 # casehub-ledger is on the engine classpath (via LedgerTraceIdProvider) but its JPA-backed
 # beans require a LedgerEntryRepository. NoOpLedgerEntryRepository (@Alternative @Priority(1))

--- a/schema/src/main/resources/schema/CaseDefinition.yaml
+++ b/schema/src/main/resources/schema/CaseDefinition.yaml
@@ -81,6 +81,45 @@ properties:
       Declares external dependencies (secrets, config maps) required by this Case definition.
       Secrets are validated at load time for fail-fast behavior.
       ConfigMaps provide non-sensitive configuration accessible via ${$config.*} in JQ.
+  semanticData:
+    type: object
+    additionalProperties: true
+    description: Static domain knowledge injected into the semantic panel at case start
+  episodic:
+    type: object
+    description: Episodic memory configuration for this case definition
+    unevaluatedProperties: false
+    properties:
+      memory:
+        type: object
+        required:
+          - domain
+          - entityId
+        unevaluatedProperties: false
+        properties:
+          domain:
+            type: string
+            description: MemoryDomain name (e.g. "fraud-check")
+          entityId:
+            type: string
+            description: JQ expression evaluated against semantic panel to resolve entity ID(s)
+          recent:
+            type: integer
+            default: 10
+            minimum: 1
+            description: Max items to return; default 10
+  panels:
+    type: array
+    description: User-defined panel names for this case definition
+    items:
+      type: object
+      required:
+        - name
+      unevaluatedProperties: false
+      properties:
+        name:
+          type: string
+          description: User-defined panel name
   spec:
     $ref: "#/$defs/CaseDefinitionSpec"
   required: [ dsl, namespace, name, version ]
@@ -373,6 +412,9 @@ $defs:
       filter:
         type: string
         description: "JQ predicate over { context, event } where event is a synthetic ContextChanged envelope"
+      listenPanel:
+        type: string
+        description: "Optional panel name; if set, binding only re-evaluates when this panel changes"
     additionalProperties: false
 
   CloudEventTrigger:

--- a/work-adapter/src/main/java/io/casehub/workadapter/PlanItemCompletionApplier.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/PlanItemCompletionApplier.java
@@ -18,6 +18,7 @@ package io.casehub.workadapter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.casehub.api.context.ContextPanel;
 import io.casehub.api.model.CapabilityTarget;
 import io.casehub.api.model.ExtensionTarget;
 import io.casehub.api.model.HumanTaskTarget;
@@ -96,7 +97,8 @@ public class PlanItemCompletionApplier {
     applyOutputMapping(item, workItem, instance);
     eventBus.publish(
         EventBusAddresses.CONTEXT_CHANGED,
-        new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+        new CaseContextChangedEvent(
+            instance, instance.getCaseContext().snapshot(), ContextPanel.WORKING));
   }
 
   private boolean applyStatus(PlanItem item, WorkItemStatus status) {

--- a/work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
+++ b/work-adapter/src/main/java/io/casehub/workadapter/WorkItemLifecycleAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.workadapter;
 
+import io.casehub.api.context.ContextPanel;
 import io.casehub.blackboard.plan.CasePlanModel;
 import io.casehub.blackboard.plan.PlanItem;
 import io.casehub.blackboard.registry.BlackboardRegistry;
@@ -137,7 +138,8 @@ public class WorkItemLifecycleAdapter {
 
     eventBus.publish(
         EventBusAddresses.CONTEXT_CHANGED,
-        new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+        new CaseContextChangedEvent(
+            instance, instance.getCaseContext().snapshot(), ContextPanel.WORKING));
   }
 
   private boolean applyGroupStatus(PlanItem item, GroupStatus status) {
@@ -213,7 +215,8 @@ public class WorkItemLifecycleAdapter {
 
     eventBus.publish(
         EventBusAddresses.CONTEXT_CHANGED,
-        new CaseContextChangedEvent(instance, instance.getCaseContext().asJsonNode()));
+        new CaseContextChangedEvent(
+            instance, instance.getCaseContext().snapshot(), ContextPanel.WORKING));
 
     LOG.infof(
         "WorkItem escalation signal: caseId=%s planItemId=%s bindingName=%s newGroups=%s",

--- a/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskPlannerIntegrationTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/HumanTaskPlannerIntegrationTest.java
@@ -78,7 +78,7 @@ class HumanTaskPlannerIntegrationTest {
               Binding.builder()
                   .name("approval-binding")
                   .humanTask(HumanTaskTarget.inline().title("Approval Required").build())
-                  .on(new ContextChangeTrigger(".status == \"pending\""))
+                  .on(new ContextChangeTrigger(".working.status == \"pending\""))
                   .build())
           .build();
     }


### PR DESCRIPTION
## Summary

Introduces named, policy-aware panels to `CaseContext`, replacing the flat `Map<String, Object>` with a structured blackboard that partitions memory by concern.

**Issues:** Closes #80, Closes #81

### Panels (#80)

Three built-in panels with typed access control:

- **Working panel** (`"working"`) — read-write; worker output, engine signals, milestone state
- **Semantic panel** (`"semantic"`) — read-only; domain knowledge injected at case start from `CaseDefinition.semanticData` and call-site augmentation
- **Episodic panel** (`"episodic"`) — engine-managed; intra-case EventLog summary + optional inter-case history from `ReactiveCaseMemoryStore`

### Interface design

- `ReadablePanel` / `WritablePanel` interfaces (separate from `CaseContext`)
- `WritablePanelImpl.freeze()` — post-init immutability without a separate wrapper class
- `CaseContext.panel(String name): ReadablePanel` — external access
- `CaseContextImpl.writablePanel(String name)` — engine-internal writes
- `CaseContextImpl.fromPanelDocument(JsonNode)` — recovery factory

### Breaking changes

- `CaseContext.asJsonNode()` now returns the full panel document `{"working":{...},"semantic":{...},"episodic":{...}}`
- All JQ string expressions must use panel-qualified paths: `.working.key`, `.semantic.key`, `.episodic.key`
- Lambda `Predicate<CaseContext>` expressions are unchanged — `context.get("key")` still delegates to working panel
- `CaseContextChangedEvent` changed from `JsonNode contextSnapshot` to `CaseContext contextSnapshot` + `String changedPanel`

### User-defined panels (#81)

- `CaseDefinition.panels[]` — declare named read-write panels in YAML or DSL
- `ContextChangeTrigger.listenPanel` — binding subscribes only to a specific panel's changes
- Panel-scoped Vert.x addresses (`casehub.context.changed.{name}`) for external subscribers

### Recovery

`DefaultWorkerExecutionRecoveryService.rebuildStateContext()` rewritten to use `fromPanelDocument()` — reconstructs all panels from the CASE_STARTED EventLog payload rather than flattening to a single map.

## Test plan

- [ ] Unit tests: `PanelTest`, `CaseContextImplTest`, `SemanticPanelTest`, `EpisodicPanelIntraCaseTest`, `RecoveryPanelAwareTest`, `CaseDefinitionYamlMapperTest`
- [ ] JQ migration: 47 test files across api, common, runtime, blackboard, work-adapter updated
- [ ] `@QuarkusTest` suites blocked by pre-existing casehub-ledger field-shadowing issue (ledger#134)

## Follow-up

- engine#464 — revisit "panel" terminology after implementation
- engine#465 — validate panel event model for Drools WorkingMemoryBridge (#446)
- engine#466 — review casehub-platform compile scope in runtime/pom.xml
- ledger#134 — LedgerEntry.tenancyId field shadowing blocks @QuarkusTest suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)