### PR TITLE
fix(ci): correct /retest workflow reference

### DIFF
--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -42,7 +42,7 @@ jobs:
           # Get latest Maven CI workflow run for this PR
           RUN_ID=$(gh run list \
             --repo ${{ github.repository }} \
-            --workflow=maven.yml \
+            --workflow=publish.yml \
             --json databaseId,headSha,status \
             --jq "[.[] | select(.headSha == \"$HEAD_SHA\")] | .[0].databaseId")
 


### PR DESCRIPTION
## Summary
- `/retest` PR command referenced non-existent `maven.yml` workflow, causing it to silently fail (no run found)
- Changed to `publish.yml` which is the actual CI workflow ("Build and Publish")

## Test plan
- [ ] Comment `/retest` on a PR and verify it finds and reruns the CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)