### PR TITLE
refactor(#681): replace *Prev() method explosion with modify() primitive

### DIFF
--- a/runtime/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/CaseContextImpl.java
@@ -173,7 +173,14 @@ public class CaseContextImpl implements CaseContext {
     if (!hasListeners()) {
       working().set(key, value);
     } else {
-      Object prev = working().setPrev(key, value);
+      Object prev = working().modify((data, changed) -> {
+        Object p = data.get(key);
+        if (!Objects.equals(p, value)) {
+          data.put(key, value);
+          changed.run();
+        }
+        return p;
+      });
       if (!Objects.equals(prev, value)) {
         fireListeners(key, prev, value);
       }
@@ -201,7 +208,19 @@ public class CaseContextImpl implements CaseContext {
     if (!hasListeners()) {
       return working().computeIfAbsent(key, mappingFunction);
     }
-    Object[] result = working().computeIfAbsentPrev(key, mappingFunction);
+    Object[] result = working().modify((data, changed) -> {
+      Object v = data.get(key);
+      if (v == null) {
+        v = mappingFunction.apply(key);
+        if (v != null) {
+          data.put(key, v);
+          changed.run();
+          return new Object[] {Boolean.FALSE, v};
+        }
+        return new Object[] {Boolean.TRUE, null};
+      }
+      return new Object[] {Boolean.TRUE, v};
+    });
     boolean existed = (Boolean) result[0];
     Object value = result[1];
     if (!existed && value != null) {
@@ -215,7 +234,15 @@ public class CaseContextImpl implements CaseContext {
     if (!hasListeners()) {
       return working().putIfAbsent(key, value);
     }
-    Object[] result = working().putIfAbsentPrev(key, value);
+    Object[] result = working().modify((data, changed) -> {
+      Object existing = data.get(key);
+      if (existing == null) {
+        data.put(key, value);
+        changed.run();
+        return new Object[] {null, Boolean.TRUE};
+      }
+      return new Object[] {existing, Boolean.FALSE};
+    });
     Object previous = result[0];
     boolean wasAbsent = (Boolean) result[1];
     if (wasAbsent) {
@@ -229,7 +256,17 @@ public class CaseContextImpl implements CaseContext {
     if (!hasListeners()) {
       return working().compareAndSet(key, expected, newValue);
     }
-    Object[] result = working().compareAndSetPrev(key, expected, newValue);
+    Object[] result = working().modify((data, changed) -> {
+      Object current = data.get(key);
+      if (Objects.equals(current, expected)) {
+        if (!Objects.equals(current, newValue)) {
+          data.put(key, newValue);
+          changed.run();
+        }
+        return new Object[] {current, Boolean.TRUE};
+      }
+      return new Object[] {current, Boolean.FALSE};
+    });
     Object oldValue = result[0];
     boolean swapped = (Boolean) result[1];
     if (swapped && !Objects.equals(oldValue, newValue)) {
@@ -243,7 +280,20 @@ public class CaseContextImpl implements CaseContext {
     if (!hasListeners()) {
       working().update(key, updateFunction);
     } else {
-      Object[] result = working().updatePrev(key, updateFunction);
+      Object[] result = working().modify((data, changed) -> {
+        Object current = data.get(key);
+        Object nv = updateFunction.apply(current);
+        if (nv != null) {
+          if (!Objects.equals(current, nv)) {
+            data.put(key, nv);
+            changed.run();
+          }
+        } else if (data.containsKey(key)) {
+          data.remove(key);
+          changed.run();
+        }
+        return new Object[] {current, nv};
+      });
       Object oldValue = result[0];
       Object newValue = result[1];
       if (!Objects.equals(oldValue, newValue)) {
@@ -293,15 +343,36 @@ public class CaseContextImpl implements CaseContext {
     return working().getPathAsString(path);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public CaseContext setPath(String path, Object value) {
     if (!hasListeners()) {
       working().setPath(path, value);
     } else {
-      // Fire listener on the top-level key (first segment of the path)
       String topKey = path.contains(".") ? path.substring(0, path.indexOf('.')) : path;
-      Object prev = working().setPathPrev(path, value);
-      // For nested paths, always fire on the top-level key with the leaf old/new values
+      Object prev = working().modify((data, changed) -> {
+        String[] parts = path.split("\\.");
+        Map<String, Object> current = data;
+        for (int i = 0; i < parts.length - 1; i++) {
+          Object next = current.get(parts[i]);
+          if (next == null) {
+            next = new LinkedHashMap<String, Object>();
+            current.put(parts[i], next);
+          }
+          if (next instanceof Map) {
+            current = (Map<String, Object>) next;
+          } else {
+            throw new IllegalStateException("Cannot set path: " + parts[i] + " is not a Map");
+          }
+        }
+        String leaf = parts[parts.length - 1];
+        Object p = current.get(leaf);
+        if (!Objects.equals(p, value)) {
+          current.put(leaf, value);
+          changed.run();
+        }
+        return p;
+      });
       if (!Objects.equals(prev, value)) {
         fireListeners(topKey, prev, value);
       }
@@ -313,8 +384,21 @@ public class CaseContextImpl implements CaseContext {
   public CaseContext setAll(Map<String, Object> values) {
     if (!hasListeners()) {
       working().setAll(values);
-    } else {
-      Map<String, Object> changed = working().setAllPrev(values);
+    } else if (values != null && !values.isEmpty()) {
+      Map<String, Object> changed = working().modify((data, markChanged) -> {
+        Map<String, Object> diff = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : values.entrySet()) {
+          Object prev = data.get(e.getKey());
+          if (!Objects.equals(prev, e.getValue())) {
+            data.put(e.getKey(), e.getValue());
+            diff.put(e.getKey(), prev);
+          }
+        }
+        if (!diff.isEmpty()) {
+          markChanged.run();
+        }
+        return diff;
+      });
       for (Map.Entry<String, Object> entry : changed.entrySet()) {
         fireListeners(entry.getKey(), entry.getValue(), values.get(entry.getKey()));
       }
@@ -337,7 +421,13 @@ public class CaseContextImpl implements CaseContext {
     if (!hasListeners()) {
       working().remove(key);
     } else {
-      Object prev = working().removePrev(key);
+      Object prev = working().modify((data, changed) -> {
+        if (data.containsKey(key)) {
+          changed.run();
+          return data.remove(key);
+        }
+        return null;
+      });
       if (prev != null) {
         fireListeners(key, prev, null);
       }
@@ -350,7 +440,15 @@ public class CaseContextImpl implements CaseContext {
     if (!hasListeners()) {
       working().clear();
     } else {
-      Map<String, Object> prev = working().clearPrev();
+      Map<String, Object> prev = working().modify((data, changed) -> {
+        if (!data.isEmpty()) {
+          Map<String, Object> snapshot = new LinkedHashMap<>(data);
+          data.clear();
+          changed.run();
+          return snapshot;
+        }
+        return Map.<String, Object>of();
+      });
       for (Map.Entry<String, Object> entry : prev.entrySet()) {
         fireListeners(entry.getKey(), entry.getValue(), null);
       }
@@ -392,11 +490,24 @@ public class CaseContextImpl implements CaseContext {
   @Override
   public CaseContext merge(CaseContext other) {
     if (other == null) return this;
+    Map<String, Object> otherData = other.getData();
     if (!hasListeners()) {
-      working().setAll(other.getData());
-    } else {
-      Map<String, Object> otherData = other.getData();
-      Map<String, Object> changed = working().setAllPrev(otherData);
+      working().setAll(otherData);
+    } else if (!otherData.isEmpty()) {
+      Map<String, Object> changed = working().modify((data, markChanged) -> {
+        Map<String, Object> diff = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : otherData.entrySet()) {
+          Object prev = data.get(e.getKey());
+          if (!Objects.equals(prev, e.getValue())) {
+            data.put(e.getKey(), e.getValue());
+            diff.put(e.getKey(), prev);
+          }
+        }
+        if (!diff.isEmpty()) {
+          markChanged.run();
+        }
+        return diff;
+      });
       for (Map.Entry<String, Object> entry : changed.entrySet()) {
         fireListeners(entry.getKey(), entry.getValue(), otherData.get(entry.getKey()));
       }

--- a/runtime/src/main/java/io/casehub/engine/internal/context/WritableLayerImpl.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/context/WritableLayerImpl.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /** Thread-safe, versioned data store for a single CaseFile layer. */
@@ -569,244 +570,26 @@ public class WritableLayerImpl implements WritableLayer {
     }
   }
 
-  // ── Atomic prev-returning variants (package-private, used by CaseContextImpl listeners) ───
+  // ── Atomic read-modify-write primitive (package-private) ────────────────────
 
   /**
-   * Sets a key and returns the previous value, captured atomically inside the write lock. Returns
-   * {@code null} if the key was absent. Version is incremented only when the value actually
-   * changes.
+   * Executes an atomic read-modify-write operation under the write lock. The action receives the
+   * underlying data map and a {@code markChanged} callback; call it when the action mutates data so
+   * the version counter stays correct. Returns whatever the action returns.
+   *
+   * <p>Used by {@link CaseContextImpl} to capture previous values for listener notification without
+   * requiring a dedicated {@code *Prev()} variant of every mutating method.
    */
-  Object setPrev(String key, Object value) {
+  <R> R modify(BiFunction<Map<String, Object>, Runnable, R> action) {
     checkWritable();
     lock.writeLock().lock();
     try {
-      Object prev = data.get(key);
-      if (!Objects.equals(prev, value)) {
-        data.put(key, value);
+      boolean[] changed = {false};
+      R result = action.apply(data, () -> changed[0] = true);
+      if (changed[0]) {
         version++;
       }
-      return prev;
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * Sets multiple keys and returns a map of (key -> previousValue) for each key that actually
-   * changed. Keys whose value did not change are not included in the returned map.
-   */
-  Map<String, Object> setAllPrev(Map<String, Object> values) {
-    checkWritable();
-    if (values == null || values.isEmpty()) {
-      return Map.of();
-    }
-    lock.writeLock().lock();
-    try {
-      Map<String, Object> changed = new LinkedHashMap<>();
-      for (Map.Entry<String, Object> e : values.entrySet()) {
-        Object prev = data.get(e.getKey());
-        if (!Objects.equals(prev, e.getValue())) {
-          data.put(e.getKey(), e.getValue());
-          changed.put(e.getKey(), prev);
-        }
-      }
-      if (!changed.isEmpty()) {
-        version++;
-      }
-      return changed;
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * Removes a key and returns the previous value atomically. Returns {@code null} if the key was
-   * absent.
-   */
-  Object removePrev(String key) {
-    checkWritable();
-    lock.writeLock().lock();
-    try {
-      if (data.containsKey(key)) {
-        Object prev = data.remove(key);
-        version++;
-        return prev;
-      }
-      return null;
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * Clears all entries and returns the data that was present before the clear, captured atomically.
-   * Returns an empty map if already empty.
-   */
-  Map<String, Object> clearPrev() {
-    checkWritable();
-    lock.writeLock().lock();
-    try {
-      if (!data.isEmpty()) {
-        Map<String, Object> prev = new LinkedHashMap<>(data);
-        data.clear();
-        version++;
-        return prev;
-      }
-      return Map.of();
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * Applies an update function and returns a two-element array {@code [oldValue, newValue]},
-   * captured atomically.
-   */
-  Object[] updatePrev(String key, Function<Object, Object> updateFunction) {
-    checkWritable();
-    lock.writeLock().lock();
-    try {
-      Object current = data.get(key);
-      Object newValue = updateFunction.apply(current);
-      if (newValue != null) {
-        if (!Objects.equals(current, newValue)) {
-          data.put(key, newValue);
-          version++;
-        }
-      } else {
-        if (data.containsKey(key)) {
-          data.remove(key);
-          version++;
-        }
-      }
-      return new Object[] {current, newValue};
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * computeIfAbsent variant that returns a two-element array {@code [existed, computedValue]}.
-   * {@code existed} is {@code Boolean.TRUE} if the key was already present (no change), {@code
-   * Boolean.FALSE} if a new value was computed.
-   */
-  Object[] computeIfAbsentPrev(String key, Function<String, Object> mappingFunction) {
-    checkWritable();
-    lock.writeLock().lock();
-    try {
-      Object value = data.get(key);
-      if (value == null) {
-        value = mappingFunction.apply(key);
-        if (value != null) {
-          data.put(key, value);
-          version++;
-          return new Object[] {Boolean.FALSE, value};
-        }
-        return new Object[] {Boolean.TRUE, null};
-      }
-      return new Object[] {Boolean.TRUE, value};
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * putIfAbsent variant that returns a two-element array {@code [previousValue, wasAbsent]}. {@code
-   * wasAbsent} is {@code Boolean.TRUE} if the value was inserted.
-   */
-  Object[] putIfAbsentPrev(String key, Object value) {
-    checkWritable();
-    lock.writeLock().lock();
-    try {
-      Object existing = data.get(key);
-      if (existing == null) {
-        data.put(key, value);
-        version++;
-        return new Object[] {null, Boolean.TRUE};
-      }
-      return new Object[] {existing, Boolean.FALSE};
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * compareAndSet variant that returns the old value atomically. Returns a two-element array {@code
-   * [oldValue, swapped]}. {@code swapped} is {@code Boolean.TRUE} if the swap occurred.
-   */
-  Object[] compareAndSetPrev(String key, Object expected, Object newValue) {
-    checkWritable();
-    lock.writeLock().lock();
-    try {
-      Object current = data.get(key);
-      if (Objects.equals(current, expected)) {
-        if (!Objects.equals(current, newValue)) {
-          data.put(key, newValue);
-          version++;
-        }
-        return new Object[] {current, Boolean.TRUE};
-      }
-      return new Object[] {current, Boolean.FALSE};
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /** setPath variant that returns the previous leaf value atomically. */
-  @SuppressWarnings("unchecked")
-  Object setPathPrev(String path, Object value) {
-    checkWritable();
-    lock.writeLock().lock();
-    try {
-      String[] parts = path.split("\\.");
-      Map<String, Object> current = data;
-      for (int i = 0; i < parts.length - 1; i++) {
-        Object next = current.get(parts[i]);
-        if (next == null) {
-          next = new LinkedHashMap<String, Object>();
-          current.put(parts[i], next);
-        }
-        if (next instanceof Map) {
-          current = (Map<String, Object>) next;
-        } else {
-          throw new IllegalStateException("Cannot set path: " + parts[i] + " is not a Map");
-        }
-      }
-      String leaf = parts[parts.length - 1];
-      Object prev = current.get(leaf);
-      if (!Objects.equals(prev, value)) {
-        current.put(leaf, value);
-        version++;
-      }
-      return prev;
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * Merge variant that returns a map of (key -> previousValue) for each key that actually changed.
-   */
-  Map<String, Object> mergePrev(ReadableLayer other) {
-    checkWritable();
-    if (other == null) {
-      return Map.of();
-    }
-    lock.writeLock().lock();
-    try {
-      Map<String, Object> otherData = other.getData();
-      Map<String, Object> changed = new LinkedHashMap<>();
-      for (Map.Entry<String, Object> e : otherData.entrySet()) {
-        Object prev = data.get(e.getKey());
-        if (!Objects.equals(prev, e.getValue())) {
-          data.put(e.getKey(), e.getValue());
-          changed.put(e.getKey(), prev);
-        }
-      }
-      if (!changed.isEmpty()) {
-        version++;
-      }
-      return changed;
+      return result;
     } finally {
       lock.writeLock().unlock();
     }


### PR DESCRIPTION
## Summary

- Replaces 10 package-private `*Prev()` methods (~240 lines) in `WritableLayerImpl` with a single generic `modify(BiFunction<Map, Runnable, R>)` primitive
- `CaseContextImpl` now inlines mutation logic in `modify()` lambdas to atomically capture previous values for listener notification
- Net reduction: ~106 lines, no behavioral change

## Context

Item 4 of #681 (S/XS backlog sweep). The `*Prev()` methods existed solely to let `CaseContextImpl` capture old values under the write lock for change listener notification. Each method duplicated the logic of its public counterpart (`set`→`setPrev`, `remove`→`removePrev`, etc.) with an additional return of the previous value. The single `modify()` primitive provides the same atomicity guarantee without per-method duplication.

## Test plan

- [ ] Existing `CaseContextImplTest` listener tests pass (same behavior, different internal path)
- [ ] `WritableLayerImplTest` passes (public API unchanged)
- [ ] No remaining references to deleted `*Prev()` methods

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)