### PR TITLE
chore(#770): remove reactive remnants — CDI exclusions and dead async method

### DIFF
--- a/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerSchedulerService.java
+++ b/scheduler-quartz/src/main/java/io/casehub/engine/scheduler/quartz/QuartzWorkerSchedulerService.java
@@ -15,11 +15,6 @@
  */
 package io.casehub.engine.scheduler.quartz;
 
-import static org.quartz.JobBuilder.newJob;
-import static org.quartz.TriggerBuilder.newTrigger;
-
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.quartz.JobDetail;
@@ -28,6 +23,9 @@ import org.quartz.ObjectAlreadyExistsException;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
+
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.TriggerBuilder.newTrigger;
 
 @ApplicationScoped
 class QuartzWorkerSchedulerService {
@@ -65,17 +63,6 @@ class QuartzWorkerSchedulerService {
         newTrigger().withIdentity(idempotency, group).startNow().forJob(jobKey).build();
 
     scheduleRetry(job, trigger);
-  }
-
-  Uni<Void> scheduleRetryAsync(JobDetail job, Trigger trigger) {
-    return Uni.createFrom()
-        .item(
-            () -> {
-              scheduleRetry(job, trigger);
-              return (Void) null;
-            })
-        .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
-        .replaceWithVoid();
   }
 
   private void scheduleRetryTrigger(JobDetail job, Trigger trigger) throws SchedulerException {


### PR DESCRIPTION
## Summary

- Remove `ReactiveAgentIdentityVerificationService` CDI exclusion from 7 test modules — the ledger dependency now ships without it
- Delete dead `scheduleRetryAsync()` method from `QuartzWorkerSchedulerService` (zero callers after blocking migration)

8 files changed, net -20 lines.

## Test plan

- [x] IntelliJ build: 0 errors
- [x] Pre-existing SNAPSHOT dependency drift on main confirmed (PlanCbrCase constructor) — not from this change

Refs #770