### PR TITLE
feat(#327): mutual exclusion for expiresIn/expiresInExpression + tests

### DIFF
--- a/api/src/main/java/io/casehub/api/model/HumanTaskTarget.java
+++ b/api/src/main/java/io/casehub/api/model/HumanTaskTarget.java
@@ -379,6 +379,11 @@ public final class HumanTaskTarget implements BindingTarget {
         throw new IllegalStateException(
             "Inline HumanTaskTarget requires a non-blank title or a titleExpression");
       }
+      if (expiresIn != null && expiresInExpression != null) {
+        throw new IllegalStateException(
+            "cannot specify both expiresIn and expiresInExpression"
+                + " — use static duration or dynamic expression, not both");
+      }
       return new HumanTaskTarget(this);
     }
   }

--- a/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
+++ b/api/src/main/java/io/casehub/api/model/converter/CaseDefinitionYamlMapper.java
@@ -942,6 +942,11 @@ public final class CaseDefinitionYamlMapper {
       builder.scopeExpression(schema.getScopeExpression());
     }
     if (schema.getExpiresInExpression() != null && !schema.getExpiresInExpression().isBlank()) {
+      if (schema.getExpiresIn() != null) {
+        throw new IllegalArgumentException(
+            "cannot specify both expiresIn and expiresInExpression"
+                + " — use static duration or dynamic expression, not both");
+      }
       validateJqSyntax(schema.getExpiresInExpression(), "expiresInExpression");
       builder.expiresInExpression(schema.getExpiresInExpression());
     }

--- a/api/src/test/java/io/casehub/api/model/HumanTaskTargetTest.java
+++ b/api/src/test/java/io/casehub/api/model/HumanTaskTargetTest.java
@@ -339,6 +339,136 @@ class HumanTaskTargetTest {
   }
 
   @Test
