### PR TITLE
feat(engine#733): add temporalDecayHalfLifeDays to CbrConfig

### DIFF
--- a/api/src/main/java/io/casehub/api/model/cbr/CbrConfig.java
+++ b/api/src/main/java/io/casehub/api/model/cbr/CbrConfig.java
@@ -30,7 +30,8 @@ public record CbrConfig(
     String caseType,
     double vectorWeight,
     CbrRetrievalTiming timing,
-    String cbrType) {
+    String cbrType,
+    Integer temporalDecayHalfLifeDays) {
 
   public enum CbrRetrievalTiming {
     PER_EVALUATION,
@@ -58,6 +59,10 @@ public record CbrConfig(
     }
     if (cbrType != null && cbrType.isBlank()) {
       throw new IllegalArgumentException("cbrType must not be blank when provided");
+    }
+    if (temporalDecayHalfLifeDays != null && temporalDecayHalfLifeDays < 1) {
+      throw new IllegalArgumentException(
+          "temporalDecayHalfLifeDays must be >= 1, got: " + temporalDecayHalfLifeDays);
     }
     weights = Map.copyOf(weights);
     for (var entry : weights.entrySet()) {
@@ -89,6 +94,7 @@ public record CbrConfig(
     private double vectorWeight = 0.5;
     private CbrRetrievalTiming timing = CbrRetrievalTiming.PER_EVALUATION;
     private String cbrType;
+    private Integer temporalDecayHalfLifeDays;
 
     public Builder feature(final String name, final String jqExpression) {
       if (lambdaExtractor != null) {
@@ -146,6 +152,11 @@ public record CbrConfig(
       return this;
     }
 
+    public Builder temporalDecayHalfLifeDays(final Integer temporalDecayHalfLifeDays) {
+      this.temporalDecayHalfLifeDays = temporalDecayHalfLifeDays;
+      return this;
+    }
+
     public CbrConfig build() {
       final FeatureExtractor extractor;
       if (!jqFeatures.isEmpty()) {
@@ -156,7 +167,16 @@ public record CbrConfig(
         throw new IllegalStateException("No feature extractor configured");
       }
       return new CbrConfig(
-          extractor, topK, minSimilarity, weights, domain, caseType, vectorWeight, timing, cbrType);
+          extractor,
+          topK,
+          minSimilarity,
+          weights,
+          domain,
+          caseType,
+          vectorWeight,
+          timing,
+          cbrType,
+          temporalDecayHalfLifeDays);
     }
   }
 }

--- a/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
+++ b/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
@@ -565,6 +565,9 @@ public final class CaseDefinitionYamlMapper {
       if (cbrNode != null && cbrNode.has("cbrType")) {
         cbrBuilder.cbrType(cbrNode.get("cbrType").asText());
       }
+      if (cbr.getTemporalDecayHalfLifeDays() != null) {
+        cbrBuilder.temporalDecayHalfLifeDays(cbr.getTemporalDecayHalfLifeDays());
+      }
       def.setCbrConfig(cbrBuilder.build());
     }
 

--- a/api/src/test/java/io/casehub/api/model/cbr/CbrConfigBuilderTest.java
+++ b/api/src/test/java/io/casehub/api/model/cbr/CbrConfigBuilderTest.java
@@ -140,4 +140,30 @@ class CbrConfigBuilderTest {
         IllegalArgumentException.class,
         () -> CbrConfig.builder().feature("f1", ".x").cbrType("  ").build());
   }
+
+  @Test
+  void temporalDecayHalfLifeDays_defaults_to_null() {
+    var config = CbrConfig.builder().feature("f1", ".x").build();
+    assertNull(config.temporalDecayHalfLifeDays());
+  }
+
+  @Test
+  void temporalDecayHalfLifeDays_set_via_builder() {
+    var config = CbrConfig.builder().feature("f1", ".x").temporalDecayHalfLifeDays(30).build();
+    assertEquals(30, config.temporalDecayHalfLifeDays());
+  }
+
+  @Test
+  void temporalDecayHalfLifeDays_zero_rejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CbrConfig.builder().feature("f1", ".x").temporalDecayHalfLifeDays(0).build());
+  }
+
+  @Test
+  void temporalDecayHalfLifeDays_negative_rejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CbrConfig.builder().feature("f1", ".x").temporalDecayHalfLifeDays(-5).build());
+  }
 }

--- a/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperCbrTest.java
+++ b/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperCbrTest.java
@@ -114,6 +114,45 @@ class CaseDefinitionYamlMapperCbrTest {
   }
 
   @Test
+  void cbr_temporalDecayHalfLifeDays_parsed() throws IOException {
+    String yaml =
+        """
+        dsl: "0.1.0"
+        namespace: test
+        name: test-case
+        version: "1.0.0"
+        spec:
+          cbr:
+            features:
+              f1: ".x"
+            temporalDecayHalfLifeDays: 30
+        """;
+    InputStream is = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+    CaseDefinition def = CaseDefinitionYamlMapper.load(is);
+    assertThat(def.getCbrConfig()).isNotNull();
+    assertThat(def.getCbrConfig().temporalDecayHalfLifeDays()).isEqualTo(30);
+  }
+
+  @Test
+  void cbr_temporalDecayHalfLifeDays_defaults_to_null() throws IOException {
+    String yaml =
+        """
+        dsl: "0.1.0"
+        namespace: test
+        name: test-case
+        version: "1.0.0"
+        spec:
+          cbr:
+            features:
+              f1: ".x"
+        """;
+    InputStream is = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+    CaseDefinition def = CaseDefinitionYamlMapper.load(is);
+    assertThat(def.getCbrConfig()).isNotNull();
+    assertThat(def.getCbrConfig().temporalDecayHalfLifeDays()).isNull();
+  }
+
+  @Test
   void cbr_cbrType_parsed() throws IOException {
     String yaml =
         """

--- a/schema/src/main/resources/schema/CaseDefinition.yaml
+++ b/schema/src/main/resources/schema/CaseDefinition.yaml
@@ -361,6 +361,13 @@ $defs:
           Retrieval timing strategy. 'per-evaluation' retrieves on every
           evaluation (default). 'case-lifetime' retrieves once on first access
           and caches the result for the case's lifetime.
+      temporalDecayHalfLifeDays:
+        type: integer
+        minimum: 1
+        description: >
+          Half-life in days for temporal decay during retrieval. Older cases
+          lose relevance via similarity *= 0.5^(age / halfLife). Null means
+          no decay (backward compatible).
 
   Capability:
     description: >


### PR DESCRIPTION
Nullable Integer field (default null = no decay) for per-case-type temporal decay during CBR retrieval. Schema, record, builder, YAML mapper, and tests updated.