### PR TITLE
feat: signal API, implementation routing SPI, repeatable stage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ is public (`public Long id`) and set by the repository after save.
 
 All JQ expressions (binding filters, `when` conditions, goals, milestones, `inputSchema`, `outputSchema`) evaluate against the **working panel** (`context.panel(ContextPanel.WORKING).asJsonNode()`), NOT the full panel document (`context.asJsonNode()`). YAML definitions use unqualified field paths (`.transaction`, `.entityResolution`) — the panel structure is an engine implementation detail.
 
-`CaseHubRuntime.signal()` has a 5-arg overload carrying `triggerChannelId` and `triggerCorrelationId` (both nullable). When a Qhorus COMMAND triggers a context update, the triggering COMMAND's channel and correlation IDs are threaded through `SignalReceivedEvent` → `CaseContextChangedEvent` → `ProvisionContext` so provisioners can establish causal lineage. Refs engine#231.
+`CaseHubRuntime.signal()` returns `CompletionStage<Void>` (engine#493). The CompletionStage resolves when the signal has been applied, the event log written, and CONTEXT_CHANGED dispatched — it does NOT guarantee goal evaluation completion. The 5-arg overload carries `triggerChannelId` and `triggerCorrelationId` (both nullable) for Qhorus causal lineage. CDI lifecycle events in all handlers (`SignalReceivedEventHandler`, `CaseStartedEventHandler`, `WorkflowExecutionCompletedHandler`) use fire-and-forget `.invoke()` — never `.chain()` — to prevent slow observers from blocking case state progression. Refs engine#231, engine#493.
 
 ## Worker Provisioner SPIs
 
@@ -279,6 +279,30 @@ public class AmlActionRiskClassifier implements ActionRiskClassifier {
 **New event bus addresses** (in `EventBusAddresses`): `ACTION_GATE_SCHEDULE`, `ACTION_GATE_APPROVED`, `ACTION_GATE_REJECTED`, `ACTION_GATE_EXPIRED`, `ACTION_GATE_CANCELLED`, `ACTION_GATE_WORKER_FAULTED` (distinct from `WORKER_RETRIES_EXHAUSTED` — gate faults must not fault the CaseInstance).
 
 See design spec: `docs/specs/2026-06-05-action-risk-classifier-design.md`. Consumer exploration issues: life#20, devtown#56, aml#42, clinical#47, openclaw#6.
+
+## ImplementationRoutingStrategy SPI
+
+Selects which binding(s) handle a capability when multiple bindings target the same capability. Symmetric to `AgentRoutingStrategy` (which selects which worker instance handles a task). Package: `io.casehub.api.spi.routing`. Refs engine#476.
+
+**Pipeline:** Binding eligibility → Stage gating → **ImplementationRouting** → PlanningStrategy → **AgentRouting** → Worker scheduling.
+
+**Sealed result:** `ImplementationSelection` — `Selected(List<String> bindingNames)` | `RunAll()` | `RunNone()`. `Selected` enforces non-empty via constructor validation.
+
+**Default:** `NoOpImplementationRoutingStrategy` (`@DefaultBean @ApplicationScoped` in `runtime/internal/routing/`) returns `RunAll`.
+
+**Integration:** `PlanningStrategyLoopControl.applyImplementationRouting()` runs at step 3.5 — after `stageLifecycleEvaluator.evaluate()`, before `planningStrategy.select()`. Routing filters bindings before PlanItem creation (no create-then-cancel).
+
+## Repeatable Stage
+
+Stage gains `repeatable` (final boolean, builder-only) and `instanceIndex` (AtomicInteger, 0-based). When a repeatable stage autocompletes, `StageAutocompleteEvaluator` calls `resetForRepetition()` — CAS COMPLETED→PENDING, clears `containedPlanItemIds`/`requiredItemIds`/`containedMilestoneIds`, increments `instanceIndex`. Binding names persist across resets (design-time declarations).
+
+**Event records:** `StageCompletedEvent(caseId, stage, instanceIndex)` and `StageActivatedEvent(caseId, stage, instanceIndex)` carry an explicit `instanceIndex` snapshot — use the field, not `stage.getInstanceIndex()` which may have advanced.
+
+**V1 constraint:** Repeatable stages must not contain nested stages or milestones. Runtime enforcement in `StageAutocompleteEvaluator` — logs warning and skips reset.
+
+**Fan-out race:** `WORKER_EXECUTION_FINISHED` fan-out means auto-registration and `resetForRepetition()` may interleave. Self-healing — at worst one cycle skipped. Refs engine#482.
+
+**Stage-PlanItem auto-registration:** `PlanningStrategyLoopControl` auto-registers newly created PlanItems with their owning stage's `containedPlanItemIds` and `requiredItemIds` via `registerWithOwningStages()`. This makes stage autocomplete work in production (previously test-only). Refs engine#497.
 
 ## Agent Worker AI Model
 

--- a/api/src/main/java/io/casehub/api/engine/CaseHub.java
+++ b/api/src/main/java/io/casehub/api/engine/CaseHub.java
@@ -42,8 +42,8 @@ public abstract class CaseHub {
     return runtime.startCase(getDefinition(), inputData);
   }
 
-  public void signal(UUID caseId, String path, Object value) {
-    runtime.signal(caseId, path, value);
+  public CompletionStage<Void> signal(UUID caseId, String path, Object value) {
+    return runtime.signal(caseId, path, value);
   }
 
   public void cancelCase(UUID caseId) {

--- a/api/src/main/java/io/casehub/api/engine/CaseHubRuntime.java
+++ b/api/src/main/java/io/casehub/api/engine/CaseHubRuntime.java
@@ -48,7 +48,15 @@ public interface CaseHubRuntime {
       UUID parentCaseId,
       PropagationContext propagationContext);
 
-  void signal(UUID caseId, String path, Object value);
+  /**
+   * Signals a case context update. The returned {@code CompletionStage} resolves when the signal
+   * has been applied to the context, the event log written, and {@code CONTEXT_CHANGED} dispatched.
+   * It does NOT guarantee that goal evaluation has completed — callers that need to await case
+   * state transitions should use Awaitility on the case status.
+   *
+   * <p>Refs casehubio/engine#493.
+   */
+  CompletionStage<Void> signal(UUID caseId, String path, Object value);
 
   /**
    * Signals a case context update with Qhorus trigger context for causal lineage.
@@ -59,15 +67,15 @@ public interface CaseHubRuntime {
    * establish causal linkage in the ledger. Both fields are nullable — pass {@code null} when the
    * signal is not triggered by a Qhorus COMMAND.
    *
-   * <p>Refs casehubio/engine#231, claudony#94.
+   * <p>Refs casehubio/engine#231, casehubio/engine#493, claudony#94.
    */
-  default void signal(
+  default CompletionStage<Void> signal(
       UUID caseId,
       String path,
       Object value,
       String triggerChannelId,
       String triggerCorrelationId) {
-    signal(caseId, path, value); // default: discard trigger context
+    return signal(caseId, path, value);
   }
 
   /**

--- a/api/src/main/java/io/casehub/api/spi/routing/ImplementationCandidate.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/ImplementationCandidate.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi.routing;
+
+/**
+ * One competing implementation for a capability, passed to {@link
+ * ImplementationRoutingStrategy#select}.
+ *
+ * @param bindingName the binding that targets this capability
+ * @param workerName the resolved worker name for this binding
+ * @param capabilityName the capability being targeted
+ */
+public record ImplementationCandidate(
+    String bindingName, String workerName, String capabilityName) {}

--- a/api/src/main/java/io/casehub/api/spi/routing/ImplementationRoutingContext.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/ImplementationRoutingContext.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi.routing;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.UUID;
+
+/**
+ * Routing context passed to {@link ImplementationRoutingStrategy#select}.
+ *
+ * @param caseId the case instance UUID
+ * @param capabilityName the capability being routed
+ * @param caseContext the current case context as a JSON node (working panel)
+ */
+public record ImplementationRoutingContext(
+    UUID caseId, String capabilityName, JsonNode caseContext) {}

--- a/api/src/main/java/io/casehub/api/spi/routing/ImplementationRoutingStrategy.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/ImplementationRoutingStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi.routing;
+
+import io.smallrye.mutiny.Uni;
+import java.util.List;
+
+/**
+ * Selects which implementation(s) handle a capability when multiple bindings target the same
+ * capability. Symmetric to {@link AgentRoutingStrategy} which selects which worker instance handles
+ * a task.
+ *
+ * <p>Returns {@link Uni} per protocol PP-20260529-9f9627 — implementations may perform blocking I/O
+ * (trust lookups, external classification).
+ *
+ * <p>Refs casehubio/engine#476.
+ */
+public interface ImplementationRoutingStrategy {
+
+  Uni<ImplementationSelection> select(
+      ImplementationRoutingContext context, List<ImplementationCandidate> candidates);
+}

--- a/api/src/main/java/io/casehub/api/spi/routing/ImplementationSelection.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/ImplementationSelection.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi.routing;
+
+import java.util.List;
+
+/**
+ * Result of {@link ImplementationRoutingStrategy#select}. A sealed type with three outcomes:
+ *
+ * <ul>
+ *   <li>{@link Selected} — one or more specific bindings were chosen
+ *   <li>{@link RunAll} — all implementations run (current default behaviour)
+ *   <li>{@link RunNone} — all candidates are inappropriate; skip this capability
+ * </ul>
+ *
+ * <p>Callers must switch exhaustively on the sealed type. Refs casehubio/engine#476.
+ */
+public sealed interface ImplementationSelection
+    permits ImplementationSelection.Selected,
+        ImplementationSelection.RunAll,
+        ImplementationSelection.RunNone {
+
+  record Selected(List<String> bindingNames) implements ImplementationSelection {
+    public Selected(List<String> bindingNames) {
+      if (bindingNames.isEmpty())
+        throw new IllegalArgumentException("Use RunNone for empty selection");
+      this.bindingNames = List.copyOf(bindingNames);
+    }
+  }
+
+  record RunAll() implements ImplementationSelection {}
+
+  record RunNone() implements ImplementationSelection {}
+}

--- a/api/src/test/java/io/casehub/api/spi/routing/ImplementationSelectionTest.java
+++ b/api/src/test/java/io/casehub/api/spi/routing/ImplementationSelectionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.api.spi.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ImplementationSelectionTest {
+
+  @Test
+  void selected_rejects_empty_list() {
+    assertThatThrownBy(() -> new ImplementationSelection.Selected(List.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void selected_single_binding() {
+    var s = new ImplementationSelection.Selected(List.of("b1"));
+    assertThat(s.bindingNames()).containsExactly("b1");
+  }
+
+  @Test
+  void selected_subset() {
+    var s = new ImplementationSelection.Selected(List.of("b1", "b2"));
+    assertThat(s.bindingNames()).containsExactly("b1", "b2");
+  }
+
+  @Test
+  void selected_defensively_copies_list() {
+    var mutable = new ArrayList<>(List.of("b1"));
+    var s = new ImplementationSelection.Selected(mutable);
+    mutable.add("b2");
+    assertThat(s.bindingNames()).containsExactly("b1");
+  }
+
+  @Test
+  void selected_list_is_immutable() {
+    var s = new ImplementationSelection.Selected(List.of("b1"));
+    assertThatThrownBy(() -> s.bindingNames().add("b2"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/blackboard/src/main/java/io/casehub/blackboard/control/PlanningStrategyLoopControl.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/control/PlanningStrategyLoopControl.java
@@ -24,9 +24,14 @@ import io.casehub.api.model.ExtensionTarget;
 import io.casehub.api.model.HumanTaskTarget;
 import io.casehub.api.model.SubCaseTarget;
 import io.casehub.api.model.Worker;
+import io.casehub.api.spi.routing.ImplementationCandidate;
+import io.casehub.api.spi.routing.ImplementationRoutingContext;
+import io.casehub.api.spi.routing.ImplementationRoutingStrategy;
+import io.casehub.api.spi.routing.ImplementationSelection;
 import io.casehub.blackboard.plan.CasePlanModel;
 import io.casehub.blackboard.plan.PlanItem;
 import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.blackboard.stage.Stage;
 import io.casehub.engine.common.internal.model.PlanItemStatus;
 import io.smallrye.mutiny.Uni;
 import jakarta.annotation.Priority;
@@ -34,7 +39,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -59,17 +67,20 @@ public class PlanningStrategyLoopControl implements LoopControl {
   private final PlanningStrategy planningStrategy;
   private final StageLifecycleEvaluator stageLifecycleEvaluator;
   private final Instance<BlackboardPlanConfigurer> configurers;
+  private final ImplementationRoutingStrategy implementationRoutingStrategy;
 
   @Inject
   public PlanningStrategyLoopControl(
       BlackboardRegistry registry,
       PlanningStrategy planningStrategy,
       StageLifecycleEvaluator stageLifecycleEvaluator,
-      Instance<BlackboardPlanConfigurer> configurers) {
+      Instance<BlackboardPlanConfigurer> configurers,
+      ImplementationRoutingStrategy implementationRoutingStrategy) {
     this.registry = registry;
     this.planningStrategy = planningStrategy;
     this.stageLifecycleEvaluator = stageLifecycleEvaluator;
     this.configurers = configurers;
+    this.implementationRoutingStrategy = implementationRoutingStrategy;
   }
 
   @Override
@@ -115,20 +126,92 @@ public class PlanningStrategyLoopControl implements LoopControl {
                             || activeStagedNames.contains(b.getName())) // staged → only if ACTIVE
                 .collect(Collectors.toList());
 
-    // Create a PlanItem for each gated-eligible Binding and add to agenda, skipping duplicates.
-    // addPlanItemIfAbsent performs the check-and-insert atomically — no TOCTOU window.
-    gatedEligible.forEach(
-        binding -> {
-          String workerName = resolveWorkerName(binding, ctx);
-          plan.addPlanItemIfAbsent(
-              PlanItem.create(binding.getName(), workerName, 0, binding.target()));
-        });
-
     return stageLifecycleEvaluator
         .evaluate(plan, ctx)
-        .chain(() -> planningStrategy.select(plan, ctx, gatedEligible))
+        .chain(() -> applyImplementationRouting(ctx, gatedEligible))
+        .invoke(
+            routed -> {
+              // Create PlanItems only for surviving bindings — routing decision is upstream.
+              // addPlanItemIfAbsent is atomic (no TOCTOU). Auto-register with owning stages
+              // for autocomplete tracking. Refs casehubio/engine#497, engine#476.
+              routed.forEach(
+                  binding -> {
+                    String workerName = resolveWorkerName(binding, ctx);
+                    PlanItem item =
+                        PlanItem.create(binding.getName(), workerName, 0, binding.target());
+                    if (plan.addPlanItemIfAbsent(item)) {
+                      registerWithOwningStages(plan, binding.getName(), item.getPlanItemId());
+                    }
+                  });
+            })
+        .chain(routed -> planningStrategy.select(plan, ctx, routed))
         .map(selected -> filterToDispatchable(plan, selected))
         .invoke(dispatchable -> indexSelectedForCompletion(caseId, dispatchable, plan));
+  }
+
+  /**
+   * Groups gated-eligible bindings by capability name. Groups with a single binding pass through
+   * unchanged. Groups with multiple bindings consult {@link ImplementationRoutingStrategy} to
+   * select which binding(s) survive. Non-capability bindings are never grouped. Refs
+   * casehubio/engine#476.
+   */
+  private Uni<List<Binding>> applyImplementationRouting(
+      PlanExecutionContext ctx, List<Binding> gatedEligible) {
+    Map<String, List<Binding>> byCapability = new LinkedHashMap<>();
+    List<Binding> nonCapability = new ArrayList<>();
+    for (Binding b : gatedEligible) {
+      if (b.target() instanceof CapabilityTarget ct) {
+        byCapability.computeIfAbsent(ct.capability().getName(), k -> new ArrayList<>()).add(b);
+      } else {
+        nonCapability.add(b);
+      }
+    }
+
+    Uni<List<Binding>> result = Uni.createFrom().item(new ArrayList<>(nonCapability));
+    for (var entry : byCapability.entrySet()) {
+      String capName = entry.getKey();
+      List<Binding> group = entry.getValue();
+      if (group.size() == 1) {
+        result = result.invoke(acc -> acc.addAll(group));
+      } else {
+        result =
+            result.chain(
+                acc -> {
+                  List<ImplementationCandidate> candidates =
+                      group.stream()
+                          .map(
+                              b ->
+                                  new ImplementationCandidate(
+                                      b.getName(), resolveWorkerName(b, ctx), capName))
+                          .toList();
+                  var routingCtx =
+                      new ImplementationRoutingContext(
+                          ctx.caseId(),
+                          capName,
+                          ctx.caseContext() != null ? ctx.caseContext().asJsonNode() : null);
+                  return implementationRoutingStrategy
+                      .select(routingCtx, candidates)
+                      .map(
+                          selection ->
+                              switch (selection) {
+                                case ImplementationSelection.Selected s -> {
+                                  Set<String> kept = Set.copyOf(s.bindingNames());
+                                  acc.addAll(
+                                      group.stream()
+                                          .filter(b -> kept.contains(b.getName()))
+                                          .toList());
+                                  yield acc;
+                                }
+                                case ImplementationSelection.RunAll ignored -> {
+                                  acc.addAll(group);
+                                  yield acc;
+                                }
+                                case ImplementationSelection.RunNone ignored -> acc;
+                              });
+                });
+      }
+    }
+    return result;
   }
 
   /**
@@ -221,6 +304,21 @@ public class PlanningStrategyLoopControl implements LoopControl {
                 pi.markRunning();
                 registry.indexForCompletion(caseId, pi.getWorkerName(), pi.getPlanItemId());
               });
+    }
+  }
+
+  /**
+   * Registers a newly created PlanItem with all stages that declare ownership of its binding name
+   * via {@link Stage#getContainedBindingNames()}. Enables {@link
+   * io.casehub.blackboard.handler.StageAutocompleteEvaluator} to detect when all required items in
+   * a stage have reached terminal states. Refs casehubio/engine#497.
+   */
+  private void registerWithOwningStages(CasePlanModel plan, String bindingName, String planItemId) {
+    for (Stage stage : plan.getAllStages()) {
+      if (stage.getContainedBindingNames().contains(bindingName)) {
+        stage.addPlanItem(planItemId);
+        stage.addRequiredItem(planItemId);
+      }
     }
   }
 }

--- a/blackboard/src/main/java/io/casehub/blackboard/control/StageLifecycleEvaluator.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/control/StageLifecycleEvaluator.java
@@ -96,7 +96,7 @@ public class StageLifecycleEvaluator {
         stage.activate();
         eventBus.publish(
             BlackboardEventBusAddresses.STAGE_ACTIVATED,
-            new StageActivatedEvent(ctx.caseId(), stage));
+            new StageActivatedEvent(ctx.caseId(), stage, stage.getInstanceIndex()));
       }
     }
   }

--- a/blackboard/src/main/java/io/casehub/blackboard/event/StageActivatedEvent.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/event/StageActivatedEvent.java
@@ -21,9 +21,12 @@ import java.util.UUID;
 /**
  * Published when a Stage transitions PENDING → ACTIVE. See casehubio/engine#76.
  *
+ * <p>{@code instanceIndex} captures the activating instance's index at publish time. Refs
+ * casehubio/engine#482.
+ *
  * <p><strong>Note:</strong> {@code stage} is passed by reference via {@link
  * io.casehub.blackboard.event.BlackboardEventCodecRegistrar.LocalOnlyCodec}. Consumers must not
  * retain this reference — the Stage object is mutable and its state will reflect subsequent
  * lifecycle transitions.
  */
-public record StageActivatedEvent(UUID caseId, Stage stage) {}
+public record StageActivatedEvent(UUID caseId, Stage stage, int instanceIndex) {}

--- a/blackboard/src/main/java/io/casehub/blackboard/event/StageCompletedEvent.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/event/StageCompletedEvent.java
@@ -21,9 +21,13 @@ import java.util.UUID;
 /**
  * Published when a Stage autocompletes or all required items finish. See casehubio/engine#76.
  *
+ * <p>{@code instanceIndex} captures the completing instance's index at publish time — use this
+ * field instead of {@code stage.getInstanceIndex()} which may have advanced if the stage is
+ * repeatable. Refs casehubio/engine#482.
+ *
  * <p><strong>Note:</strong> {@code stage} is passed by reference via {@link
  * io.casehub.blackboard.event.BlackboardEventCodecRegistrar.LocalOnlyCodec}. Consumers must not
  * retain this reference — the Stage object is mutable and its state will reflect subsequent
  * lifecycle transitions.
  */
-public record StageCompletedEvent(UUID caseId, Stage stage) {}
+public record StageCompletedEvent(UUID caseId, Stage stage, int instanceIndex) {}

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/StageAutocompleteEvaluator.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/StageAutocompleteEvaluator.java
@@ -65,11 +65,24 @@ public class StageAutocompleteEvaluator {
                       plan.getPlanItem(itemId).map(pi -> isTerminal(pi.getStatus())).orElse(false));
 
       if (allTerminal) {
+        int completingIndex = stage.getInstanceIndex();
         stage.complete();
         eventBus.publish(
-            BlackboardEventBusAddresses.STAGE_COMPLETED, new StageCompletedEvent(caseId, stage));
+            BlackboardEventBusAddresses.STAGE_COMPLETED,
+            new StageCompletedEvent(caseId, stage, completingIndex));
+        if (stage.isRepeatable()) {
+          if (!stage.getContainedStageIds().isEmpty()
+              || !stage.getContainedMilestoneIds().isEmpty()) {
+            LOG.warnf(
+                "Repeatable stage '%s' contains nested stages or milestones — skipping reset",
+                stage.getName());
+          } else {
+            stage.resetForRepetition();
+          }
+        }
         LOG.debugf(
-            "Stage autocomplete fired for caseId=%s after item=%s settled", caseId, changedItemId);
+            "Stage autocomplete fired for caseId=%s after item=%s settled (instance=%d)",
+            caseId, changedItemId, completingIndex);
       }
     }
   }

--- a/blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/stage/Stage.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
@@ -68,11 +69,18 @@ public class Stage {
   // Behaviour
   private boolean autocomplete = true;
   private boolean manualActivation = false;
+  private final boolean repeatable;
+  private final AtomicInteger instanceIndex = new AtomicInteger(0);
 
-  private Stage(String name) {
+  private Stage(String name, boolean repeatable) {
     this.stageId = UUID.randomUUID().toString();
     this.name = name;
     this.createdAt = Instant.now();
+    this.repeatable = repeatable;
+  }
+
+  private Stage(String name) {
+    this(name, false);
   }
 
   /**
@@ -109,6 +117,7 @@ public class Stage {
     private ExpressionEvaluator exitCondition;
     private boolean manualActivation = false;
     private boolean autocomplete = true;
+    private boolean repeatable = false;
     private String parentStageId;
     private final java.util.Set<String> bindingNames = new java.util.HashSet<>();
 
@@ -161,6 +170,11 @@ public class Stage {
       return this;
     }
 
+    public Builder repeatable(boolean repeatable) {
+      this.repeatable = repeatable;
+      return this;
+    }
+
     public Stage build() {
       if (entryCondition == null) {
         throw new IllegalStateException(
@@ -171,7 +185,7 @@ public class Stage {
                 + name
                 + "\") if the stage should activate on every cycle.");
       }
-      Stage stage = new Stage(name);
+      Stage stage = new Stage(name, this.repeatable);
       stage.entryCondition = this.entryCondition;
       stage.exitCondition = this.exitCondition;
       stage.manualActivation = this.manualActivation;
@@ -405,5 +419,36 @@ public class Stage {
 
   public boolean isManualActivation() {
     return manualActivation;
+  }
+
+  public boolean isRepeatable() {
+    return repeatable;
+  }
+
+  public int getInstanceIndex() {
+    return instanceIndex.get();
+  }
+
+  /**
+   * Resets a repeatable Stage from COMPLETED to PENDING for the next instance. Clears all
+   * containment sets (PlanItems, milestones) so the next instance starts fresh. Binding names are
+   * preserved — they are design-time declarations, not instance state.
+   *
+   * <p>Refs casehubio/engine#482.
+   *
+   * @return true if reset succeeded; false if the stage is not repeatable or not COMPLETED
+   */
+  public boolean resetForRepetition() {
+    if (!repeatable) return false;
+    if (status.compareAndSet(StageStatus.COMPLETED, StageStatus.PENDING)) {
+      instanceIndex.incrementAndGet();
+      containedPlanItemIds.clear();
+      requiredItemIds.clear();
+      containedMilestoneIds.clear();
+      activatedAt = null;
+      completedAt = null;
+      return true;
+    }
+    return false;
   }
 }

--- a/blackboard/src/test/java/io/casehub/blackboard/control/BindingGatingTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/control/BindingGatingTest.java
@@ -76,7 +76,13 @@ class BindingGatingTest {
     Instance<BlackboardPlanConfigurer> emptyConfigurers = mock(Instance.class);
     when(emptyConfigurers.stream()).thenReturn(Stream.empty());
 
-    loopControl = new PlanningStrategyLoopControl(registry, strategy, evaluator, emptyConfigurers);
+    loopControl =
+        new PlanningStrategyLoopControl(
+            registry,
+            strategy,
+            evaluator,
+            emptyConfigurers,
+            new io.casehub.engine.internal.routing.NoOpImplementationRoutingStrategy());
 
     caseId = UUID.randomUUID();
     CaseDefinition def = mock(CaseDefinition.class);
@@ -374,5 +380,70 @@ class BindingGatingTest {
     assertThat(result.stream().map(Binding::getName))
         .as("RUNNING case must not re-dispatch a binding whose PlanItem is already RUNNING")
         .doesNotContain("in-flight-b");
+  }
+
+  // ------------------------------------------------------------------ //
+  // Auto-registration: PlanItems registered with owning stage           //
+  // Refs casehubio/engine#497                                           //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void staged_binding_auto_registers_planItem_with_owning_stage() {
+    Stage stage = Stage.alwaysActivate("intake");
+    stage.activate();
+    stage.addBinding("staged-b");
+    plan().addStage(stage);
+
+    Binding b = binding("staged-b");
+    loopControl.select(ctx, List.of(b)).await().indefinitely();
+
+    assertThat(stage.getContainedPlanItemIds())
+        .as("PlanItem must be auto-registered in stage's containedPlanItemIds")
+        .hasSize(1);
+    assertThat(stage.getRequiredItemIds())
+        .as("PlanItem must be auto-registered in stage's requiredItemIds")
+        .hasSize(1);
+    assertThat(stage.getContainedPlanItemIds())
+        .as("containedPlanItemIds and requiredItemIds must contain the same PlanItem")
+        .containsExactlyElementsOf(stage.getRequiredItemIds());
+  }
+
+  @Test
+  void free_floating_binding_does_not_register_with_any_stage() {
+    Stage stage = Stage.alwaysActivate("intake");
+    stage.activate();
+    stage.addBinding("other-b");
+    plan().addStage(stage);
+
+    Binding b = binding("free-b");
+    loopControl.select(ctx, List.of(b)).await().indefinitely();
+
+    assertThat(stage.getContainedPlanItemIds())
+        .as("free-floating binding must not register with unrelated stage")
+        .isEmpty();
+    assertThat(stage.getRequiredItemIds())
+        .as("free-floating binding must not register with unrelated stage")
+        .isEmpty();
+  }
+
+  @Test
+  void auto_registration_skipped_when_planItem_already_exists() {
+    Stage stage = Stage.alwaysActivate("intake");
+    stage.activate();
+    stage.addBinding("staged-b");
+    plan().addStage(stage);
+
+    Binding b = binding("staged-b");
+    // First select creates and registers the PlanItem
+    loopControl.select(ctx, List.of(b)).await().indefinitely();
+    int afterFirst = stage.getRequiredItemIds().size();
+
+    // Second select — PlanItem exists (RUNNING after indexSelectedForCompletion),
+    // addPlanItemIfAbsent returns false, no duplicate registration
+    loopControl.select(ctx, List.of(b)).await().indefinitely();
+
+    assertThat(stage.getRequiredItemIds())
+        .as("second select must not duplicate registration")
+        .hasSize(afterFirst);
   }
 }

--- a/blackboard/src/test/java/io/casehub/blackboard/control/ImplementationRoutingTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/control/ImplementationRoutingTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.blackboard.control;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.casehub.api.context.CaseContext;
+import io.casehub.api.engine.PlanExecutionContext;
+import io.casehub.api.model.Binding;
+import io.casehub.api.model.Capability;
+import io.casehub.api.model.CapabilityTarget;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.Worker;
+import io.casehub.api.spi.routing.ImplementationRoutingStrategy;
+import io.casehub.api.spi.routing.ImplementationSelection;
+import io.casehub.blackboard.plan.DefaultCasePlanModel;
+import io.casehub.blackboard.registry.BlackboardRegistry;
+import io.casehub.platform.api.identity.TenancyConstants;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.inject.Instance;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ImplementationRoutingStrategy} integration in {@link
+ * PlanningStrategyLoopControl}. Refs casehubio/engine#476.
+ */
+@SuppressWarnings("unchecked")
+class ImplementationRoutingTest {
+
+  private BlackboardRegistry registry;
+  private PlanningStrategyLoopControl loopControl;
+  private UUID caseId;
+  private PlanExecutionContext ctx;
+  private ImplementationRoutingStrategy routingStrategy;
+
+  @BeforeEach
+  void setUp() {
+    registry = new BlackboardRegistry();
+    DefaultPlanningStrategy strategy = new DefaultPlanningStrategy();
+    StageLifecycleEvaluator evaluator = mock(StageLifecycleEvaluator.class);
+    when(evaluator.evaluate(any(), any())).thenReturn(Uni.createFrom().voidItem());
+    Instance<BlackboardPlanConfigurer> emptyConfigurers = mock(Instance.class);
+    when(emptyConfigurers.stream()).thenReturn(Stream.empty());
+
+    routingStrategy = mock(ImplementationRoutingStrategy.class);
+
+    loopControl =
+        new PlanningStrategyLoopControl(
+            registry, strategy, evaluator, emptyConfigurers, routingStrategy);
+
+    caseId = UUID.randomUUID();
+
+    Capability cap =
+        Capability.builder().name("analyse").inputSchema(".").outputSchema(".").build();
+    Worker w1 =
+        Worker.builder()
+            .name("worker-a")
+            .capabilities(cap)
+            .function(input -> io.casehub.api.model.WorkerResult.of(java.util.Map.of()))
+            .build();
+    Worker w2 =
+        Worker.builder()
+            .name("worker-b")
+            .capabilities(cap)
+            .function(input -> io.casehub.api.model.WorkerResult.of(java.util.Map.of()))
+            .build();
+
+    CaseDefinition def = mock(CaseDefinition.class);
+    when(def.getWorkers()).thenReturn(List.of(w1, w2));
+
+    ctx =
+        new PlanExecutionContext(
+            caseId,
+            def,
+            mock(CaseContext.class),
+            io.casehub.api.model.CaseStatus.RUNNING,
+            TenancyConstants.DEFAULT_TENANT_ID);
+  }
+
+  private Binding capabilityBinding(String name, String capName) {
+    Capability cap = Capability.builder().name(capName).inputSchema(".").outputSchema(".").build();
+    Binding b = mock(Binding.class);
+    when(b.getName()).thenReturn(name);
+    when(b.target()).thenReturn(new CapabilityTarget(cap));
+    return b;
+  }
+
+  private DefaultCasePlanModel plan() {
+    return (DefaultCasePlanModel) registry.getOrCreate(caseId, "test-tenant");
+  }
+
+  @Test
+  void selected_single_binding_only_that_binding_passes() {
+    when(routingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(new ImplementationSelection.Selected(List.of("b1"))));
+
+    Binding b1 = capabilityBinding("b1", "analyse");
+    Binding b2 = capabilityBinding("b2", "analyse");
+
+    List<Binding> result = loopControl.select(ctx, List.of(b1, b2)).await().indefinitely();
+
+    assertThat(result.stream().map(Binding::getName))
+        .as("Only the selected binding should pass")
+        .containsExactly("b1");
+    assertThat(plan().hasActivePlanItem("b2"))
+        .as("Non-selected binding must not have a PlanItem")
+        .isFalse();
+  }
+
+  @Test
+  void runAll_all_bindings_pass() {
+    when(routingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(new ImplementationSelection.RunAll()));
+
+    Binding b1 = capabilityBinding("b1", "analyse");
+    Binding b2 = capabilityBinding("b2", "analyse");
+
+    List<Binding> result = loopControl.select(ctx, List.of(b1, b2)).await().indefinitely();
+
+    assertThat(result.stream().map(Binding::getName))
+        .as("RunAll must pass all bindings")
+        .containsExactlyInAnyOrder("b1", "b2");
+  }
+
+  @Test
+  void runNone_no_bindings_pass() {
+    when(routingStrategy.select(any(), any()))
+        .thenReturn(Uni.createFrom().item(new ImplementationSelection.RunNone()));
+
+    Binding b1 = capabilityBinding("b1", "analyse");
+    Binding b2 = capabilityBinding("b2", "analyse");
+
+    List<Binding> result = loopControl.select(ctx, List.of(b1, b2)).await().indefinitely();
+
+    assertThat(result.stream().map(Binding::getName))
+        .as("RunNone must block all bindings in the group")
+        .doesNotContain("b1", "b2");
+  }
+
+  @Test
+  void single_binding_per_capability_skips_routing() {
+    Binding b1 = capabilityBinding("b1", "analyse");
+
+    List<Binding> result = loopControl.select(ctx, List.of(b1)).await().indefinitely();
+
+    assertThat(result.stream().map(Binding::getName)).contains("b1");
+  }
+}

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/StageAutocompleteEvaluatorTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/StageAutocompleteEvaluatorTest.java
@@ -15,6 +15,7 @@
  */
 package io.casehub.blackboard.handler;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import io.casehub.blackboard.event.StageCompletedEvent;
 import io.casehub.blackboard.plan.CasePlanModel;
+import io.casehub.blackboard.plan.DefaultCasePlanModel;
 import io.casehub.blackboard.plan.PlanItem;
 import io.casehub.blackboard.stage.Stage;
 import io.casehub.engine.common.internal.model.PlanItemStatus;
@@ -64,7 +66,7 @@ class StageAutocompleteEvaluatorTest {
     verify(eventBus)
         .publish(
             io.casehub.blackboard.event.BlackboardEventBusAddresses.STAGE_COMPLETED,
-            new StageCompletedEvent(caseId, stage));
+            new StageCompletedEvent(caseId, stage, 0));
   }
 
   @Test
@@ -201,5 +203,38 @@ class StageAutocompleteEvaluatorTest {
     when(stage.isAutocomplete()).thenReturn(true);
     when(stage.getRequiredItemIds()).thenReturn(List.of(requiredIds));
     return stage;
+  }
+
+  // --- repeatable stage reset through evaluator ---
+
+  @Test
+  void repeatable_stage_resets_to_pending_after_autocomplete() {
+    UUID caseId = UUID.randomUUID();
+    DefaultCasePlanModel plan = new DefaultCasePlanModel(caseId);
+
+    Stage stage =
+        Stage.builder("decision")
+            .entryCondition(ctx -> true)
+            .repeatable(true)
+            .binding("do-work")
+            .build();
+    stage.activate();
+    plan.addStage(stage);
+
+    PlanItem item = PlanItem.create("do-work", "worker-a", 0);
+    plan.addPlanItem(item);
+    stage.addPlanItem(item.getPlanItemId());
+    stage.addRequiredItem(item.getPlanItemId());
+    item.markRunning();
+    item.markCompleted();
+
+    evaluator.evaluate(caseId, plan, item.getPlanItemId());
+
+    assertThat(stage.getStatus())
+        .as("repeatable stage must reset to PENDING after autocomplete")
+        .isEqualTo(io.casehub.blackboard.stage.StageStatus.PENDING);
+    assertThat(stage.getInstanceIndex()).isEqualTo(1);
+    assertThat(stage.getContainedPlanItemIds()).isEmpty();
+    assertThat(stage.getRequiredItemIds()).isEmpty();
   }
 }

--- a/blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/stage/StageTest.java
@@ -272,4 +272,88 @@ class StageTest {
     s.addBinding("b2");
     assertThat(snapshot).containsExactly("b1"); // snapshot unaffected by later add
   }
+
+  // ------------------------------------------------------------------ //
+  // Repeatable Stage (casehubio/engine#482)                             //
+  // ------------------------------------------------------------------ //
+
+  @Test
+  void repeatable_defaults_to_false() {
+    assertThat(Stage.create("intake").isRepeatable()).isFalse();
+  }
+
+  @Test
+  void builder_repeatable_sets_flag() {
+    Stage s = Stage.builder("intake").entryCondition(ctx -> true).repeatable(true).build();
+    assertThat(s.isRepeatable()).isTrue();
+  }
+
+  @Test
+  void resetForRepetition_on_repeatable_completed_stage() {
+    Stage s = Stage.builder("intake").entryCondition(ctx -> true).repeatable(true).build();
+    s.activate();
+    s.addPlanItem("pi-1");
+    s.addRequiredItem("pi-1");
+    s.complete();
+
+    boolean reset = s.resetForRepetition();
+
+    assertThat(reset).isTrue();
+    assertThat(s.getStatus()).isEqualTo(StageStatus.PENDING);
+    assertThat(s.getInstanceIndex()).isEqualTo(1);
+    assertThat(s.getContainedPlanItemIds()).isEmpty();
+    assertThat(s.getRequiredItemIds()).isEmpty();
+    assertThat(s.getContainedMilestoneIds()).isEmpty();
+    assertThat(s.getActivatedAt()).isNull();
+    assertThat(s.getCompletedAt()).isNull();
+  }
+
+  @Test
+  void resetForRepetition_on_non_repeatable_returns_false() {
+    Stage s = Stage.create("intake");
+    s.activate();
+    s.complete();
+
+    assertThat(s.resetForRepetition()).isFalse();
+    assertThat(s.getStatus()).isEqualTo(StageStatus.COMPLETED);
+  }
+
+  @Test
+  void resetForRepetition_on_non_completed_returns_false() {
+    Stage s = Stage.builder("intake").entryCondition(ctx -> true).repeatable(true).build();
+    s.activate();
+
+    assertThat(s.resetForRepetition()).isFalse();
+    assertThat(s.getStatus()).isEqualTo(StageStatus.ACTIVE);
+    assertThat(s.getInstanceIndex()).isEqualTo(0);
+  }
+
+  @Test
+  void instanceIndex_increments_on_each_reset() {
+    Stage s = Stage.builder("intake").entryCondition(ctx -> true).repeatable(true).build();
+    assertThat(s.getInstanceIndex()).isEqualTo(0);
+
+    s.activate();
+    s.complete();
+    s.resetForRepetition();
+    assertThat(s.getInstanceIndex()).isEqualTo(1);
+
+    s.activate();
+    s.complete();
+    s.resetForRepetition();
+    assertThat(s.getInstanceIndex()).isEqualTo(2);
+  }
+
+  @Test
+  void resetForRepetition_preserves_binding_names() {
+    Stage s =
+        Stage.builder("intake").entryCondition(ctx -> true).repeatable(true).binding("b1").build();
+    s.activate();
+    s.complete();
+    s.resetForRepetition();
+
+    assertThat(s.getContainedBindingNames())
+        .as("containedBindingNames must persist across resets — they are design-time declarations")
+        .containsExactly("b1");
+  }
 }

