### PR TITLE
fix: multi-tenancy batch — tenancyId propagation, EntityManager qualifier, SNAPSHOT cascade (#460, #459, #450, #429)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,15 @@ quarkus.flyway.migrate-at-start=false
 ```
 And add a `NoOpLedgerEntryRepository` (`@Alternative @Priority(1) @ApplicationScoped`) to the module's test sources — see `engine/src/test/java/io/casehub/engine/NoOpLedgerEntryRepository.java`. Applied to: `engine`, `casehub-blackboard`, `casehub-resilience`, `casehub-work-adapter`.
 
+**Modules with `casehub-engine-ledger` as a test dependency** (e.g. `casehub-engine` runtime) must additionally exclude the ledger capture beans from CDI — they observe `CaseLifecycleEvent` and call `LedgerSequenceAllocator` which requires a `ledger_subject_sequence` table not present in the runtime test schema. Without this, cases time out silently with no direct error:
+```properties
+quarkus.arc.exclude-types=\
+  ...,\
+  io.casehub.ledger.service.CaseLedgerEventCapture,\
+  io.casehub.ledger.service.WorkerDecisionEventCapture
+```
+See protocol PP-20260610-18a084.
+
 Domain objects (`CaseMetaModel`, `CaseInstance`, `EventLog`) are plain POJOs. The `id` field
 is public (`public Long id`) and set by the repository after save.
 

--- a/blackboard/src/main/java/io/casehub/blackboard/event/PlanItemCompletedEvent.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/event/PlanItemCompletedEvent.java
@@ -37,5 +37,7 @@ import java.util.UUID;
  * @param planItemId the exact PlanItem id that just completed
  * @param trackingKey the external identifier that triggered completion (workerName for
  *     CapabilityTarget; childCaseId string for SubCaseTarget)
+ * @param tenancyId the tenant that owns the case — available without a cross-tenant lookup
  */
-public record PlanItemCompletedEvent(UUID caseId, String planItemId, String trackingKey) {}
+public record PlanItemCompletedEvent(
+    UUID caseId, String planItemId, String trackingKey, String tenancyId) {}

--- a/blackboard/src/main/java/io/casehub/blackboard/event/SubCaseExecutionCompleted.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/event/SubCaseExecutionCompleted.java
@@ -27,5 +27,6 @@ import java.util.UUID;
  *
  * @param parentCaseId the parent case whose SubCase binding produced the child
  * @param childCaseId the child case that just terminated
+ * @param tenancyId the tenant that owns the parent case
  */
-public record SubCaseExecutionCompleted(UUID parentCaseId, UUID childCaseId) {}
+public record SubCaseExecutionCompleted(UUID parentCaseId, UUID childCaseId, String tenancyId) {}

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemCompletionHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemCompletionHandler.java
@@ -77,15 +77,16 @@ public class PlanItemCompletionHandler {
 
   @ConsumeEvent(value = EventBusAddresses.WORKER_EXECUTION_FINISHED, blocking = true)
   public void onWorkerFinished(WorkflowExecutionCompleted event) {
-    completePlanItemByKey(event.caseInstance().getUuid(), event.worker().getName());
+    completePlanItemByKey(
+        event.caseInstance().getUuid(), event.worker().getName(), event.caseInstance().tenancyId);
   }
 
   @ConsumeEvent(value = BlackboardEventBusAddresses.SUBCASE_EXECUTION_COMPLETED, blocking = true)
   public void onSubCaseFinished(SubCaseExecutionCompleted event) {
-    completePlanItemByKey(event.parentCaseId(), event.childCaseId().toString());
+    completePlanItemByKey(event.parentCaseId(), event.childCaseId().toString(), event.tenancyId());
   }
 
-  private void completePlanItemByKey(UUID caseId, String trackingKey) {
+  private void completePlanItemByKey(UUID caseId, String trackingKey, String tenancyId) {
     CasePlanModel plan = registry.get(caseId).orElse(null);
     if (plan == null) return;
 
@@ -112,7 +113,7 @@ public class PlanItemCompletionHandler {
               stageAutocompleteEvaluator.evaluate(caseId, plan, planItemId);
               // Fire after markCompleted() so observers see the exact planItemId that completed.
               planItemCompletedEvents.fireAsync(
-                  new PlanItemCompletedEvent(caseId, planItemId, trackingKey));
+                  new PlanItemCompletedEvent(caseId, planItemId, trackingKey, tenancyId));
             });
   }
 }

--- a/blackboard/src/main/java/io/casehub/blackboard/subcase/SubCaseCompletionService.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/subcase/SubCaseCompletionService.java
@@ -204,7 +204,7 @@ public class SubCaseCompletionService {
         // and evaluate stage autocomplete. childCaseId is the completion tracking key.
         eventBus.publish(
             BlackboardEventBusAddresses.SUBCASE_EXECUTION_COMPLETED,
-            new SubCaseExecutionCompleted(parentCaseId, childCaseId));
+            new SubCaseExecutionCompleted(parentCaseId, childCaseId, event.tenancyId()));
 
       } else {
         // REJECTED — threshold is unreachable; cancel parent to prevent indefinite WAITING.
@@ -273,7 +273,7 @@ public class SubCaseCompletionService {
     // line — harmless, no transition occurs.
     eventBus.publish(
         BlackboardEventBusAddresses.SUBCASE_EXECUTION_COMPLETED,
-        new SubCaseExecutionCompleted(parentCaseId, childCaseId));
+        new SubCaseExecutionCompleted(parentCaseId, childCaseId, event.tenancyId()));
   }
 
   /**

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemCompletionHandlerTest.java
@@ -194,7 +194,7 @@ class PlanItemCompletionHandlerTest {
     UUID childCaseId = UUID.randomUUID();
     registry.indexForCompletion(caseId, childCaseId.toString(), item.getPlanItemId());
 
-    handler.onSubCaseFinished(new SubCaseExecutionCompleted(caseId, childCaseId));
+    handler.onSubCaseFinished(new SubCaseExecutionCompleted(caseId, childCaseId, "test-tenant"));
 
     assertThat(item.getStatus()).isEqualTo(PlanItemStatus.COMPLETED);
   }
@@ -213,7 +213,7 @@ class PlanItemCompletionHandlerTest {
     stage.activate();
     plan.addStage(stage);
 
-    handler.onSubCaseFinished(new SubCaseExecutionCompleted(caseId, childCaseId));
+    handler.onSubCaseFinished(new SubCaseExecutionCompleted(caseId, childCaseId, "test-tenant"));
 
     assertThat(stage.isTerminal()).isTrue();
     verify(mockBus).publish(eq(BlackboardEventBusAddresses.STAGE_COMPLETED), any());
@@ -221,7 +221,8 @@ class PlanItemCompletionHandlerTest {
 
   @Test
   void subcase_completion_unknown_tracking_key_does_not_throw() {
-    handler.onSubCaseFinished(new SubCaseExecutionCompleted(caseId, UUID.randomUUID()));
+    handler.onSubCaseFinished(
+        new SubCaseExecutionCompleted(caseId, UUID.randomUUID(), "test-tenant"));
   }
 
   @Test
@@ -236,7 +237,7 @@ class PlanItemCompletionHandlerTest {
     registry.indexForCompletion(caseId, child2.toString(), item.getPlanItemId());
 
     // Completion arrives for child2 (threshold-triggering child)
-    handler.onSubCaseFinished(new SubCaseExecutionCompleted(caseId, child2));
+    handler.onSubCaseFinished(new SubCaseExecutionCompleted(caseId, child2, "test-tenant"));
 
     assertThat(item.getStatus()).isEqualTo(PlanItemStatus.COMPLETED);
   }

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseCompletionServiceTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCaseCompletionServiceTest.java
@@ -138,7 +138,7 @@ class SubCaseCompletionServiceTest {
     verify(mockBus)
         .publish(
             eq(BlackboardEventBusAddresses.SUBCASE_EXECUTION_COMPLETED),
-            eq(new SubCaseExecutionCompleted(parentCaseId, childCaseId)));
+            eq(new SubCaseExecutionCompleted(parentCaseId, childCaseId, null)));
   }
 
   @Test

--- a/ledger/src/main/java/io/casehub/ledger/repository/CaseLedgerEntryRepository.java
+++ b/ledger/src/main/java/io/casehub/ledger/repository/CaseLedgerEntryRepository.java
@@ -17,6 +17,7 @@ package io.casehub.ledger.repository;
 
 import io.casehub.ledger.model.CaseLedgerEntry;
 import io.casehub.ledger.model.WorkerDecisionEntry;
+import io.casehub.ledger.runtime.persistence.LedgerPersistenceUnit;
 import io.casehub.ledger.runtime.repository.jpa.JpaLedgerEntryRepository;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -43,7 +44,7 @@ import java.util.UUID;
 @ApplicationScoped
 public class CaseLedgerEntryRepository extends JpaLedgerEntryRepository {
 
-  @Inject EntityManager caseEm; // own field — parent's em is package-private
+  @Inject @LedgerPersistenceUnit EntityManager caseEm; // own field — parent's em is package-private
 
   /** All ledger entries for the given case, ordered by sequence number ascending. */
   @Transactional

--- a/work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java
+++ b/work-adapter/src/test/java/io/casehub/workadapter/WorkItemLifecycleAdapterTest.java
@@ -394,7 +394,8 @@ class WorkItemLifecycleAdapterTest {
             0,
             3,
             GroupStatus.REJECTED,
-            PlanItemCallerRef.encode(caseId, delegatedItemId)));
+            PlanItemCallerRef.encode(caseId, delegatedItemId),
+            "test-tenant"));
 
     await()
         .atMost(5, TimeUnit.SECONDS)
@@ -426,7 +427,8 @@ class WorkItemLifecycleAdapterTest {
             2,
             0,
             GroupStatus.COMPLETED,
-            "some-other-system:xyz");
+            "some-other-system:xyz",
+            "test-tenant");
 
     groupLifecycleEvents.fireAsync(event);
 
@@ -458,6 +460,7 @@ class WorkItemLifecycleAdapterTest {
         2,
         0,
         status,
-        PlanItemCallerRef.encode(caseId, planItemId));
+        PlanItemCallerRef.encode(caseId, planItemId),
+        "test-tenant");
   }
 }


### PR DESCRIPTION
## Summary

- **#460** — `CaseLedgerEntry.tenancyId` field shadow: already fixed in prior session (dc37cd50); closed without code change
- **#459** — `WorkItemGroupLifecycleEvent.of()` gained `tenancyId` param in casehub-work SNAPSHOT; three test call sites updated
- **#450** — `CaseLedgerEntryRepository.caseEm` injected without `@LedgerPersistenceUnit`; silently routed `findByCaseId` to wrong PU in multi-datasource deployments (e.g. devtown + qhorus)
- **#429** — `tenancyId` added to `PlanItemCompletedEvent` and `SubCaseExecutionCompleted`; eliminates the need for `CrossTenantCaseInstanceRepository` inside `@ObservesAsync` handlers (devtown#43)

## Protocols added
- PP-20260611-d4e5cf — CDI event records consumed by `@ObservesAsync` must carry `tenancyId`
- PP-20260611-cc63b4 — `JpaLedgerEntryRepository` subclasses must qualify all `EntityManager` fields with `@LedgerPersistenceUnit`

## Test plan
- [ ] Full build passes: `mvn install -DskipTests`
- [ ] Existing blackboard tests cover `PlanItemCompletedEvent` and `SubCaseExecutionCompleted` changes
- [ ] `WorkItemLifecycleAdapterTest` passes with updated `WorkItemGroupLifecycleEvent.of()` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)