### PR TITLE
feat(engine#455): wire CurrentPrincipal identity into PropagationContext

### DIFF
--- a/api/src/main/java/io/casehub/api/context/PropagationContext.java
+++ b/api/src/main/java/io/casehub/api/context/PropagationContext.java
@@ -17,7 +17,6 @@ package io.casehub.api.context;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -52,7 +51,7 @@ public class PropagationContext {
       Instant deadline,
       Duration remainingBudget) {
     this.traceId = traceId;
-    this.inheritedAttributes = Collections.unmodifiableMap(new HashMap<>(inheritedAttributes));
+    this.inheritedAttributes = Map.copyOf(inheritedAttributes);
     this.deadline = deadline;
     this.remainingBudget = remainingBudget;
     this.createdAt = Instant.now();
@@ -97,6 +96,17 @@ public class PropagationContext {
   public static PropagationContext createRoot(String traceId) {
     Objects.requireNonNull(traceId, "traceId must not be null");
     return new PropagationContext(traceId, Map.of(), null, null);
+  }
+
+  /**
+   * Creates a root context with a caller-supplied trace ID and inherited attributes, but no budget.
+   *
+   * @param traceId the trace ID to use (must not be null)
+   * @param attributes key-value pairs to carry through the hierarchy (e.g. userId, roles)
+   */
+  public static PropagationContext createRoot(String traceId, Map<String, String> attributes) {
+    Objects.requireNonNull(traceId, "traceId must not be null");
+    return new PropagationContext(traceId, attributes, null, null);
   }
 
   /**

--- a/api/src/test/java/io/casehub/api/context/PropagationContextTest.java
+++ b/api/src/test/java/io/casehub/api/context/PropagationContextTest.java
@@ -98,6 +98,36 @@ class PropagationContextTest {
     assertThat(ctx.getInheritedAttributes()).containsEntry("region", "eu");
   }
 
+  // ---- createRoot(traceId, attributes) — no budget -------------------------
+
+  @Test
+  void createRoot_withTraceIdAndAttributes_carriesProvidedAttributes() {
+    PropagationContext ctx =
+        PropagationContext.createRoot("trace-42", Map.of("userId", "u1", "roles", "admin,viewer"));
+    assertThat(ctx.getInheritedAttributes())
+        .containsEntry("userId", "u1")
+        .containsEntry("roles", "admin,viewer");
+  }
+
+  @Test
+  void createRoot_withTraceIdAndAttributes_usesProvidedTraceId() {
+    PropagationContext ctx = PropagationContext.createRoot("trace-42", Map.of("k", "v"));
+    assertThat(ctx.getTraceId()).isEqualTo("trace-42");
+  }
+
+  @Test
+  void createRoot_withTraceIdAndAttributes_hasNoDeadline() {
+    PropagationContext ctx = PropagationContext.createRoot("trace-42", Map.of("k", "v"));
+    assertThat(ctx.getDeadline()).isEmpty();
+    assertThat(ctx.getRemainingBudget()).isEmpty();
+  }
+
+  @Test
+  void createRoot_withTraceIdAndAttributes_nullTraceId_throws() {
+    assertThatThrownBy(() -> PropagationContext.createRoot(null, Map.of("k", "v")))
+        .isInstanceOf(NullPointerException.class);
+  }
+
   // ---- createChild() --------------------------------------------------------
 
   @Test

--- a/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCasePropagationContextTest.java
+++ b/blackboard/src/test/java/io/casehub/blackboard/subcase/SubCasePropagationContextTest.java
@@ -73,6 +73,20 @@ class SubCasePropagationContextTest {
     assertThat(child.getPropagationContext().getTraceId())
         .as("child must inherit parent's trace ID")
         .isEqualTo(parentTraceId);
+
+    // Identity propagation (engine#455): userId and roles must flow from root to child
+    assertThat(parent.getPropagationContext().getAttribute("userId"))
+        .as("parent must carry userId from CurrentPrincipal")
+        .isPresent();
+    assertThat(parent.getPropagationContext().getAttribute("roles"))
+        .as("parent must carry roles from CurrentPrincipal")
+        .isPresent();
+    assertThat(child.getPropagationContext().getAttribute("userId"))
+        .as("child must inherit userId from parent")
+        .hasValue(parent.getPropagationContext().getAttribute("userId").orElseThrow());
+    assertThat(child.getPropagationContext().getAttribute("roles"))
+        .as("child must inherit roles from parent")
+        .hasValue(parent.getPropagationContext().getAttribute("roles").orElseThrow());
   }
 
   // ------------------------------------------------------------------ //

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/CaseHubReactor.java
@@ -158,12 +158,15 @@ class CaseHubReactor {
               .filter(id -> !id.isBlank())
               .orElseGet(() -> UUID.randomUUID().toString());
 
+      Map<String, String> identityAttrs =
+          Map.of(
+              "userId", currentPrincipal.actorId(),
+              "roles", String.join(",", currentPrincipal.roles()));
+
       propagationContext =
           maxDuration
-              .map(
-                  budget ->
-                      PropagationContext.createRoot(traceId, Map.<String, String>of(), budget))
-              .orElse(PropagationContext.createRoot(traceId));
+              .map(budget -> PropagationContext.createRoot(traceId, identityAttrs, budget))
+              .orElse(PropagationContext.createRoot(traceId, identityAttrs));
     }
 
     // Populate semantic panel: definition defaults first, call-site overrides second.

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -563,7 +563,7 @@ public class CaseContextChangedEventHandler {
                       caseInstance.tenancyId,
                       capability.getName(),
                       workerContext,
-                      PropagationContext.createRoot(),
+                      caseInstance.getPropagationContext(),
                       triggerChannelId,
                       triggerCorrelationId);
               return reactiveWorkerProvisioner

--- a/runtime/src/main/java/io/casehub/engine/internal/worker/EmptyReactiveWorkerContextProvider.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/worker/EmptyReactiveWorkerContextProvider.java
@@ -21,6 +21,7 @@ import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkerContext;
 import io.casehub.api.spi.ReactiveCaseChannelProvider;
 import io.casehub.api.spi.ReactiveWorkerContextProvider;
+import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.quarkus.arc.DefaultBean;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -42,8 +43,15 @@ public class EmptyReactiveWorkerContextProvider implements ReactiveWorkerContext
   @Inject
   ReactiveCaseChannelProvider reactiveCaseChannelProvider; // package-private for test injection
 
+  @Inject CurrentPrincipal currentPrincipal; // package-private for test injection
+
   @Override
   public Uni<WorkerContext> buildContext(String workerId, UUID caseId, WorkRequest task) {
+    PropagationContext propagationContext =
+        PropagationContext.createRoot(
+            Map.of(
+                "userId", currentPrincipal.actorId(),
+                "roles", String.join(",", currentPrincipal.roles())));
     Uni<List<CaseChannel>> channelsUni =
         caseId != null
             ? reactiveCaseChannelProvider.listChannels(caseId)
@@ -51,11 +59,6 @@ public class EmptyReactiveWorkerContextProvider implements ReactiveWorkerContext
     return channelsUni.map(
         channels ->
             new WorkerContext(
-                task.capability(),
-                caseId,
-                channels,
-                List.of(),
-                PropagationContext.createRoot(),
-                Map.of()));
+                task.capability(), caseId, channels, List.of(), propagationContext, Map.of()));
   }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/worker/EmptyWorkerContextProvider.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/worker/EmptyWorkerContextProvider.java
@@ -21,6 +21,7 @@ import io.casehub.api.model.WorkRequest;
 import io.casehub.api.model.WorkerContext;
 import io.casehub.api.spi.CaseChannelProvider;
 import io.casehub.api.spi.WorkerContextProvider;
+import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.quarkus.arc.DefaultBean;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -39,12 +40,18 @@ import java.util.UUID;
 public class EmptyWorkerContextProvider implements WorkerContextProvider {
 
   @Inject CaseChannelProvider caseChannelProvider; // package-private for test injection
+  @Inject CurrentPrincipal currentPrincipal; // package-private for test injection
 
   @Override
   public WorkerContext buildContext(String workerId, UUID caseId, WorkRequest task) {
     List<CaseChannel> channels =
         caseId != null ? caseChannelProvider.listChannels(caseId) : List.of();
+    PropagationContext propagationContext =
+        PropagationContext.createRoot(
+            Map.of(
+                "userId", currentPrincipal.actorId(),
+                "roles", String.join(",", currentPrincipal.roles())));
     return new WorkerContext(
-        task.capability(), caseId, channels, List.of(), PropagationContext.createRoot(), Map.of());
+        task.capability(), caseId, channels, List.of(), propagationContext, Map.of());
   }
 }

--- a/runtime/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
@@ -33,6 +33,7 @@ import io.casehub.api.spi.ReactiveCaseChannelProvider;
 import io.casehub.eidos.api.AgentDescriptor;
 import io.casehub.eidos.api.CapabilityHealth.CapabilityStatus;
 import io.casehub.eidos.api.CapabilityHealth.ProbeContext;
+import io.casehub.platform.api.identity.CurrentPrincipal;
 import io.smallrye.mutiny.Uni;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,13 @@ import org.junit.jupiter.api.Test;
  * to verify actual behaviour.
  */
 class DefaultWorkerSpiImplementationsTest {
+
+  private static CurrentPrincipal stubPrincipal() {
+    var p = mock(CurrentPrincipal.class);
+    when(p.actorId()).thenReturn("test-user");
+    when(p.roles()).thenReturn(Set.of("viewer"));
+    return p;
+  }
 
   // --- NoOpWorkerProvisioner ---
 
@@ -145,6 +153,7 @@ class DefaultWorkerSpiImplementationsTest {
   @Test
   void emptyContextProvider_buildContext_taskDescriptionMatchesCapability() {
     var provider = new EmptyWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     WorkerContext ctx =
         provider.buildContext("worker-1", null, WorkRequest.of("researcher", Map.of()));
     assertThat(ctx.taskDescription()).isEqualTo("researcher");
@@ -153,6 +162,7 @@ class DefaultWorkerSpiImplementationsTest {
   @Test
   void emptyContextProvider_buildContext_priorWorkersIsEmptyNotNull() {
     var provider = new EmptyWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     WorkerContext ctx = provider.buildContext("worker-1", null, WorkRequest.of("task", Map.of()));
     assertThat(ctx.priorWorkers()).isNotNull().isEmpty();
   }
@@ -160,13 +170,24 @@ class DefaultWorkerSpiImplementationsTest {
   @Test
   void emptyContextProvider_buildContext_propagationContextIsNotNull() {
     var provider = new EmptyWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     WorkerContext ctx = provider.buildContext("worker-1", null, WorkRequest.of("task", Map.of()));
     assertThat(ctx.propagationContext()).isNotNull();
   }
 
   @Test
+  void emptyContextProvider_buildContext_propagationContextCarriesIdentity() {
+    var provider = new EmptyWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
+    WorkerContext ctx = provider.buildContext("worker-1", null, WorkRequest.of("task", Map.of()));
+    assertThat(ctx.propagationContext().getAttribute("userId")).hasValue("test-user");
+    assertThat(ctx.propagationContext().getAttribute("roles")).hasValue("viewer");
+  }
+
+  @Test
   void emptyContextProvider_buildContext_caseIdPopulated() {
     var provider = new EmptyWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     UUID caseId = UUID.randomUUID();
     provider.caseChannelProvider = mock(CaseChannelProvider.class);
     when(provider.caseChannelProvider.listChannels(caseId)).thenReturn(List.of());
@@ -183,6 +204,7 @@ class DefaultWorkerSpiImplementationsTest {
     when(mockProvider.listChannels(caseId)).thenReturn(List.of(channel));
 
     var provider = new EmptyWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     provider.caseChannelProvider = mockProvider;
 
     WorkerContext ctx = provider.buildContext("worker-1", caseId, WorkRequest.of("task", Map.of()));
@@ -192,6 +214,7 @@ class DefaultWorkerSpiImplementationsTest {
   @Test
   void emptyContextProvider_buildContext_nullCaseId_channelsEmpty() {
     var provider = new EmptyWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     WorkerContext ctx = provider.buildContext("worker-1", null, WorkRequest.of("task", Map.of()));
     assertThat(ctx.channels()).isEmpty();
   }
@@ -281,6 +304,7 @@ class DefaultWorkerSpiImplementationsTest {
   @Test
   void emptyReactiveContextProvider_buildContext_taskDescriptionMatchesCapability() {
     var provider = new EmptyReactiveWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     WorkerContext ctx =
         provider
             .buildContext("worker-1", null, WorkRequest.of("researcher", Map.of()))
@@ -292,6 +316,7 @@ class DefaultWorkerSpiImplementationsTest {
   @Test
   void emptyReactiveContextProvider_buildContext_priorWorkersIsEmpty() {
     var provider = new EmptyReactiveWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     WorkerContext ctx =
         provider
             .buildContext("worker-1", null, WorkRequest.of("task", Map.of()))
@@ -303,9 +328,20 @@ class DefaultWorkerSpiImplementationsTest {
   @Test
   void emptyReactiveContextProvider_buildContext_propagationContextIsNotNull() {
     var provider = new EmptyReactiveWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     WorkerContext ctx =
         provider.buildContext("w", null, WorkRequest.of("task", Map.of())).await().indefinitely();
     assertThat(ctx.propagationContext()).isNotNull();
+  }
+
+  @Test
+  void emptyReactiveContextProvider_buildContext_propagationContextCarriesIdentity() {
+    var provider = new EmptyReactiveWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
+    WorkerContext ctx =
+        provider.buildContext("w", null, WorkRequest.of("task", Map.of())).await().indefinitely();
+    assertThat(ctx.propagationContext().getAttribute("userId")).hasValue("test-user");
+    assertThat(ctx.propagationContext().getAttribute("roles")).hasValue("viewer");
   }
 
   @Test
@@ -314,6 +350,7 @@ class DefaultWorkerSpiImplementationsTest {
     ReactiveCaseChannelProvider mockProvider = mock(ReactiveCaseChannelProvider.class);
     when(mockProvider.listChannels(caseId)).thenReturn(Uni.createFrom().item(List.of()));
     var provider = new EmptyReactiveWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     provider.reactiveCaseChannelProvider = mockProvider;
     WorkerContext ctx =
         provider
@@ -332,6 +369,7 @@ class DefaultWorkerSpiImplementationsTest {
     when(mockProvider.listChannels(caseId)).thenReturn(Uni.createFrom().item(List.of(channel)));
 
     var provider = new EmptyReactiveWorkerContextProvider();
+    provider.currentPrincipal = stubPrincipal();
     provider.reactiveCaseChannelProvider = mockProvider;
 
     WorkerContext ctx =


### PR DESCRIPTION
## Summary

- Add `createRoot(traceId, attributes)` overload to `PropagationContext` (no-budget path)
- `CaseHubReactor.buildInstance()`: populate `userId` and `roles` from `CurrentPrincipal` at root context creation
- `CaseContextChangedEventHandler.tryProvision()`: reuse case's `PropagationContext` instead of `createRoot()` — also fixes traceId loss in provisioning flow
- `EmptyWorkerContextProvider` / `EmptyReactiveWorkerContextProvider`: inject `CurrentPrincipal`, pass identity attributes

Once populated at root, `createChild()` propagates identity automatically through the entire subcase hierarchy.

## Test plan

- [x] 4 unit tests for new `createRoot(traceId, attributes)` overload
- [x] 2 unit tests verifying identity attributes in sync/reactive worker context providers
- [x] Integration test: parent→child identity propagation via `SubCasePropagationContextTest`
- [x] 269 tests green across api, runtime, blackboard modules

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)