### PR TITLE
feat(#486): thread tenancyId through WorkerRetriesExhaustedEvent and ActionGateWorkerFaultedEvent

### DIFF
--- a/blackboard/src/main/java/io/casehub/blackboard/handler/ActionGateExpiredPlanItemHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/ActionGateExpiredPlanItemHandler.java
@@ -74,7 +74,8 @@ public class ActionGateExpiredPlanItemHandler {
               }
               item.markFaulted();
               planItemFaultedEvents.fireAsync(
-                  new PlanItemFaultedEvent(event.caseId(), planItemId, event.workerId(), null));
+                  new PlanItemFaultedEvent(
+                      event.caseId(), planItemId, event.workerId(), event.tenancyId()));
               LOG.infof(
                   "PlanItem %s faulted (gate worker faulted): caseId=%s workerId=%s",
                   planItemId, event.caseId(), event.workerId());

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/ActionGateRejectedPlanItemHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/ActionGateRejectedPlanItemHandler.java
@@ -74,7 +74,8 @@ public class ActionGateRejectedPlanItemHandler {
               }
               item.markFaulted();
               planItemFaultedEvents.fireAsync(
-                  new PlanItemFaultedEvent(event.caseId(), planItemId, event.workerId(), null));
+                  new PlanItemFaultedEvent(
+                      event.caseId(), planItemId, event.workerId(), event.tenancyId()));
               LOG.infof(
                   "PlanItem %s faulted (gate worker faulted): caseId=%s workerId=%s",
                   planItemId, event.caseId(), event.workerId());

--- a/blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemFaultHandler.java
+++ b/blackboard/src/main/java/io/casehub/blackboard/handler/PlanItemFaultHandler.java
@@ -83,7 +83,8 @@ public class PlanItemFaultHandler {
                   "PlanItem %s marked FAULTED for worker '%s' in case %s",
                   planItemId, event.workerId(), event.caseId());
               planItemFaultedEvents.fireAsync(
-                  new PlanItemFaultedEvent(event.caseId(), planItemId, event.workerId(), null));
+                  new PlanItemFaultedEvent(
+                      event.caseId(), planItemId, event.workerId(), event.tenancyId()));
             });
   }
 }

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemFaultHandlerTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/PlanItemFaultHandlerTest.java
@@ -48,7 +48,7 @@ class PlanItemFaultHandlerTest {
   }
 
   private WorkerRetriesExhaustedEvent eventFor(String workerId) {
-    return new WorkerRetriesExhaustedEvent(caseId, workerId, "idempotency-key");
+    return new WorkerRetriesExhaustedEvent(caseId, workerId, "idempotency-key", "test-tenant");
   }
 
   @Test
@@ -120,6 +120,7 @@ class PlanItemFaultHandlerTest {
   @Test
   void no_plan_registered_does_not_throw() {
     UUID otherCase = UUID.randomUUID();
-    handler.onWorkerRetriesExhausted(new WorkerRetriesExhaustedEvent(otherCase, "w", "key"));
+    handler.onWorkerRetriesExhausted(
+        new WorkerRetriesExhaustedEvent(otherCase, "w", "key", "test-tenant"));
   }
 }

--- a/blackboard/src/test/java/io/casehub/blackboard/handler/WorkerRetryExhaustionHandlerTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/handler/WorkerRetryExhaustionHandlerTest.java
@@ -60,7 +60,7 @@ class WorkerRetryExhaustionHandlerTest {
     registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
 
     handler.onWorkerRetriesExhausted(
-        new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123"));
+        new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123", "test-tenant"));
 
     assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED);
   }
@@ -68,14 +68,14 @@ class WorkerRetryExhaustionHandlerTest {
   @Test
   void unknown_case_is_a_noop() {
     handler.onWorkerRetriesExhausted(
-        new WorkerRetriesExhaustedEvent(UUID.randomUUID(), "worker-x", "hash"));
+        new WorkerRetriesExhaustedEvent(UUID.randomUUID(), "worker-x", "hash", "test-tenant"));
     // no exception
   }
 
   @Test
   void unknown_worker_is_a_noop() {
     handler.onWorkerRetriesExhausted(
-        new WorkerRetriesExhaustedEvent(caseId, "unknown-worker", "hash"));
+        new WorkerRetriesExhaustedEvent(caseId, "unknown-worker", "hash", "test-tenant"));
     // no exception
   }
 
