### PR TITLE
fix: guard withCrossTenantTransaction role switch behind casehub.rls.enabled

### DIFF
--- a/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/TenantAwareRepository.java
+++ b/persistence-hibernate/src/main/java/io/casehub/persistence/jpa/TenantAwareRepository.java
@@ -20,6 +20,7 @@ import io.quarkus.hibernate.reactive.panache.Panache;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import java.util.function.Supplier;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Extends AbstractJpaRepository with RLS session-variable injection.
@@ -29,12 +30,15 @@ import java.util.function.Supplier;
  * in withTransaction() because SET LOCAL only applies within an explicit transaction.
  *
  * <p>withCrossTenantTransaction(): sets SET LOCAL ROLE casehub_crosstenancy (BYPASSRLS role). Used
- * by cross-tenant repositories. Requires casehub_crosstenancy role to exist. RlsPolicyApplicator
- * creates the role when casehub.rls.enabled=true.
+ * by cross-tenant repositories. Only issues the role switch when casehub.rls.enabled=true;
+ * otherwise runs the work in a plain transaction.
  */
 abstract class TenantAwareRepository extends AbstractJpaRepository {
 
   @Inject CurrentPrincipal currentPrincipal;
+
+  @ConfigProperty(name = "casehub.rls.enabled", defaultValue = "false")
+  boolean rlsEnabled;
 
   protected <T> Uni<T> withTenantTransaction(Supplier<Uni<T>> work) {
     // PostgreSQL does not support bind parameters in SET LOCAL — the value must be
@@ -60,6 +64,9 @@ abstract class TenantAwareRepository extends AbstractJpaRepository {
   }
 
   protected <T> Uni<T> withCrossTenantTransaction(Supplier<Uni<T>> work) {
+    if (!rlsEnabled) {
+      return withSafeContext(() -> Panache.withTransaction(work));
+    }
     return withSafeContext(
         () ->
             Panache.withTransaction(


### PR DESCRIPTION
## Summary

- `TenantAwareRepository.withCrossTenantTransaction()` unconditionally executed `SET LOCAL ROLE casehub_crosstenancy`, which fails on deployments where RLS is not enabled (the role doesn't exist)
- The `casehub_crosstenancy` PostgreSQL role is only created by `RlsPolicyApplicator` when `casehub.rls.enabled=true`
- Added a guard: when `casehub.rls.enabled=false` (default), the method runs a plain `Panache.withTransaction()` instead of switching roles

## Problem

When running **scaffold** (or any deployment without RLS), all tests that touch cross-tenant repositories failed with:

```
ERROR: role "casehub_crosstenancy" does not exist
```

The root cause: `withCrossTenantTransaction()` assumed the role always exists, but `RlsPolicyApplicator` only creates it when RLS is explicitly enabled.

## Test plan

- [x] Engine full build with tests passes (`mvn install` — 4:20 min, all green)
- [x] Scaffold build with 32 tests passes
- [ ] Verify RLS-enabled path still works (requires `casehub.rls.enabled=true` + PostgreSQL with the role)

🤖 Generated with [Claude Code](https://claude.com/claude-code)