### PR TITLE
fix: update CbrCase constructors for trustScore and producerAgentId

### DIFF
--- a/runtime/src/main/java/io/casehub/engine/internal/memory/CbrCaseRetainObserver.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/memory/CbrCaseRetainObserver.java
@@ -164,7 +164,8 @@ public class CbrCaseRetainObserver implements CaseOutcomeObserver {
             .collect(Collectors.joining(", "));
 
     PlanCbrCase cbrCase =
-        new PlanCbrCase(event.caseType(), solution, event.outcomeLabel(), null, features, traces);
+        new PlanCbrCase(
+            event.caseType(), solution, event.outcomeLabel(), null, features, traces, null, null);
 
     cbrStore.store(
         cbrCase,

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRetrievalCachingTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRetrievalCachingTest.java
@@ -239,7 +239,9 @@ class CbrRetrievalCachingTest {
             "COMPLETED",
             0.95,
             Map.of("f1", FeatureValue.string("v1")),
-            List.of(trace));
+            List.of(trace),
+            null,
+            null);
     return new ScoredCbrCase<>(cbrCase, 0.87);
   }
 

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRetrievalServiceTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRetrievalServiceTest.java
@@ -202,7 +202,9 @@ class CbrRetrievalServiceTest {
             "COMPLETED",
             0.95,
             Map.of("f1", FeatureValue.string("v1")),
-            List.of(planTrace));
+            List.of(planTrace),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(cbrCase, 0.87)));
 
     List<RetrievedExperience> result = service.retrieve(def, buildInstance());
@@ -266,7 +268,13 @@ class CbrRetrievalServiceTest {
     CaseDefinition def = buildDefinition(config);
     io.casehub.neocortex.memory.cbr.FeatureVectorCbrCase fvCase =
         new io.casehub.neocortex.memory.cbr.FeatureVectorCbrCase(
-            "problem1", "solution1", "COMPLETED", 0.9, Map.of("f1", FeatureValue.string("v1")));
+            "problem1",
+            "solution1",
+            "COMPLETED",
+            0.9,
+            Map.of("f1", FeatureValue.string("v1")),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(fvCase, 0.85)));
     List<RetrievedExperience> result = service.retrieve(def, buildInstance());
     assertEquals(1, result.size());
@@ -281,7 +289,13 @@ class CbrRetrievalServiceTest {
     CaseDefinition def = buildDefinition(config);
     io.casehub.neocortex.memory.cbr.FeatureVectorCbrCase fvCase =
         new io.casehub.neocortex.memory.cbr.FeatureVectorCbrCase(
-            "problem1", "solution1", "COMPLETED", 0.8, Map.of("f1", FeatureValue.string("v1")));
+            "problem1",
+            "solution1",
+            "COMPLETED",
+            0.8,
+            Map.of("f1", FeatureValue.string("v1")),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(fvCase, 0.75)));
     List<RetrievedExperience> result =
         service.retrieve(
@@ -320,7 +334,9 @@ class CbrRetrievalServiceTest {
             "COMPLETED",
             0.95,
             Map.of("f1", FeatureValue.string("v1")),
-            List.of(pt));
+            List.of(pt),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(planCase, 0.9)));
     List<RetrievedExperience> result = service.retrieve(def, buildInstance());
     assertEquals(1, result.size());
@@ -373,7 +389,9 @@ class CbrRetrievalServiceTest {
             "COMPLETED",
             0.95,
             Map.of("f1", FeatureValue.string("v1")),
-            List.of(pt));
+            List.of(pt),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(planCase, 0.87)));
 
     List<RetrievedExperience> result = service.retrieve(def, buildInstance());
@@ -400,7 +418,9 @@ class CbrRetrievalServiceTest {
             "COMPLETED",
             0.9,
             Map.of("f1", FeatureValue.string("v1")),
-            List.of(new PlanTrace("b1", "c1", "w1", "SUCCESS", 0, Map.of())));
+            List.of(new PlanTrace("b1", "c1", "w1", "SUCCESS", 0, Map.of())),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(planCase, 0.8)));
 
     service.retrieve(def, buildInstance());
@@ -422,7 +442,9 @@ class CbrRetrievalServiceTest {
             Map.of("f1", FeatureValue.string("v1")),
             List.of(
                 new PlanTrace("b1", "c1", "w1", "SUCCESS", 0, Map.of()),
-                new PlanTrace("b2", "c2", "w2", "FAILURE", 0, Map.of())));
+                new PlanTrace("b2", "c2", "w2", "FAILURE", 0, Map.of())),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(planCase, 0.8)));
 
     planAdapter.setResult(
@@ -457,7 +479,13 @@ class CbrRetrievalServiceTest {
     CaseDefinition def = buildDefinition(config);
     io.casehub.neocortex.memory.cbr.FeatureVectorCbrCase fvCase =
         new io.casehub.neocortex.memory.cbr.FeatureVectorCbrCase(
-            "problem1", "solution1", "COMPLETED", 0.9, Map.of("f1", FeatureValue.string("v1")));
+            "problem1",
+            "solution1",
+            "COMPLETED",
+            0.9,
+            Map.of("f1", FeatureValue.string("v1")),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(fvCase, 0.85)));
 
     service.retrieve(def, buildInstance());
@@ -478,7 +506,9 @@ class CbrRetrievalServiceTest {
             "COMPLETED",
             0.9,
             Map.of("f1", FeatureValue.string("v1")),
-            List.of(pt));
+            List.of(pt),
+            null,
+            null);
     cbrStore.setResult(List.of(new ScoredCbrCase<>(planCase, 0.8)));
 
     service =

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRoutingFuncDslIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRoutingFuncDslIntegrationTest.java
@@ -79,7 +79,9 @@ class CbrRoutingFuncDslIntegrationTest {
             "COMPLETED",
             0.88,
             Map.of("riskLevel", FeatureValue.string("high"), "amount", FeatureValue.number(50000)),
-            List.of(trace));
+            List.of(trace),
+            null,
+            null);
     cbrStore.store(
         pastCase,
         "risk-assessment",

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRoutingIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRoutingIntegrationTest.java
@@ -73,7 +73,9 @@ class CbrRoutingIntegrationTest {
             0.92,
             Map.of(
                 "posture", FeatureValue.string("aggressive"), "armySize", FeatureValue.number(100)),
-            List.of(trace));
+            List.of(trace),
+            null,
+            null);
     cbrStore.store(
         pastCase,
         "battle",


### PR DESCRIPTION
## Summary

neocortex-memory-api added `trustScore` (Double) and `producerAgentId` (String) to `PlanCbrCase` and `FeatureVectorCbrCase` records. Updates all 13 constructor calls in engine to pass `null, null` for these new fields.

- 1 production site: `CbrCaseRetainObserver`
- 12 test sites across 4 test classes

## Test plan

- [x] `mvn install -DskipTests` passes locally

Refs #770