@@ -88,7 +88,7 @@ class WorkerRetryExhaustionHandlerTest {
     registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
 
     handler.onWorkerRetriesExhausted(
-        new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123"));
+        new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123", "test-tenant"));
 
     assertThat(item.getStatus()).isEqualTo(PlanItemStatus.FAULTED); // unchanged, no throw
   }
@@ -103,7 +103,7 @@ class WorkerRetryExhaustionHandlerTest {
     registry.indexForCompletion(caseId, "worker-a", item.getPlanItemId());
 
     handler.onWorkerRetriesExhausted(
-        new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123"));
+        new WorkerRetriesExhaustedEvent(caseId, "worker-a", "hash-123", "test-tenant"));
 
     // PENDING is not RUNNING — handler must not transition it (guard fires before plan item
     // indexing in the guard-blocked path, so lookup returns empty; this tests a theoretical edge)

--- a/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateWorkerFaultedEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/ActionGateWorkerFaultedEvent.java
@@ -28,4 +28,5 @@ import java.util.UUID;
  * which also faults the {@code CaseInstance} state — gate faults must leave the case RUNNING so the
  * rejection binding can react.
  */
-public record ActionGateWorkerFaultedEvent(UUID caseId, String workerId, String idempotency) {}
+public record ActionGateWorkerFaultedEvent(
+    UUID caseId, String workerId, String idempotency, String tenancyId) {}

--- a/common/src/main/java/io/casehub/engine/common/internal/event/WorkerRetriesExhaustedEvent.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/event/WorkerRetriesExhaustedEvent.java
@@ -17,4 +17,5 @@ package io.casehub.engine.common.internal.event;
 
 import java.util.UUID;
 
-public record WorkerRetriesExhaustedEvent(UUID caseId, String workerId, String idempotency) {}
+public record WorkerRetriesExhaustedEvent(
+    UUID caseId, String workerId, String idempotency, String tenancyId) {}

--- a/resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterEventHandlerTest.java
+++ b/resilience/src/test/java/io/casehub/resilience/deadletter/DeadLetterEventHandlerTest.java
@@ -56,7 +56,7 @@ class DeadLetterEventHandlerTest {
 
     eventBus.publish(
         EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
-        new WorkerRetriesExhaustedEvent(caseId, workerId, hash));
+        new WorkerRetriesExhaustedEvent(caseId, workerId, hash, "test-tenant"));
 
     await()
         .atMost(5, TimeUnit.SECONDS)
@@ -79,10 +79,10 @@ class DeadLetterEventHandlerTest {
 
     eventBus.publish(
         EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
-        new WorkerRetriesExhaustedEvent(caseA, "worker-a", "hash-a"));
+        new WorkerRetriesExhaustedEvent(caseA, "worker-a", "hash-a", "test-tenant"));
     eventBus.publish(
         EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
-        new WorkerRetriesExhaustedEvent(caseB, "worker-b", "hash-b"));
+        new WorkerRetriesExhaustedEvent(caseB, "worker-b", "hash-b", "test-tenant"));
 
     await()
         .atMost(5, TimeUnit.SECONDS)
@@ -100,7 +100,7 @@ class DeadLetterEventHandlerTest {
     UUID caseId = UUID.randomUUID();
     eventBus.publish(
         EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
-        new WorkerRetriesExhaustedEvent(caseId, "specific-worker", "hash-xyz"));
+        new WorkerRetriesExhaustedEvent(caseId, "specific-worker", "hash-xyz", "test-tenant"));
 
     await()
         .atMost(5, TimeUnit.SECONDS)

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateExpiredHandler.java
@@ -110,7 +110,8 @@ public class ActionGateExpiredHandler {
     // WORKER_RETRIES_EXHAUSTED)
     eventBus.publish(
         EventBusAddresses.ACTION_GATE_WORKER_FAULTED,
-        new ActionGateWorkerFaultedEvent(instance.getUuid(), gate.workerId(), gate.idempotency()));
+        new ActionGateWorkerFaultedEvent(
+            instance.getUuid(), gate.workerId(), gate.idempotency(), instance.tenancyId));
 
     // EventLog write is best-effort — failures are logged, not propagated
     writeResolutionEventLog(instance, gate)

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/ActionGateRejectedHandler.java
@@ -126,7 +126,8 @@ public class ActionGateRejectedHandler {
     // transition.
     eventBus.publish(
         EventBusAddresses.ACTION_GATE_WORKER_FAULTED,
-        new ActionGateWorkerFaultedEvent(instance.getUuid(), gate.workerId(), gate.idempotency()));
+        new ActionGateWorkerFaultedEvent(
+            instance.getUuid(), gate.workerId(), gate.idempotency(), instance.tenancyId));
 
     // EventLog write is best-effort and fire-and-forget — failures are logged, not propagated
     writeResolutionEventLog(instance, gate)

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkerScheduleEventHandler.java
@@ -101,7 +101,8 @@ public class WorkerScheduleEventHandler {
           instance.getUuid(), worker.getName());
       eventBus.publish(
           EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
-          new WorkerRetriesExhaustedEvent(instance.getUuid(), worker.getName(), inputDataHash));
+          new WorkerRetriesExhaustedEvent(
+              instance.getUuid(), worker.getName(), inputDataHash, instance.tenancyId));
       return Uni.createFrom().voidItem();
     }
 

--- a/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzRetryService.java
+++ b/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzRetryService.java
@@ -126,7 +126,8 @@ class QuartzRetryService {
             ctx.workerId(), retryPolicy.maxAttempts(), ctx.caseId(), exhaust.reason());
         eventBus.publish(
             EventBusAddresses.WORKER_RETRIES_EXHAUSTED,
-            new WorkerRetriesExhaustedEvent(ctx.caseId(), ctx.workerId(), ctx.inputDataHash()));
+            new WorkerRetriesExhaustedEvent(
+                ctx.caseId(), ctx.workerId(), ctx.inputDataHash(), ctx.tenancyId()));
         yield Uni.createFrom().voidItem();
       }
     };


### PR DESCRIPTION
## Summary

- Add `String tenancyId` field to `WorkerRetriesExhaustedEvent` and `ActionGateWorkerFaultedEvent` records
- Wire `tenancyId` from `CaseInstance.tenancyId` (runtime producers) and `WorkerRetryContext.tenancyId` (Quartz producer) through to `PlanItemFaultedEvent` in the three blackboard consumers
- All three blackboard handlers (`PlanItemFaultHandler`, `ActionGateRejectedPlanItemHandler`, `ActionGateExpiredPlanItemHandler`) now pass `event.tenancyId()` instead of `null` when firing `PlanItemFaultedEvent`

## Test plan

- [x] `PlanItemFaultHandlerTest` — 7 tests pass
- [x] `WorkerRetryExhaustionHandlerTest` — 5 tests pass
- [x] `QuartzRetryServiceTest` — 6 tests pass
- [x] `DeadLetterEventHandlerTest` — 3 tests pass (QuarkusTest integration)

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)