+  void expiresInExpression_templateMode_storedAndReturned() {
+    HumanTaskTarget target =
+        HumanTaskTarget.template("irb-template").expiresInExpression(".sla.reviewWindow").build();
+
+    assertThat(target.isTemplateMode()).isTrue();
+    assertThat(target.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) target.expiresInExpression()).expression())
+        .isEqualTo(".sla.reviewWindow");
+  }
+
+  @Test
+  void expiresInExpression_inlineMode_storedAndReturned() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("Urgent Review")
+            .expiresInExpression(".urgency.deadline")
+            .build();
+
+    assertThat(target.isTemplateMode()).isFalse();
+    assertThat(target.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) target.expiresInExpression()).expression())
+        .isEqualTo(".urgency.deadline");
+  }
+
+  @Test
+  void expiresIn_andExpiresInExpression_mutuallyExclusive() {
+    assertThatThrownBy(
+            () ->
+                HumanTaskTarget.inline()
+                    .title("Review")
+                    .expiresIn(Duration.ofHours(24))
+                    .expiresInExpression(".sla.window")
+                    .build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("cannot specify both")
+        .hasMessageContaining("expiresIn")
+        .hasMessageContaining("expiresInExpression");
+  }
+
+  @Test
+  void expiresInExpression_withoutExpiresIn_builds() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline().title("Review").expiresInExpression(".sla.window").build();
+
+    assertThat(target.expiresIn()).isNull();
+    assertThat(target.expiresInExpression()).isNotNull();
+  }
+
+  @Test
+  void expiresIn_withoutExpiresInExpression_builds() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline().title("Review").expiresIn(Duration.ofHours(72)).build();
+
+    assertThat(target.expiresIn()).isEqualTo(Duration.ofHours(72));
+    assertThat(target.expiresInExpression()).isNull();
+  }
+
+  @Test
+  void expiresInExpression_coexistsWithExpiresAtExpression() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("Review")
+            .expiresInExpression(".sla.window")
+            .expiresAtExpression(".regulatory.absoluteDeadline")
+            .build();
+
+    assertThat(target.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(target.expiresAtExpression()).isInstanceOf(JQExpressionEvaluator.class);
+  }
+
+  @Test
+  void expiresInExpression_thenExpiresIn_mutuallyExclusive_reversedOrder() {
+    assertThatThrownBy(
+            () ->
+                HumanTaskTarget.inline()
+                    .title("Review")
+                    .expiresInExpression(".sla.window")
+                    .expiresIn(Duration.ofHours(24))
+                    .build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("cannot specify both");
+  }
+
+  @Test
+  void expiresIn_expiresInExpression_expiresAtExpression_allThree_throwsOnFirst() {
+    assertThatThrownBy(
+            () ->
+                HumanTaskTarget.inline()
+                    .title("Review")
+                    .expiresIn(Duration.ofHours(24))
+                    .expiresInExpression(".sla.window")
+                    .expiresAtExpression(".regulatory.deadline")
+                    .build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("cannot specify both");
+  }
+
+  @Test
+  void expiresInExpression_nullEvaluator_thenExpiresIn_buildsOk() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("Review")
+            .expiresInExpression((ExpressionEvaluator) null)
+            .expiresIn(Duration.ofHours(24))
+            .build();
+
+    assertThat(target.expiresIn()).isEqualTo(Duration.ofHours(24));
+    assertThat(target.expiresInExpression()).isNull();
+  }
+
+  @Test
+  void expiresInExpression_coexistsWithCandidateGroupsAndPriority() {
+    HumanTaskTarget target =
+        HumanTaskTarget.inline()
+            .title("Full Review")
+            .expiresInExpression(".sla.reviewWindow")
+            .candidateGroups(Set.of("ethics-committee"))
+            .priority("HIGH")
+            .scope("casehubio/clinical/adverse-event")
+            .build();
+
+    assertThat(target.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) target.expiresInExpression()).expression())
+        .isEqualTo(".sla.reviewWindow");
+    assertThat(target.candidateGroups()).isNotNull();
+    assertThat(target.priority()).isEqualTo("HIGH");
+    assertThat(target.scope()).isEqualTo("casehubio/clinical/adverse-event");
+  }
+
+  @Test
   void payloadType_storedOnBuilder() {
     HumanTaskTarget target =
         HumanTaskTarget.inline().title("Review").payloadType(java.util.Map.class).build();

--- a/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
+++ b/api/src/test/java/io/casehub/api/model/converter/CaseDefinitionYamlMapperTest.java
@@ -950,6 +950,436 @@ class CaseDefinitionYamlMapperTest {
   }
 
   @Test
+  void humanTask_expiresInExpression_templateMode_parsedCorrectly() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Template ExpiresIn Expression
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        templateRef: "sla-review-template"
+                        expiresInExpression: ".sla.reviewWindow"
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.isTemplateMode()).isTrue();
+    assertThat(ht.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.expiresInExpression()).expression())
+        .isEqualTo(".sla.reviewWindow");
+  }
+
+  @Test
+  void humanTask_expiresInExpression_blankString_treatedAsNotSet() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Blank ExpiresIn Expression
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: ""
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isNull();
+  }
+
+  @Test
+  void humanTask_expiresInExpression_whitespaceOnly_treatedAsNotSet() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Whitespace ExpiresIn Expression
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: "   "
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isNull();
+  }
+
+  @Test
+  void humanTask_withBothExpiresInAndExpiresInExpression_throwsIllegalArgument() {
+    String yaml =
+        """
+                namespace: test
+                name: Mutual Exclusion
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: conflict-binding
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresIn: "PT24H"
+                        expiresInExpression: ".sla.window"
+                """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("conflict-binding")
+        .hasMessageContaining("cannot specify both");
+  }
+
+  @Test
+  void humanTask_withInvalidExpiresInExpression_throwsIllegalArgumentAtLoadTime() {
+    String yaml =
+        """
+                namespace: test
+                name: Bad ExpiresIn Expression
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: bad-binding
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: ".foo bar("
+                """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bad-binding")
+        .hasMessageContaining("expiresInExpression");
+  }
+
+  @Test
+  void humanTask_allThreeExpiresFields_throwsOnExpiresInMutualExclusion() {
+    String yaml =
+        """
+                namespace: test
+                name: Triple Expires
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: triple-binding
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresIn: "PT24H"
+                        expiresInExpression: ".sla.window"
+                        expiresAtExpression: ".regulatory.deadline"
+                """;
+
+    assertThatThrownBy(
+            () ->
+                CaseDefinitionYamlMapper.load(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("triple-binding")
+        .hasMessageContaining("cannot specify both");
+  }
+
+  @Test
+  void humanTask_expiresInExpression_pipeOperator_parsedCorrectly() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Pipe Expression
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: ".sla | .reviewWindow"
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.expiresInExpression()).expression())
+        .isEqualTo(".sla | .reviewWindow");
+  }
+
+  @Test
+  void humanTask_expiresInExpression_yamlExplicitNull_treatedAsNotSet() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Explicit Null
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: ~
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isNull();
+  }
+
+  @Test
+  void humanTask_expiresInExpression_withExpiresAtExpression_bothAllowed() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Both Expressions
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: ".sla.reviewWindow"
+                        expiresAtExpression: ".regulatory.absoluteDeadline"
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.expiresInExpression()).expression())
+        .isEqualTo(".sla.reviewWindow");
+    assertThat(ht.expiresAtExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.expiresAtExpression()).expression())
+        .isEqualTo(".regulatory.absoluteDeadline");
+  }
+
+  @Test
+  void humanTask_expiresInExpression_complexJqExpression_parsedCorrectly() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Complex JQ
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: 'if .priority == "HIGH" then "PT4H" else "PT24H" end'
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+  }
+
+  @Test
+  void humanTask_expiresInExpression_withAllOtherFields_parsedCorrectly() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Full Fields
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: full-review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Full review task"
+                        inputMapping: "{ pr: .pr }"
+                        outputMapping: "{ approval: .decision }"
+                        candidateGroups:
+                          - architects
+                          - seniors
+                        candidateUsers:
+                          - alice
+                        expiresInExpression: ".sla.reviewWindow"
+                        expiresAtExpression: ".regulatory.absoluteDeadline"
+                        scope: "casehubio/devtown/pr-review"
+                        outcomes:
+                          - APPROVED
+                          - REJECTED
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.expiresInExpression()).expression())
+        .isEqualTo(".sla.reviewWindow");
+    assertThat(ht.expiresAtExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(ht.inputMapping()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(ht.outputMapping()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(ht.candidateGroups()).isNotNull();
+    assertThat(ht.candidateUsers()).isNotNull();
+    assertThat(ht.scope()).isEqualTo("casehubio/devtown/pr-review");
+    assertThat(ht.outcomes()).containsExactlyInAnyOrder("APPROVED", "REJECTED");
+  }
+
+  @Test
+  void humanTask_expiresInExpression_dotExpression_parsedCorrectly() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Simple Dot
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: ".expiryDuration"
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    assertThat(((JQExpressionEvaluator) ht.expiresInExpression()).expression())
+        .isEqualTo(".expiryDuration");
+  }
+
+  @Test
+  void humanTask_noExpiresInOrExpression_bothNull() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: No Expires
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresIn()).isNull();
+    assertThat(ht.expiresInExpression()).isNull();
+  }
+
+  @Test
+  void humanTask_withExpiresInOnly_expiresInExpressionNull() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Static Only
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresIn: "PT24H"
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresIn()).isEqualTo(Duration.parse("PT24H"));
+    assertThat(ht.expiresInExpression()).isNull();
+  }
+
+  @Test
+  void humanTask_expiresInExpression_fullRoundTrip() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: RoundTrip
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresInExpression: ".sla.reviewWindow"
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresInExpression()).isInstanceOf(JQExpressionEvaluator.class);
+    JQExpressionEvaluator evaluator = (JQExpressionEvaluator) ht.expiresInExpression();
+    assertThat(evaluator.expression()).isEqualTo(".sla.reviewWindow");
+    assertThat(evaluator.type()).isEqualTo("jq");
+    assertThat(ht.expiresIn()).isNull();
+  }
+
+  @Test
+  void humanTask_staticExpiresIn_fullRoundTrip_unchanged() throws IOException {
+    String yaml =
+        """
+                namespace: test
+                name: Static RoundTrip
+                version: 1.0.0
+                spec:
+                  bindings:
+                    - name: review
+                      on: { contextChange: {} }
+                      humanTask:
+                        title: "Review"
+                        expiresIn: "PT72H"
+                """;
+
+    CaseDefinition def =
+        CaseDefinitionYamlMapper.load(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    HumanTaskTarget ht = (HumanTaskTarget) def.getBindings().get(0).target();
+
+    assertThat(ht.expiresIn()).isEqualTo(Duration.parse("PT72H"));
+    assertThat(ht.expiresInExpression()).isNull();
+  }
+
+  @Test
   void humanTask_invalidTitleExpression_throwsIllegalArgument() {
     String yaml =
         """


### PR DESCRIPTION
## Summary

- Add mutual exclusion validation: static `expiresIn` and dynamic `expiresInExpression` cannot both be set on the same HumanTask binding
  - `HumanTaskTarget.build()` — throws `IllegalStateException`
  - `CaseDefinitionYamlMapper.convertHumanTask()` — throws `IllegalArgumentException` (wrapped with binding name)
- Add 26 new tests covering builder edge cases, YAML parsing, and regression checks

## Test plan

- [x] `mvn test -pl api` — 765 tests pass (0 failures)
- [x] `mvn compile -pl runtime -am` — full compile including runtime
- [x] Builder: mutual exclusion in both call orders
- [x] Builder: three-way combination (expiresIn + expiresInExpression + expiresAtExpression)
- [x] Builder: null evaluator does not trigger mutual exclusion
- [x] YAML: blank, whitespace, explicit null all treated as not set
- [x] YAML: invalid JQ syntax rejected at load time
- [x] YAML: pipe operators and complex if/then/else JQ expressions
- [x] YAML: all fields round-trip
- [x] YAML: static expiresIn regression checks

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)