--- a/docs/specs/2026-06-15-signal-stage-routing-design.md
+++ b/docs/specs/2026-06-15-signal-stage-routing-design.md
@@ -1,0 +1,369 @@
+# Signal API, Implementation Routing, and Repeatable Stage
+
+**Issues:** engine#493, engine#476, engine#482
+**Branch:** `issue-493-signal-stage-routing`
+**Date:** 2026-06-15
+**Status:** Approved (rev 3)
+
+---
+
+## 1. Signal API and CDI Event Consistency (#493)
+
+### Root Cause
+
+#493 was filed against the pre-#491 codebase. The panels refactor (#491) changed `asJsonNode()` from flat working data to a panel document, silently breaking all JQ evaluation — including goal conditions evaluated after a signal. The fix (PR #495, merged) corrected `JQExpressionEngine.evaluate()` to evaluate against `context.panel(WORKING).asJsonNode()`.
+
+The engine's own test suite (`SignalDedupExtendedTest.signalAfterCaseCompletionDoesNotTriggerWorker`) confirms signal → CONTEXT_CHANGED → goal evaluation → COMPLETED works correctly in the current codebase.
+
+#493 is resolved by #491. The work here is three architectural improvements that surfaced during analysis.
+
+### Change A — `signal()` returns `CompletionStage<Void>`
+
+`CaseHubRuntime.signal()` is currently `void` — fire-and-forget with no completion signal. `startCase()` returns `CompletionStage<UUID>`. This inconsistency prevents callers from coordinating on signal processing completion and makes testing fragile.
+
+**API change (breaking):**
+
+```java
+// CaseHubRuntime — was void, now async
+CompletionStage<Void> signal(UUID caseId, String path, Object value);
+CompletionStage<Void> signal(UUID caseId, String path, Object value,
+                             String triggerChannelId, String triggerCorrelationId);
+```
+
+```java
+// CaseHub convenience — delegates to runtime
+CompletionStage<Void> signal(UUID caseId, String path, Object value);
+```
+
+**Internal wiring:**
+
+`CaseHubReactor.signal()` changes from `void` to returning `Uni<Void>`. Internally uses `eventBus.<Void>request(SIGNAL_RECEIVED, ...)` which returns `Uni<Message<Void>>`, mapped to `Uni<Void>` via `.replaceWithVoid()`. `CaseHubRuntimeImpl.signal()` subscribes via `uni.subscribeAsCompletionStage()`, matching the `startCase()` pattern.
+
+The `CompletionStage<Void>` resolves when the signal has been applied to the context, the event log written, and CONTEXT_CHANGED published. It does NOT guarantee that goal evaluation has completed — only that CONTEXT_CHANGED has been dispatched. Callers that need to await case state transitions should use Awaitility on the case status.
+
+### Change B — Standardise CDI fire-and-forget in all handlers
+
+Three handlers publish CONTEXT_CHANGED and fire CDI lifecycle events. Only one uses the correct fire-and-forget CDI pattern:
+
+| Handler | Current CDI pattern | Fix |
+|---------|-------------------|-----|
+| `WorkflowExecutionCompletedHandler` | `.invoke(() -> fireAsync().whenComplete())` | Already correct |
+| `CaseStartedEventHandler` | `.chain(() -> Uni.from(completionStage(fireAsync())))` | Change to fire-and-forget |
+| `SignalReceivedEventHandler` | `.chain(() -> Uni.from(completionStage(fireAsync())))` | Change to fire-and-forget |
+
+CDI lifecycle events are audit/observability concerns. They must never gate case state progression. A blocking CDI observer (e.g. ledger capture doing DB writes under contention) must not stall the handler's Uni chain.
+
+Pattern applied to both handlers:
+```java
+.invoke(() -> {
+    lifecycleEvents.fireAsync(...)
+        .whenComplete((v, t) -> {
+            if (t != null) LOG.warnf(t, "CaseLifecycleEvent observer failed...");
+        });
+})
+```
+
+### Change C — Standardise event dispatch ordering: CDI first, CONTEXT_CHANGED second
+
+All handlers adopt the dispatch ordering from `WorkflowExecutionCompletedHandler`:
+
+1. Dispatch CDI lifecycle events (fire-and-forget)
+2. Dispatch CONTEXT_CHANGED to event bus
+
+Both are fire-and-forget dispatches — there is no processing-order guarantee between the CDI managed executor and the Vert.x event loop. The value of CDI-first ordering is **decoupling**: both events are dispatched regardless of what happens next. With the current `.chain()` pattern in `SignalReceivedEventHandler`, the handler's Uni completion is gated on CDI observer completion — a slow observer blocks the chain and delays CONTEXT_CHANGED dispatch. The fire-and-forget pattern decouples them. The dispatch ordering is secondary; the decoupling is the point.
+
+### Change D — Integration test: signal → direct goal completion
+
+New test: a signal directly satisfies a goal condition with no worker or binding intermediary. The case definition has only a goal — no bindings, no workers. `signal()` sets a context value; the goal condition matches; the case transitions to COMPLETED.
+
+This exercises the signal-to-goal pipeline that the Claudony pattern relies on and confirms #493 is resolved.
+
+---
+
+## 2. ImplementationRoutingStrategy SPI (#476)
+
+### Problem
+
+When multiple workers register for the same capability, the engine schedules all of them. Application repos are forced to implement workarounds (QuarkMind's `StrategyTrustRouter` — ~300 lines). This is an engine concern: selecting which implementation handles a capability is symmetric to selecting which worker instance handles a task (`AgentRoutingStrategy`).
+
+### SPI Design
+
+Package: `io.casehub.api.spi.routing` (alongside `AgentRoutingStrategy`)
+
+```java
+public interface ImplementationRoutingStrategy {
+    Uni<ImplementationSelection> select(
+        ImplementationRoutingContext context,
+        List<ImplementationCandidate> candidates);
+}
+```
+
+**Supporting types:**
+
+```java
+public record ImplementationRoutingContext(
+    UUID caseId,
+    String capabilityName,
+    JsonNode caseContext       // working panel JSON — matches AgentRoutingContext
+) {}
+
+public record ImplementationCandidate(
+    String bindingName,
+    String workerName,
+    String capabilityName     // matches AgentRoutingContext field naming
+) {}
+
+public sealed interface ImplementationSelection {
+    record Selected(List<String> bindingNames) implements ImplementationSelection {
+        Selected {
+            if (bindingNames.isEmpty())
+                throw new IllegalArgumentException("Use RunNone for empty selection");
+            bindingNames = List.copyOf(bindingNames);
+        }
+    }
+    record RunAll() implements ImplementationSelection {}
+    record RunNone() implements ImplementationSelection {}
+}
+```
+
+**`Selected(List<String>)`** covers both single and subset selection. Compact constructor enforces non-empty and defensive copy via `List.copyOf()` — sealed types are API surface.
+
+**`RunAll`** preserves current behaviour — all implementations run. Default fallback when the strategy cannot decide.
+
+**`RunNone`** — all candidates are inappropriate. The capability is skipped entirely for this evaluation cycle. Covers the case where all implementations are untrusted or unavailable.
+
+### Routing Pipeline
+
+The relationship between `ImplementationRoutingStrategy` and `AgentRoutingStrategy` is a two-stage pipeline — separate concerns applied sequentially:
+
+```
+Binding eligibility → Stage gating
+  → [ImplementationRouting: which binding(s) for this capability?]
+  → PlanningStrategy: priority/ordering
+  → [AgentRouting: which worker instance for this binding?]
+  → Worker scheduling
+```
+
+### Default
+
+`NoOpImplementationRoutingStrategy` — `@DefaultBean @ApplicationScoped`, returns `RunAll`. Zero behaviour change without a strategy on classpath.
+
+Located in `runtime/src/main/java/io/casehub/engine/internal/routing/`.
+
+### Integration Point
+
+`PlanningStrategyLoopControl.select()` — implementation routing runs at step 3.5: after `stageLifecycleEvaluator.evaluate()` (step 3) and before `planningStrategy.select()` (step 4). Stage lifecycle evaluation can change which stages are ACTIVE, affecting binding eligibility — routing must operate on the post-evaluation state.
+
+The routing filters **bindings before PlanItem creation**, not PlanItems after creation. This avoids a create-then-cancel anti-pattern:
+
+1. Stage gating → gated-eligible bindings
+2. `stageLifecycleEvaluator.evaluate()` → stage states updated
+3. Group gated-eligible bindings by capability name (extracted from `CapabilityTarget`)
+4. Groups with a single binding → pass through
+5. Groups with >1 binding → build `ImplementationCandidate` list, call `select()`
+6. If `Selected(bindingNames)` → keep only selected bindings, discard rest
+7. If `RunAll` → keep all (current behaviour)
+8. If `RunNone` → discard all bindings in the group
+9. Create PlanItems only for surviving bindings via `addPlanItemIfAbsent()`
+
+No PlanItem is ever created and then cancelled — the routing decision happens upstream of PlanItem creation.
+
+### Failure Fallback
+
+If the selected implementation's worker fails and retries are exhausted, the engine does NOT automatically try another implementation. The PlanItem goes FAULTED. Retry-at-routing-level (tracking which implementations have been tried) is explicitly out of scope for v1. File as tracked issue.
+
+### Contract Tests
+
+Abstract contract test in `api/src/test/java/io/casehub/api/spi/routing/` — verifies:
+- Single candidate → returns `Selected` with that candidate
+- Empty candidates → throws or returns `RunAll`
+- Null context → throws
+
+### Engine Unit Tests
+
+In `runtime/src/test/java/io/casehub/engine/internal/routing/`:
+- `NoOpImplementationRoutingStrategy` returns `RunAll`
+- Verify `NoOpImplementationRoutingStrategy` is `@DefaultBean`
+
+### Blackboard Integration Tests
+
+In `blackboard/src/test/java/io/casehub/blackboard/it/`:
+- Case with two bindings targeting the same capability, different workers
+- Recording `ImplementationRoutingStrategy` selects one → only the selected worker runs
+- Routing → agent routing pipeline test: routing picks the binding, agent routing picks the worker within that binding
+- `RunNone` test: strategy returns `RunNone` → no PlanItem created, no worker scheduled
+
+### Future Work (tracked issues, not in this branch)
+
+- `TrustWeightedImplementationStrategy` in `casehub-engine-ledger` — four-phase trust maturity model, symmetric with `TrustWeightedAgentStrategy`. File as engine issue.
+- QuarkMind migration — delete `StrategyTrustRouter`, `StrategySelector`, `StrategyTrustObserver` (~300 lines). File as quarkmind issue.
+- Failure fallback to alternative implementation after retry exhaustion. File as engine issue.
+
+---
+
+## 3. Repeatable Stage (#482)
+
+### Prerequisite: Stage–PlanItem Auto-Registration
+
+**Critical gap (not specific to repeatable stages):** `Stage.addRequiredItem()` and `Stage.addPlanItem()` are only called from test code. Zero production call sites. `StageAutocompleteEvaluator.evaluate()` checks `stage.getRequiredItemIds().contains(changedItemId)` — with an empty `requiredItemIds`, autocomplete never fires in production for ANY stage.
+
+**Fix (precursor commit, before #482):** `PlanningStrategyLoopControl.select()` automatically registers PlanItems with their owning stage. After `addPlanItemIfAbsent()` returns `true`, if the binding name is in a stage's `containedBindingNames`, the loop control calls:
+
+```java
+stage.addPlanItem(planItem.getPlanItemId());
+stage.addRequiredItem(planItem.getPlanItemId());
+```
+
+This makes autocomplete work for ALL stages in production, not just in tests. Without this, neither repeatable nor non-repeatable stages autocomplete in production.
+
+Committed as a separate fix before #482 since it's a general blackboard correctness issue. File as a separate engine issue.
+
+### Problem
+
+CMMN supports repeatable plan items (§8.5.3) — a Stage that can activate more than once during a case lifecycle. The current Stage has a single lifecycle: PENDING → ACTIVE → COMPLETED/TERMINATED. No mechanism to re-activate after completion.
+
+QuarkMind's game loop needs a per-tick "decision stage" that activates on each `game.state` signal, runs workers, autocompletes, and re-activates on the next tick.
+
+### Model Change
+
+`Stage` gains two fields:
+
+```java
+private final boolean repeatable;  // set at construction, immutable
+private final AtomicInteger instanceIndex = new AtomicInteger(0);
+```
+
+Builder addition only — no fluent setter:
+```java
+public Builder repeatable(boolean repeatable) {
+    this.repeatable = repeatable;
+    return this;
+}
+```
+
+`repeatable` is a lifecycle-model flag set at construction time. Unlike `withEntryCondition()` and `withAutocomplete()` (which configure behaviour), `repeatable` changes the fundamental lifecycle model — a stage that wasn't constructed as repeatable should never become repeatable. The `Builder.repeatable()` method is the only way to set it.
+
+### V1 Constraint: No Nested Stages or Milestones in Repeatable Stages
+
+Repeatable stages with nested stages or milestones require complex lifecycle interleaving (nested stage reset semantics, milestone re-evaluation after parent reset). Runtime enforcement only — the builder lacks containment context at construction time (nested stages and milestones are added after construction via `addNestedStage()` and `addMilestone()`). `StageAutocompleteEvaluator` logs a warning and skips reset if a repeatable stage has non-empty `containedStageIds` or `containedMilestoneIds`. File nested-repeatable as tracked issue.
+
+### Lifecycle Extension
+
+Standard: `PENDING → ACTIVE → COMPLETED` (terminal)
+
+Repeatable: `PENDING → ACTIVE → COMPLETED → PENDING → ACTIVE → COMPLETED → ...`
+
+When a repeatable Stage reaches COMPLETED, it resets to PENDING with an incremented instance index.
+
+### Reset Mechanism
+
+New method on `Stage`:
+
+```java
+public boolean resetForRepetition() {
+    if (!repeatable) return false;
+    if (status.compareAndSet(StageStatus.COMPLETED, StageStatus.PENDING)) {
+        instanceIndex.incrementAndGet();
+        containedPlanItemIds.clear();
+        requiredItemIds.clear();
+        containedMilestoneIds.clear();
+        activatedAt = null;
+        completedAt = null;
+        return true;
+    }
+    return false;
+}
+```
+
+All containment sets are cleared — new PlanItems (with new UUIDs from `PlanItem.create()`) will be registered by the auto-registration fix above. Previous-instance PlanItems remain in the agenda in terminal states — `filterToDispatchable()` skips them, and they're visible for audit/CBR.
+
+### Where Reset Is Called
+
+`StageAutocompleteEvaluator` — after marking a Stage COMPLETED:
+
+1. Capture `int completingIndex = stage.getInstanceIndex()` BEFORE reset
+2. Publish `StageCompletedEvent(caseId, stage, completingIndex)`
+3. If `stage.isRepeatable()`, call `resetForRepetition()`
+
+The completion event fires with the captured index — not read from the mutable stage after reset.
+
+### Event Record Changes
+
+`StageCompletedEvent` and `StageActivatedEvent` gain an explicit `instanceIndex` field:
+
+```java
+public record StageCompletedEvent(UUID caseId, Stage stage, int instanceIndex) {}
+public record StageActivatedEvent(UUID caseId, Stage stage, int instanceIndex) {}
+```
+
+The existing Javadoc already warns that `stage` is passed by reference and is mutable. The `instanceIndex` field captures a snapshot value at publish time — handlers use this field for the completing/activating instance, not `stage.getInstanceIndex()` which may have advanced.
+
+`StageLifecycleEvaluator.activatePendingStages()` captures the index when publishing:
+```java
+eventBus.publish(BlackboardEventBusAddresses.STAGE_ACTIVATED,
+    new StageActivatedEvent(ctx.caseId(), stage, stage.getInstanceIndex()));
+```
+
+### Instance Tracking
+
+- `Stage.getInstanceIndex()` — current instance (0-based)
+- Event log payload includes `instanceIndex` for each STAGE_ACTIVATED / STAGE_COMPLETED entry
+
+### Re-activation Semantics with Persistent Entry Conditions
+
+A repeatable stage with a persistent entry condition (e.g. a lambda that tests `context.get("game.state") != null`) will re-activate on every CONTEXT_CHANGED after reset — including those triggered by the previous instance's worker output being applied. This is correct behaviour for QuarkMind's game loop (per-output-change re-activation). Consumers who want signal-gated activation need entry conditions that test for new values (e.g. a version counter or changed flag), not the existence of existing values.
+
+### Concurrency Policy
+
+Sequential only: previous instance must complete before next activates. `StageLifecycleEvaluator.activatePendingStages()` naturally enforces this — a reset Stage starts in PENDING, and the entry condition re-evaluates on the next CONTEXT_CHANGED cycle.
+
+Known timing race: `WORKER_EXECUTION_FINISHED` fan-out means auto-registration and `resetForRepetition()` may interleave on different threads (`WorkflowExecutionCompletedHandler` on event loop, `PlanItemCompletionHandler` on worker thread with `blocking = true`). The race is self-healing — at worst one evaluation cycle is skipped before the next CONTEXT_CHANGED correctly re-registers PlanItems.
+
+Concurrent mode (overlapping instances) is a future extension. File as tracked issue.
+
+### YAML Support
+
+`BlackboardPlanConfigurer` supports `repeatable: true` in Stage YAML schema. `CaseDefinitionYamlMapper` maps it to `Stage.Builder.repeatable(true)`.
+
+### Tests
+
+**Unit tests (`StageTest`):**
+- `resetForRepetition` on repeatable stage → status PENDING, index incremented, all containment sets cleared
+- `resetForRepetition` on non-repeatable stage → returns false, no state change
+- `resetForRepetition` on non-COMPLETED stage → returns false
+- `repeatable` flag is immutable — only settable via Builder
+
+**`StageLifecycleEvaluator` tests:**
+- Repeatable COMPLETED stage (after reset) → re-evaluates entry condition on next cycle
+- Non-repeatable COMPLETED stage → skipped (current behaviour preserved)
+
+**`StageAutocompleteEvaluator` tests:**
+- Autocomplete on repeatable stage → fires StageCompletedEvent with correct instanceIndex, resets to PENDING
+- Instance index increments on each completion
+- StageCompletedEvent.instanceIndex captures the completing instance, not the post-reset index
+
+**`DefaultCasePlanModel` tests:**
+- `addPlanItemIfAbsent` creates new PlanItems after a terminal PlanItem exists for the same binding (confirms the contract supports repetition — terminal PlanItem in `activeByBinding` is evicted)
+
+**Integration test (`blackboard/`):**
+- Signal N times → verify N Stage activations and N completions in event log, each with incrementing instance index
+- Verify workers inside the Stage run once per activation
+- Auto-registration: PlanItems created by `addPlanItemIfAbsent` are automatically registered as required items on their owning stage
+
+### Future Work (tracked issues)
+
+- Concurrent repetition mode (overlapping instances) — engine issue
+- `signalAndAwait()` imperative alternative — engine issue (mentioned in #482)
+- Nested stages and milestones inside repeatable stages — engine issue
+- `instanceIndex` recovery on JVM restart — engine issue (minor: most cases complete before restart; recovery would replay event log to find last recorded index)
+
+---
+
+## Execution Order
+
+1. **Stage–PlanItem auto-registration** — precursor blackboard correctness fix (new engine issue)
+2. **#493** — signal API + CDI consistency
+3. **#476** — ImplementationRoutingStrategy SPI
+4. **#482** — Repeatable Stage (depends on auto-registration fix)
+
+Each issue is committed separately with `Refs #N` / `Closes #N`.

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -294,19 +294,21 @@ class CaseHubReactor {
     }
   }
 
-  void signal(UUID caseId, String path, Object value) {
-    signal(caseId, path, value, null, null);
+  Uni<Void> signal(UUID caseId, String path, Object value) {
+    return signal(caseId, path, value, null, null);
   }
 
-  void signal(
+  Uni<Void> signal(
       UUID caseId,
       String path,
       Object value,
       String triggerChannelId,
       String triggerCorrelationId) {
-    eventBus.publish(
-        SIGNAL_RECEIVED,
-        new SignalReceivedEvent(caseId, path, value, triggerChannelId, triggerCorrelationId));
+    return eventBus
+        .<Void>request(
+            SIGNAL_RECEIVED,
+            new SignalReceivedEvent(caseId, path, value, triggerChannelId, triggerCorrelationId))
+        .replaceWithVoid();
   }
 
   void cancelCase(UUID caseId) {

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubRuntimeImpl.java
@@ -90,18 +90,20 @@ class CaseHubRuntimeImpl implements CaseHubRuntime {
   }
 
   @Override
-  public void signal(UUID caseId, String path, Object value) {
-    reactor.signal(caseId, path, value, null, null);
+  public CompletionStage<Void> signal(UUID caseId, String path, Object value) {
+    return reactor.signal(caseId, path, value, null, null).subscribeAsCompletionStage();
   }
 
   @Override
-  public void signal(
+  public CompletionStage<Void> signal(
       UUID caseId,
       String path,
       Object value,
       String triggerChannelId,
       String triggerCorrelationId) {
-    reactor.signal(caseId, path, value, triggerChannelId, triggerCorrelationId);
+    return reactor
+        .signal(caseId, path, value, triggerChannelId, triggerCorrelationId)
+        .subscribeAsCompletionStage();
   }
 
   @Override

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseStartedEventHandler.java
@@ -72,35 +72,32 @@ public class CaseStartedEventHandler {
         .append(eventLog, instance.tenancyId)
         .chain(() -> schedulerService.registerScheduledTriggers(instance))
         .invoke(
-            () ->
-                eventBus.publish(
-                    EventBusAddresses.CONTEXT_CHANGED,
-                    new CaseContextChangedEvent(
-                        instance, instance.getCaseContext().snapshot(), null)))
-        .chain(
-            () ->
-                Uni.createFrom()
-                    .completionStage(
-                        () ->
-                            lifecycleEvents.fireAsync(
-                                new CaseLifecycleEvent(
-                                    instance.getUuid(),
-                                    instance.tenancyId,
-                                    "StartCase",
-                                    "CaseStarted",
-                                    instance.getState().name(),
-                                    null,
-                                    "System",
-                                    traceId)))
-                    .onFailure()
-                    .recoverWithItem(
-                        t -> {
+            () -> {
+              lifecycleEvents
+                  .fireAsync(
+                      new CaseLifecycleEvent(
+                          instance.getUuid(),
+                          instance.tenancyId,
+                          "StartCase",
+                          "CaseStarted",
+                          instance.getState().name(),
+                          null,
+                          "System",
+                          traceId))
+                  .whenComplete(
+                      (v, t) -> {
+                        if (t != null)
                           LOG.warnf(
                               t,
                               "CaseLifecycleEvent observer failed for caseId=%s event=CaseStarted",
                               instance.getUuid());
-                          return null;
-                        })
-                    .replaceWithVoid());
+                      });
+            })
+        .invoke(
+            () ->
+                eventBus.publish(
+                    EventBusAddresses.CONTEXT_CHANGED,
+                    new CaseContextChangedEvent(
+                        instance, instance.getCaseContext().snapshot(), null)));
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/SignalReceivedEventHandler.java
@@ -114,6 +114,28 @@ public class SignalReceivedEventHandler {
     return eventLogRepository
         .append(eventLog, instance.tenancyId)
         .invoke(
+            () -> {
+              lifecycleEvents
+                  .fireAsync(
+                      new CaseLifecycleEvent(
+                          instance.getUuid(),
+                          instance.tenancyId,
+                          "SignalCase",
+                          "SignalReceived",
+                          instance.getState().name(),
+                          null,
+                          "System",
+                          traceId))
+                  .whenComplete(
+                      (v, t) -> {
+                        if (t != null)
+                          LOG.warnf(
+                              t,
+                              "CaseLifecycleEvent observer failed for caseId=%s event=SignalReceived",
+                              instance.getUuid());
+                      });
+            })
+        .invoke(
             () ->
                 eventBus.publish(
                     CONTEXT_CHANGED,
@@ -123,31 +145,6 @@ public class SignalReceivedEventHandler {
                         ContextPanel.WORKING,
                         event.triggerChannelId(),
                         event.triggerCorrelationId())))
-        .chain(
-            () ->
-                Uni.createFrom()
-                    .completionStage(
-                        () ->
-                            lifecycleEvents.fireAsync(
-                                new CaseLifecycleEvent(
-                                    instance.getUuid(),
-                                    instance.tenancyId,
-                                    "SignalCase",
-                                    "SignalReceived",
-                                    instance.getState().name(),
-                                    null,
-                                    "System",
-                                    traceId)))
-                    .onFailure()
-                    .recoverWithItem(
-                        t -> {
-                          LOG.warnf(
-                              t,
-                              "CaseLifecycleEvent observer failed for caseId=%s event=SignalReceived",
-                              instance.getUuid());
-                          return null;
-                        })
-                    .replaceWithVoid())
         .replaceWithVoid()
         .onFailure()
         .invoke(

--- a/runtime/src/main/java/io/casehub/engine/internal/routing/NoOpImplementationRoutingStrategy.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/routing/NoOpImplementationRoutingStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.routing;
+
+import io.casehub.api.spi.routing.ImplementationCandidate;
+import io.casehub.api.spi.routing.ImplementationRoutingContext;
+import io.casehub.api.spi.routing.ImplementationRoutingStrategy;
+import io.casehub.api.spi.routing.ImplementationSelection;
+import io.quarkus.arc.DefaultBean;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+/**
+ * Default no-op implementation routing — all competing implementations run. Zero behaviour change
+ * without a consumer strategy on the classpath. Protocol PP-20260514-engine-spi-noops-defaultbean.
+ * Refs casehubio/engine#476.
+ */
+@DefaultBean
+@ApplicationScoped
+public class NoOpImplementationRoutingStrategy implements ImplementationRoutingStrategy {
+
+  @Override
+  public Uni<ImplementationSelection> select(
+      ImplementationRoutingContext context, List<ImplementationCandidate> candidates) {
+    return Uni.createFrom().item(new ImplementationSelection.RunAll());
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/SignalGoalCompletionTest.java
+++ b/runtime/src/test/java/io/casehub/engine/SignalGoalCompletionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.casehub.api.engine.CaseHub;
+import io.casehub.api.model.CaseDefinition;
+import io.casehub.api.model.CaseStatus;
+import io.casehub.api.model.Goal;
+import io.casehub.api.model.GoalExpression;
+import io.casehub.api.model.GoalKind;
+import io.casehub.engine.common.spi.cache.CaseInstanceCache;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the signal-to-goal pipeline: a signal directly satisfies a goal condition with no worker
+ * or binding intermediary. The case definition has only a goal — no bindings, no workers.
+ *
+ * <p>Exercises the pipeline that Claudony relies on and confirms casehubio/engine#493 is resolved.
+ * Refs casehubio/engine#493.
+ */
+@QuarkusTest
+public class SignalGoalCompletionTest {
+
+  @Inject SignalGoalOnlyBean bean;
+
+  @Inject CaseInstanceCache caseInstanceCache;
+
+  @Test
+  void signalDirectlySatisfiesGoalAndCompletesCase() {
+    UUID caseId = bean.startCase(Map.of()).toCompletableFuture().join();
+
+    assertEquals(CaseStatus.RUNNING, caseInstanceCache.get(caseId).getState());
+
+    bean.signal(caseId, "done", true).toCompletableFuture().join();
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    CaseStatus.COMPLETED,
+                    caseInstanceCache.get(caseId).getState(),
+                    "Case must transition to COMPLETED when signal satisfies goal"));
+  }
+
+  @ApplicationScoped
+  public static class SignalGoalOnlyBean extends CaseHub {
+
+    private final Goal doneGoal =
+        Goal.builder().name("signalDone").condition(".done == true").kind(GoalKind.SUCCESS).build();
+
+    @Override
+    public CaseDefinition getDefinition() {
+      return CaseDefinition.builder()
+          .namespace("test-signal-goal")
+          .name("Signal Goal Only Test")
+          .version("1.0.0")
+          .goals(doneGoal)
+          .completion(GoalExpression.allOf(doneGoal))
+          .build();
+    }
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/NoOpImplementationRoutingStrategyTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/NoOpImplementationRoutingStrategyTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.casehub.api.spi.routing.ImplementationCandidate;
+import io.casehub.api.spi.routing.ImplementationRoutingContext;
+import io.casehub.api.spi.routing.ImplementationSelection;
+import io.quarkus.arc.DefaultBean;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class NoOpImplementationRoutingStrategyTest {
+
+  private final NoOpImplementationRoutingStrategy strategy =
+      new NoOpImplementationRoutingStrategy();
+
+  @Test
+  void returns_runAll() {
+    var ctx = new ImplementationRoutingContext(UUID.randomUUID(), "someCapability", null);
+    var candidates =
+        List.of(
+            new ImplementationCandidate("b1", "w1", "someCapability"),
+            new ImplementationCandidate("b2", "w2", "someCapability"));
+
+    ImplementationSelection result = strategy.select(ctx, candidates).await().indefinitely();
+
+    assertThat(result).isInstanceOf(ImplementationSelection.RunAll.class);
+  }
+
+  @Test
+  void is_annotated_defaultBean() {
+    assertThat(NoOpImplementationRoutingStrategy.class.isAnnotationPresent(DefaultBean.class))
+        .as("NoOpImplementationRoutingStrategy must be @DefaultBean")
+        .isTrue();
+  }
+}


### PR DESCRIPTION
## Summary

- **Signal API (#493)**: `signal()` returns `CompletionStage<Void>` (was `void`). CDI lifecycle events standardised to fire-and-forget across all handlers. New integration test: signal directly satisfies goal with no workers.
- **ImplementationRoutingStrategy SPI (#476)**: new SPI selects which binding(s) handle a capability when multiple compete. Sealed `ImplementationSelection` (Selected/RunAll/RunNone). `NoOp @DefaultBean` returns `RunAll`. Routing filters bindings before PlanItem creation.
- **Repeatable Stage (#482)**: Stage gains immutable `repeatable` flag and `instanceIndex`. `resetForRepetition()` clears containment sets after autocomplete. Event records carry explicit `instanceIndex` snapshot.
- **Stage-PlanItem auto-registration (#497)**: `PlanningStrategyLoopControl` auto-registers PlanItems with owning stages, enabling stage autocomplete in production (previously test-only).

Closes #493, Refs #476, Refs #482, Refs #497

## Test plan

- [x] `ImplementationSelectionTest` — empty list rejection, defensive copy, immutability
- [x] `NoOpImplementationRoutingStrategyTest` — returns RunAll, `@DefaultBean` verified
- [x] `ImplementationRoutingTest` — Selected/RunAll/RunNone outcomes, single-binding skip
- [x] `BindingGatingTest` — auto-registration (staged/free-floating/idempotent)
- [x] `StageTest` — resetForRepetition, instanceIndex, binding name preservation
- [x] `StageAutocompleteEvaluatorTest` — repeatable reset through evaluator path
- [x] `SignalGoalCompletionTest` — signal directly satisfies goal, case COMPLETED
- [x] `SignalDedupExtendedTest` — existing dedup tests pass with new CompletionStage API
- [x] Full blackboard suite (263 tests) — zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)