### PR TITLE
docs(#681): document mandatory Subscription.cancel() to prevent listener leak

### DIFF
--- a/api/src/main/java/io/casehub/api/context/CaseContext.java
+++ b/api/src/main/java/io/casehub/api/context/CaseContext.java
@@ -107,6 +107,10 @@ public interface CaseContext {
    *
    * <p>Engine-internal writes ({@code engineSet()}, {@code applyDiff()}) do NOT fire listeners.
    *
+   * <p><b>Callers must call {@link Subscription#cancel()} when the listener is no longer needed.</b>
+   * Listeners are held by strong reference and accumulate for the lifetime of the CaseContext if
+   * not cancelled. For long-running cases with many registrations this can cause unbounded growth.
+   *
    * @param key the context key to observe
    * @param listener consumer invoked with a {@link ContextChangeEvent} carrying old/new values
    * @return a {@link Subscription} whose {@link Subscription#cancel()} removes this listener
@@ -118,6 +122,9 @@ public interface CaseContext {
   /**
    * Registers a listener that fires whenever any key in the working layer is changed via the flat
    * API. Any-change listeners fire after per-key listeners, in registration order.
+   *
+   * <p><b>Callers must call {@link Subscription#cancel()} when the listener is no longer needed.</b>
+   * See {@link #onChange(String, Consumer)} for lifecycle details.
    *
    * @param listener consumer invoked with a {@link ContextChangeEvent} carrying old/new values
    * @return a {@link Subscription} whose {@link Subscription#cancel()} removes this listener

--- a/api/src/main/java/io/casehub/api/context/Subscription.java
+++ b/api/src/main/java/io/casehub/api/context/Subscription.java
@@ -18,6 +18,10 @@ package io.casehub.api.context;
 /**
  * Handle returned by {@link CaseContext#onChange} and {@link CaseContext#onAnyChange} to allow
  * callers to unsubscribe from change notifications.
+ *
+ * <p><b>Callers must call {@link #cancel()} when the listener is no longer needed.</b> Listeners
+ * are held by strong reference in the CaseContext and will accumulate if not cancelled, causing
+ * unbounded memory growth in long-running cases.
  */
 @FunctionalInterface
 public interface Subscription {


### PR DESCRIPTION
## Summary

- Add Javadoc to `CaseContext.onChange()` and `onAnyChange()` warning that `Subscription.cancel()` is mandatory
- Add Javadoc to `Subscription` interface documenting strong-reference lifecycle and unbounded growth risk
- Listeners accumulate in `CopyOnWriteArrayList` for the lifetime of the CaseContext if not cancelled

Addresses #681 (item 2: CaseContext listener memory leak potential)

## Test plan

- [ ] Javadoc-only change — no behavioral change, existing `CaseContextListenerTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)