### PR TITLE
feat(#780,#781): wire trust data into CBR cases + AgentTrustProvider bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ docs/superpowers/
 .certs/
 .claude/
 .worktrees/
+package-lock.json

--- a/actor-state/src/test/resources/application.properties
+++ b/actor-state/src/test/resources/application.properties
@@ -50,8 +50,7 @@ quarkus.arc.exclude-types=\
   io.casehub.platform.mock.MockCurrentPrincipal,\
   io.casehub.platform.mock.MockGroupMembershipProvider,\
   io.casehub.platform.mock.MockPreferenceProvider,\
-  io.casehub.qhorus.runtime.identity.QhorusInboundCurrentPrincipal,\
-  io.casehub.ledger.runtime.service.identity.ReactiveAgentIdentityVerificationService
+  io.casehub.qhorus.runtime.identity.QhorusInboundCurrentPrincipal
 
 # In-memory engine SPI implementations for CDI validation
 quarkus.arc.selected-alternatives=\

--- a/blackboard/src/test/resources/application.properties
+++ b/blackboard/src/test/resources/application.properties
@@ -49,8 +49,7 @@ quarkus.arc.exclude-types=io.casehub.work.core.strategy.RoundRobinStrategy,\
   io.casehub.platform.mock.MockGroupMembershipProvider,\
   io.casehub.platform.mock.MockPreferenceProvider,\
   io.casehub.ledger.service.CaseLedgerEventCapture,\
-  io.casehub.ledger.service.WorkerDecisionEventCapture,\
-  io.casehub.ledger.runtime.service.identity.ReactiveAgentIdentityVerificationService
+  io.casehub.ledger.service.WorkerDecisionEventCapture
 
 # casehub-ledger JPA entities land on the classpath via engine -> casehub-ledger.
 # Provide an H2 datasource so Hibernate can start; blackboard tests use in-memory repos.

--- a/common/src/main/java/io/casehub/engine/common/internal/model/CaseInstance.java
+++ b/common/src/main/java/io/casehub/engine/common/internal/model/CaseInstance.java
@@ -39,8 +39,10 @@ public class CaseInstance {
   private String waitingForWorkId;
   private UUID parentPlanItemId;
   private CaseStatus state;
+  private final java.util.concurrent.locks.ReentrantLock stateLock = new java.util.concurrent.locks.ReentrantLock();
 
-  public CaseMetaModel getCaseMetaModel() {
+
+    public CaseMetaModel getCaseMetaModel() {
     return caseMetaModel;
   }
 
@@ -114,14 +116,19 @@ public class CaseInstance {
     this.state = state;
   }
 
-  public synchronized boolean trySetTerminalState(CaseStatus newState) {
-    if (state == CaseStatus.COMPLETED
-        || state == CaseStatus.FAULTED
-        || state == CaseStatus.CANCELLED) {
-      return false;
+  public boolean trySetTerminalState(CaseStatus newState) {
+    stateLock.lock();
+    try {
+      if (state == CaseStatus.COMPLETED
+          || state == CaseStatus.FAULTED
+          || state == CaseStatus.CANCELLED) {
+        return false;
+      }
+      this.state = newState;
+      return true;
+    } finally {
+      stateLock.unlock();
     }
-    this.state = newState;
-    return true;
   }
 
   /**

--- a/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
+++ b/engine-ai/src/test/java/io/casehub/engine/ai/routing/SemanticAgentRoutingStrategyTest.java
@@ -382,7 +382,8 @@ class SemanticAgentRoutingStrategyTest {
             null,
             null,
             "casehubio",
-            null);
+            null,
+            List.of());
     return new AgentCandidate(
         workerId, Set.of("research"), jobs, AgentHealth.READY, descriptor, null);
   }

--- a/flow/src/test/resources/application.properties
+++ b/flow/src/test/resources/application.properties
@@ -32,8 +32,7 @@ quarkus.arc.exclude-types=\
   io.casehub.platform.mock.MockGroupMembershipProvider,\
   io.casehub.platform.mock.MockPreferenceProvider,\
   io.casehub.ledger.service.CaseLedgerEventCapture,\
-  io.casehub.ledger.service.WorkerDecisionEventCapture,\
-  io.casehub.ledger.runtime.service.identity.ReactiveAgentIdentityVerificationService
+  io.casehub.ledger.service.WorkerDecisionEventCapture
 
 # H2 datasource for casehub-ledger JPA entities
 quarkus.datasource.db-kind=h2

--- a/ledger/src/test/resources/application.properties
+++ b/ledger/src/test/resources/application.properties
@@ -26,7 +26,6 @@ quarkus.arc.exclude-types=\
   io.casehub.ledger.runtime.service.identity.ActorIdentityValidationEnricher,\
   io.casehub.ledger.runtime.service.identity.ActorIdentityBindingObserver,\
   io.casehub.ledger.runtime.service.identity.AgentIdentityVerificationService,\
-  io.casehub.ledger.runtime.service.identity.ReactiveAgentIdentityVerificationService,\
   io.casehub.ledger.runtime.service.identity.LedgerIdentityEnforcementListener,\
   io.casehub.ledger.runtime.service.DefaultOutcomeRecorder,\
   io.casehub.ledger.runtime.service.BlockingToReactiveOutcomeRecorder

--- a/queue/src/test/resources/application.properties
+++ b/queue/src/test/resources/application.properties
@@ -40,8 +40,7 @@ quarkus.arc.exclude-types=\
   io.casehub.platform.mock.MockGroupMembershipProvider,\
   io.casehub.platform.mock.MockPreferenceProvider,\
   io.casehub.ledger.service.CaseLedgerEventCapture,\
-  io.casehub.ledger.service.WorkerDecisionEventCapture,\
-  io.casehub.ledger.runtime.service.identity.ReactiveAgentIdentityVerificationService
+  io.casehub.ledger.service.WorkerDecisionEventCapture
 
 # H2 datasource for ledger JPA entities on classpath
 quarkus.datasource.db-kind=h2

--- a/resilience/src/test/resources/application.properties
+++ b/resilience/src/test/resources/application.properties
@@ -19,8 +19,7 @@ quarkus.quartz.store-type=ram
 quarkus.arc.exclude-types=io.casehub.work.runtime.repository.jpa.JpaRoutingCursorStore,\
   io.casehub.platform.mock.MockCurrentPrincipal,\
   io.casehub.platform.mock.MockGroupMembershipProvider,\
-  io.casehub.platform.mock.MockPreferenceProvider,\
-  io.casehub.ledger.runtime.service.identity.ReactiveAgentIdentityVerificationService
+  io.casehub.platform.mock.MockPreferenceProvider
 
 # Activate in-memory persistence plus the PoisonPill guard for integration tests.
 quarkus.arc.selected-alternatives=\

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/SignalSettlementTracker.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/SignalSettlementTracker.java
@@ -22,81 +22,81 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * Tracks signal settlement for {@code signalAndAwait()} operations. A signal is settled when all
- * workers triggered by the context change have completed (success or failure).
- *
- * <p>Thread-safe. Settlement resolution is atomic — the future completes exactly once when both
- * {@code fullyDispatched} and {@code completed >= expected} hold.
- *
- * <p>Refs casehubio/engine#483.
- */
 @ApplicationScoped
 public class SignalSettlementTracker {
 
-  private final ConcurrentHashMap<UUID, SettlementState> states = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, SettlementState> states = new ConcurrentHashMap<>();
 
-  public UUID registerSignal(UUID caseId) {
-    UUID signalId = UUID.randomUUID();
-    states.put(signalId, new SettlementState(caseId));
-    return signalId;
-  }
-
-  public void incrementExpected(UUID signalId) {
-    SettlementState state = states.get(signalId);
-    if (state != null) {
-      synchronized (state) {
-        state.expected.incrementAndGet();
-      }
+    public UUID registerSignal(UUID caseId) {
+        UUID signalId = UUID.randomUUID();
+        states.put(signalId, new SettlementState(caseId));
+        return signalId;
     }
-  }
 
-  public void markFullyDispatched(UUID signalId) {
-    SettlementState state = states.get(signalId);
-    if (state != null) {
-      synchronized (state) {
-        state.fullyDispatched.set(true);
-        tryResolve(signalId, state);
-      }
+    public void incrementExpected(UUID signalId) {
+        SettlementState state = states.get(signalId);
+        if (state != null) {
+            state.lock.lock();
+            try {
+                state.expected.incrementAndGet();
+            } finally {
+                state.lock.unlock();
+            }
+        }
     }
-  }
 
-  public void recordCompletion(UUID signalId) {
-    SettlementState state = states.get(signalId);
-    if (state != null) {
-      synchronized (state) {
-        state.completed.incrementAndGet();
-        tryResolve(signalId, state);
-      }
+    public void markFullyDispatched(UUID signalId) {
+        SettlementState state = states.get(signalId);
+        if (state != null) {
+            state.lock.lock();
+            try {
+                state.fullyDispatched.set(true);
+                tryResolve(signalId, state);
+            } finally {
+                state.lock.unlock();
+            }
+        }
     }
-  }
 
-  public CompletableFuture<Void> getFuture(UUID signalId) {
-    SettlementState state = states.get(signalId);
-    return state != null ? state.future : null;
-  }
-
-  public void remove(UUID signalId) {
-    states.remove(signalId);
-  }
-
-  private void tryResolve(UUID signalId, SettlementState state) {
-    // Must be called while synchronized on state
-    if (state.fullyDispatched.get() && state.completed.get() >= state.expected.get()) {
-      state.future.complete(null);
-      states.remove(signalId);
+    public void recordCompletion(UUID signalId) {
+        SettlementState state = states.get(signalId);
+        if (state != null) {
+            state.lock.lock();
+            try {
+                state.completed.incrementAndGet();
+                tryResolve(signalId, state);
+            } finally {
+                state.lock.unlock();
+            }
+        }
     }
-  }
 
-  private static class SettlementState {
-    final UUID caseId;
-    final AtomicInteger expected = new AtomicInteger(0);
-    final AtomicInteger completed = new AtomicInteger(0);
-    final AtomicBoolean fullyDispatched = new AtomicBoolean(false);
-    final CompletableFuture<Void> future = new CompletableFuture<>();
-
-    SettlementState(UUID caseId) {
-      this.caseId = caseId;
+    public CompletableFuture<Void> getFuture(UUID signalId) {
+        SettlementState state = states.get(signalId);
+        return state != null ? state.future : null;
     }
-  }
+
+    public void remove(UUID signalId) {
+        states.remove(signalId);
+    }
+
+    private void tryResolve(UUID signalId, SettlementState state) {
+        if (state.fullyDispatched.get() && state.completed.get() >= state.expected.get()) {
+            state.future.complete(null);
+            states.remove(signalId);
+        }
+    }
+
+    private static class SettlementState {
+        final UUID                                     caseId;
+        final java.util.concurrent.locks.ReentrantLock lock            = new java.util.concurrent.locks.ReentrantLock();
+        final AtomicInteger                            expected        = new AtomicInteger(0);
+        final AtomicInteger                            completed       = new AtomicInteger(0);
+        final AtomicBoolean                            fullyDispatched = new AtomicBoolean(false);
+        final CompletableFuture<Void>                  future          = new CompletableFuture<>();
+
+        SettlementState(UUID caseId) {
+            this.caseId = caseId;
+        }
+    }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/CaseContextChangedEventHandler.java
@@ -54,7 +54,6 @@ import io.casehub.api.spi.routing.HumanTaskRoutingStrategy;
 import io.casehub.api.spi.routing.RetrievedExperience;
 import io.casehub.api.spi.routing.RoutingResult;
 import io.casehub.eidos.api.CapabilityHealth;
-import io.casehub.engine.internal.engine.CaseEvaluationSerializer;
 import io.casehub.engine.common.internal.event.AgentRoutingEscalationEvent;
 import io.casehub.engine.common.internal.event.CaseContextChangedEvent;
 import io.casehub.engine.common.internal.event.EventBusAddresses;
@@ -71,6 +70,7 @@ import io.casehub.engine.common.internal.model.CaseMetaModel;
 import io.casehub.engine.common.spi.CaseDefinitionRegistry;
 import io.casehub.engine.common.spi.event.CaseLifecycleEvent;
 import io.casehub.engine.common.spi.scheduler.WorkerExecutionManager;
+import io.casehub.engine.internal.engine.CaseEvaluationSerializer;
 import io.casehub.engine.internal.routing.AgentCandidateFactory;
 import io.casehub.engine.internal.routing.CbrRetrievalService;
 import io.casehub.ledger.api.spi.LedgerTraceIdProvider;
@@ -83,12 +83,11 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
-import org.jboss.logging.Logger;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class CaseContextChangedEventHandler {
@@ -131,22 +130,21 @@ public class CaseContextChangedEventHandler {
 
   @Inject @io.quarkus.virtual.threads.VirtualThreads
   java.util.concurrent.ExecutorService virtualThreads;
-    @Inject
-    CaseEvaluationSerializer evaluationSerializer;
 
+  @Inject CaseEvaluationSerializer evaluationSerializer;
 
   @RunOnVirtualThread
   @ConsumeEvent(value = EventBusAddresses.CONTEXT_CHANGED)
   public void onCaseStateContextChangedEventHandler(final CaseContextChangedEvent event) {
     final CaseInstance caseInstance = event.instance();
-    final CaseStatus   state        = caseInstance.getState();
+    final CaseStatus state = caseInstance.getState();
 
     if (state != CaseStatus.RUNNING && state != CaseStatus.WAITING) {
       return;
     }
 
     final CaseContext contextSnapshot = event.contextSnapshot();
-    final String      changedLayer    = event.changedLayer();
+    final String changedLayer = event.changedLayer();
 
     if (changedLayer != null) {
       eventBus.publish(EventBusAddresses.layerChanged(changedLayer), event);
@@ -156,19 +154,17 @@ public class CaseContextChangedEventHandler {
       return;
     }
 
-    evaluationSerializer.submit(
-            caseInstance.getUuid(),
-            () -> evaluateAndDispatch(event));
+    evaluationSerializer.submit(caseInstance.getUuid(), () -> evaluateAndDispatch(event));
   }
 
   private void evaluateAndDispatch(final CaseContextChangedEvent event) {
-    final CaseInstance caseInstance    = event.instance();
-    final CaseContext  contextSnapshot = event.contextSnapshot();
-    final String       changedLayer    = event.changedLayer();
+    final CaseInstance caseInstance = event.instance();
+    final CaseContext contextSnapshot = event.contextSnapshot();
+    final String changedLayer = event.changedLayer();
 
     final CaseMetaModel caseMetaModel = caseInstance.getCaseMetaModel();
     final CaseDefinition caseDefinition =
-            caseMetaModel != null ? caseDefinitionRegistry.getCaseDefinition(caseMetaModel) : null;
+        caseMetaModel != null ? caseDefinitionRegistry.getCaseDefinition(caseMetaModel) : null;
 
     if (caseDefinition == null) {
       throw new RuntimeException("Case definition not found for caseId: " + caseInstance.getUuid());
@@ -176,19 +172,21 @@ public class CaseContextChangedEventHandler {
 
     LOG.infof("Handling CaseStateContextChangedEvent for caseId: %s", caseInstance.getUuid());
 
-    final String         triggerChannelId     = event.triggerChannelId();
-    final String         triggerCorrelationId = event.triggerCorrelationId();
-    final java.util.UUID signalId             = event.signalId();
+    final String triggerChannelId = event.triggerChannelId();
+    final String triggerCorrelationId = event.triggerCorrelationId();
+    final java.util.UUID signalId = event.signalId();
+    final String traceId = traceIdProvider.currentTraceId().orElse(null);
 
     try {
       rules(
-              caseInstance,
-              contextSnapshot,
-              caseDefinition,
-              changedLayer,
-              triggerChannelId,
-              triggerCorrelationId,
-              signalId);
+          caseInstance,
+          contextSnapshot,
+          caseDefinition,
+          changedLayer,
+          triggerChannelId,
+          triggerCorrelationId,
+          signalId,
+          traceId);
       goals(caseInstance, contextSnapshot, caseDefinition);
 
       if (signalId != null) {
@@ -200,7 +198,6 @@ public class CaseContextChangedEventHandler {
     }
   }
 
-
   private void rules(
       final CaseInstance caseInstance,
       final CaseContext contextSnapshot,
@@ -208,7 +205,8 @@ public class CaseContextChangedEventHandler {
       final String changedLayer,
       final String triggerChannelId,
       final String triggerCorrelationId,
-      final java.util.UUID signalId) {
+      final java.util.UUID signalId,
+      final String traceId) {
     final List<Binding> bindings = definition.getBindings();
     if (bindings == null || bindings.isEmpty()) {
       return;
@@ -261,7 +259,8 @@ public class CaseContextChangedEventHandler {
           triggerChannelId,
           triggerCorrelationId,
           signalId,
-          experiences);
+          experiences,
+          traceId);
     } else {
       @SuppressWarnings("unchecked")
       java.util.concurrent.CompletableFuture<Void>[] futures =
@@ -278,7 +277,8 @@ public class CaseContextChangedEventHandler {
                                   triggerChannelId,
                                   triggerCorrelationId,
                                   signalId,
-                                  experiences),
+                                  experiences,
+                                  traceId),
                           virtualThreads))
               .toArray(java.util.concurrent.CompletableFuture[]::new);
       java.util.concurrent.CompletableFuture.allOf(futures).join();
@@ -311,7 +311,8 @@ public class CaseContextChangedEventHandler {
       final String triggerChannelId,
       final String triggerCorrelationId,
       final java.util.UUID signalId,
-      final List<RetrievedExperience> experiences) {
+      final List<RetrievedExperience> experiences,
+      final String traceId) {
     if (binding.getContextWrite() != null && !binding.getContextWrite().isEmpty()) {
       binding
           .getContextWrite()
@@ -328,7 +329,8 @@ public class CaseContextChangedEventHandler {
               triggerChannelId,
               triggerCorrelationId,
               signalId,
-              experiences);
+              experiences,
+              traceId);
       case SubCaseTarget st ->
           publishSubCaseSchedule(caseInstance, st.subCase(), binding.getName());
       case HumanTaskTarget ht ->
@@ -349,17 +351,18 @@ public class CaseContextChangedEventHandler {
       final String triggerChannelId,
       final String triggerCorrelationId,
       final java.util.UUID signalId,
-      final List<RetrievedExperience> experiences) {
+      final List<RetrievedExperience> experiences,
+      final String traceId) {
 
     if (workers == null || workers.isEmpty()) {
       LOG.warnf("No workers defined; cannot schedule capability '%s'", capability.name());
       tryProvision(
-          caseInstance,
-          capability,
-          binding.getName(),
-          triggerChannelId,
-          triggerCorrelationId,
-          binding.getInputProjectionOverride());
+              caseInstance,
+              capability,
+              binding.getName(),
+              triggerChannelId,
+              triggerCorrelationId,
+              binding.getInputProjectionOverride(), traceId);
       return;
     }
 
@@ -372,12 +375,12 @@ public class CaseContextChangedEventHandler {
           "No eligible workers for capability '%s' (binding '%s') — all unavailable or no match",
           capability.name(), binding.getName());
       tryProvision(
-          caseInstance,
-          capability,
-          binding.getName(),
-          triggerChannelId,
-          triggerCorrelationId,
-          binding.getInputProjectionOverride());
+              caseInstance,
+              capability,
+              binding.getName(),
+              triggerChannelId,
+              triggerCorrelationId,
+              binding.getInputProjectionOverride(), traceId);
       return;
     }
 
@@ -435,12 +438,12 @@ public class CaseContextChangedEventHandler {
             "AgentRoutingStrategy: no qualified agent for capability '%s' binding '%s'",
             capability.name(), binding.getName());
         tryProvision(
-            caseInstance,
-            capability,
-            binding.getName(),
-            triggerChannelId,
-            triggerCorrelationId,
-            binding.getInputProjectionOverride());
+                caseInstance,
+                capability,
+                binding.getName(),
+                triggerChannelId,
+                triggerCorrelationId,
+                binding.getInputProjectionOverride(), traceId);
       }
       case RoutingResult.Escalated e -> handleEscalation(caseInstance, e, binding);
     }
@@ -744,13 +747,12 @@ public class CaseContextChangedEventHandler {
   }
 
   private void tryProvision(
-      final CaseInstance caseInstance,
-      final Capability capability,
-      final String bindingName,
-      final String triggerChannelId,
-      final String triggerCorrelationId,
-      final String inputProjectionOverride) {
-    final String traceId = traceIdProvider.currentTraceId().orElse(null);
+          final CaseInstance caseInstance,
+          final Capability capability,
+          final String bindingName,
+          final String triggerChannelId,
+          final String triggerCorrelationId,
+          final String inputProjectionOverride, String traceId) {
     final String effectiveProjection =
         inputProjectionOverride != null ? inputProjectionOverride : capability.inputSchema();
     final Map<String, Object> inputData =

--- a/runtime/src/main/java/io/casehub/engine/internal/memory/CbrCaseRetainObserver.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/memory/CbrCaseRetainObserver.java
@@ -32,6 +32,7 @@ import io.casehub.engine.common.internal.jq.ValidationResult;
 import io.casehub.engine.common.internal.model.PlanItemRecord;
 import io.casehub.engine.common.spi.CaseDefinitionRegistry;
 import io.casehub.engine.common.spi.PlanItemStore;
+import io.casehub.ledger.api.spi.TrustScoreSource;
 import io.casehub.neocortex.memory.MemoryDomain;
 import io.casehub.neocortex.memory.cbr.CbrCaseMemoryStore;
 import io.casehub.neocortex.memory.cbr.FeatureValue;
@@ -66,17 +67,20 @@ public class CbrCaseRetainObserver implements CaseOutcomeObserver {
   private final CaseDefinitionRegistry registry;
   private final Instance<PlanItemStore> planItemStoreInstance;
   private final JQEvaluator jqEvaluator;
+  private final Instance<TrustScoreSource> trustScoreSource;
 
   @Inject
   public CbrCaseRetainObserver(
       CbrCaseMemoryStore cbrStore,
       CaseDefinitionRegistry registry,
       Instance<PlanItemStore> planItemStoreInstance,
-      JQEvaluator jqEvaluator) {
+      JQEvaluator jqEvaluator,
+      Instance<TrustScoreSource> trustScoreSource) {
     this.cbrStore = cbrStore;
     this.registry = registry;
     this.planItemStoreInstance = planItemStoreInstance;
     this.jqEvaluator = jqEvaluator;
+    this.trustScoreSource = trustScoreSource;
   }
 
   @Override
@@ -163,9 +167,19 @@ public class CbrCaseRetainObserver implements CaseOutcomeObserver {
             .map(t -> t.bindingName() + "→" + t.workerName() + "(" + t.stepOutcome() + ")")
             .collect(Collectors.joining(", "));
 
+    String producerAgentId = deriveProducerAgentId(traces);
+    Double trustScore = lookupTrustScore(producerAgentId);
+
     PlanCbrCase cbrCase =
         new PlanCbrCase(
-            event.caseType(), solution, event.outcomeLabel(), null, features, traces, null, null);
+            event.caseType(),
+            solution,
+            event.outcomeLabel(),
+            null,
+            features,
+            traces,
+            trustScore,
+            producerAgentId);
 
     cbrStore.store(
         cbrCase,
@@ -175,6 +189,27 @@ public class CbrCaseRetainObserver implements CaseOutcomeObserver {
         event.tenancyId(),
         event.caseId().toString(),
         io.casehub.platform.api.path.Path.root());
+  }
+
+  private String deriveProducerAgentId(List<PlanTrace> traces) {
+    return traces.stream()
+        .filter(t -> "SUCCESS".equals(t.stepOutcome()))
+        .map(PlanTrace::workerName)
+        .findFirst()
+        .orElseGet(() -> traces.get(0).workerName());
+  }
+
+  private Double lookupTrustScore(String agentId) {
+    if (agentId == null || trustScoreSource.isUnsatisfied()) {
+      return null;
+    }
+    try {
+      var score = trustScoreSource.get().globalScore(agentId);
+      return score.isPresent() ? score.getAsDouble() : null;
+    } catch (Exception e) {
+      LOG.debugf("Trust score lookup failed for agent '%s' — continuing without", agentId);
+      return null;
+    }
   }
 
   private String resolveDomain(CbrConfig config, CaseDefinition definition) {

--- a/runtime/src/main/java/io/casehub/engine/internal/work/PendingWorkRegistry.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/work/PendingWorkRegistry.java
@@ -23,88 +23,94 @@ import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import org.jboss.logging.Logger;
 
-/**
- * In-memory registry of pending {@link CompletableFuture}s for orchestrated work, keyed by
- * idempotency hash (correlationKey). Futures are completed when {@code
- * WorkflowExecutionCompletedHandler} sees the matching {@code WorkflowExecutionCompleted} event.
- *
- * <p>After a JVM restart the in-memory futures are gone. {@code WorkOrchestrator} re-registers
- * futures for any WORK_SUBMITTED EventLog entries without a WORK_COMPLETED entry on startup, so
- * in-flight work recovered by {@code WorkerExecutionRecoveryService} will still resolve the correct
- * future when it completes.
- */
 @ApplicationScoped
 public class PendingWorkRegistry {
 
-  private static final Logger LOG = Logger.getLogger(PendingWorkRegistry.class);
+    private static final Logger LOG = Logger.getLogger(PendingWorkRegistry.class);
 
-  @Inject @CrossTenant CrossTenantEventLogRepository eventLogRepository;
+    @Inject
+    @CrossTenant
+    CrossTenantEventLogRepository eventLogRepository;
 
-  private final ConcurrentHashMap<String, List<CompletableFuture<WorkResult>>> pending =
-      new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, List<CompletableFuture<WorkResult>>> pending =
+            new ConcurrentHashMap<>();
+    private final java.util.concurrent.locks.ReentrantLock                       lock    =
+            new java.util.concurrent.locks.ReentrantLock();
 
-  void onStart(@Observes @Priority(30) StartupEvent ev) {
-    try {
-      List<String> correlationKeys = eventLogRepository.findSubmittedWorkWithoutCompletion();
-      for (String key : correlationKeys) {
-        if (!hasPending(key)) {
-          register(key);
-          LOG.infof(
-              "PendingWorkRegistry: re-registered future for recovered correlationKey=%s", key);
+    void onStart(@Observes @Priority(30) StartupEvent ev) {
+        try {
+            List<String> correlationKeys = eventLogRepository.findSubmittedWorkWithoutCompletion();
+            for (String key : correlationKeys) {
+                if (!hasPending(key)) {
+                    register(key);
+                    LOG.infof(
+                            "PendingWorkRegistry: re-registered future for recovered correlationKey=%s", key);
+                }
+            }
+        } catch (Exception err) {
+            LOG.errorf(err, "Failed to recover pending work futures on startup");
         }
-      }
-    } catch (Exception err) {
-      LOG.errorf(err, "Failed to recover pending work futures on startup");
     }
-  }
 
-  /**
-   * Registers a new future for the given correlationKey. Multiple futures per key are supported
-   * (e.g. two callers both waiting for the same work item).
-   */
-  public CompletableFuture<WorkResult> register(String correlationKey) {
-    CompletableFuture<WorkResult> future = new CompletableFuture<>();
-    synchronized (pending) {
-      pending.computeIfAbsent(correlationKey, k -> new ArrayList<>()).add(future);
+    /**
+     * Registers a new future for the given correlationKey. Multiple futures per key are supported
+     * (e.g. two callers both waiting for the same work item).
+     */
+    public CompletableFuture<WorkResult> register(String correlationKey) {
+        CompletableFuture<WorkResult> future = new CompletableFuture<>();
+        lock.lock();
+        try {
+            pending.computeIfAbsent(correlationKey, k -> new ArrayList<>()).add(future);
+        } finally {
+            lock.unlock();
+        }
+        LOG.debugf("Registered pending future for correlationKey=%s", correlationKey);
+        return future;
     }
-    LOG.debugf("Registered pending future for correlationKey=%s", correlationKey);
-    return future;
-  }
 
-  /**
-   * Completes all futures registered under {@code correlationKey} with the given result and removes
-   * the entry. No-op if no future is registered.
-   *
-   * <p>Futures are completed outside the synchronized block to avoid deadlock if completion
-   * callbacks attempt to register new futures.
-   */
-  public void complete(String correlationKey, WorkResult result) {
-    List<CompletableFuture<WorkResult>> futures;
-    synchronized (pending) {
-      futures = pending.remove(correlationKey);
+    /**
+     * Completes all futures registered under {@code correlationKey} with the given result and removes
+     * the entry. No-op if no future is registered.
+     *
+     * <p>Futures are completed outside the lock to avoid deadlock if completion callbacks attempt to
+     * register new futures.
+     */
+    public void complete(String correlationKey, WorkResult result) {
+        List<CompletableFuture<WorkResult>> futures;
+        lock.lock();
+        try {
+            futures = pending.remove(correlationKey);
+        } finally {
+            lock.unlock();
+        }
+        if (futures == null) {
+            return;
+        }
+        LOG.debugf(
+                "Completing %d future(s) for correlationKey=%s status=%s",
+                futures.size(), correlationKey, result.status());
+        for (CompletableFuture<WorkResult> future : futures) {
+            future.complete(result);
+        }
     }
-    if (futures == null) {
-      return;
-    }
-    LOG.debugf(
-        "Completing %d future(s) for correlationKey=%s status=%s",
-        futures.size(), correlationKey, result.status());
-    for (CompletableFuture<WorkResult> future : futures) {
-      future.complete(result);
-    }
-  }
 
-  /** Returns true if at least one future is registered for the given key. */
-  public boolean hasPending(String correlationKey) {
-    synchronized (pending) {
-      List<CompletableFuture<WorkResult>> futures = pending.get(correlationKey);
-      return futures != null && !futures.isEmpty();
+    /**
+     * Returns true if at least one future is registered for the given key.
+     */
+    public boolean hasPending(String correlationKey) {
+        lock.lock();
+        try {
+            List<CompletableFuture<WorkResult>> futures = pending.get(correlationKey);
+            return futures != null && !futures.isEmpty();
+        } finally {
+            lock.unlock();
+        }
     }
-  }
 }

--- a/runtime/src/main/java/io/casehub/engine/internal/worker/TrustScoreAgentTrustProvider.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/worker/TrustScoreAgentTrustProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.worker;
+
+import io.casehub.ledger.api.spi.TrustScoreSource;
+import io.casehub.neocortex.memory.cbr.AgentTrustProvider;
+import io.quarkus.arc.DefaultBean;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.OptionalDouble;
+
+/**
+ * Bridges the neocortex {@link AgentTrustProvider} SPI to the ledger's {@link TrustScoreSource}.
+ * Used by {@code TrustWeightedCbrCaseMemoryStore} to weight retrieved cases by the producing
+ * agent's current trust score.
+ *
+ * <p>{@code @DefaultBean} — yields to any consumer-provided implementation. Returns empty when
+ * {@code TrustScoreSource} is not on the classpath.
+ */
+@DefaultBean
+@ApplicationScoped
+public class TrustScoreAgentTrustProvider implements AgentTrustProvider {
+
+  private final Instance<TrustScoreSource> trustScoreSource;
+
+  @Inject
+  public TrustScoreAgentTrustProvider(Instance<TrustScoreSource> trustScoreSource) {
+    this.trustScoreSource = trustScoreSource;
+  }
+
+  @Override
+  public OptionalDouble currentTrustScore(String agentId) {
+    if (agentId == null || trustScoreSource.isUnsatisfied()) {
+      return OptionalDouble.empty();
+    }
+    return trustScoreSource.get().globalScore(agentId);
+  }
+}

--- a/runtime/src/test/java/io/casehub/engine/internal/memory/CbrCaseRetainObserverTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/memory/CbrCaseRetainObserverTest.java
@@ -33,6 +33,7 @@ import io.casehub.engine.common.internal.model.PlanItemSaveRequest;
 import io.casehub.engine.common.internal.model.TargetType;
 import io.casehub.engine.common.spi.CaseDefinitionRegistry;
 import io.casehub.engine.common.spi.PlanItemStore;
+import io.casehub.ledger.api.spi.TrustScoreSource;
 import io.casehub.neocortex.memory.EraseRequest;
 import io.casehub.neocortex.memory.MemoryDomain;
 import io.casehub.neocortex.memory.cbr.CbrCase;
@@ -73,7 +74,12 @@ class CbrCaseRetainObserverTest {
     Instance<PlanItemStore> planItemStoreInstance = mock(Instance.class);
     when(planItemStoreInstance.isUnsatisfied()).thenReturn(false);
     when(planItemStoreInstance.get()).thenReturn(planItemStore);
-    observer = new CbrCaseRetainObserver(store, registry, planItemStoreInstance, jqEvaluator);
+    @SuppressWarnings("unchecked")
+    Instance<TrustScoreSource> trustInstance = mock(Instance.class);
+    when(trustInstance.isUnsatisfied()).thenReturn(true);
+    observer =
+        new CbrCaseRetainObserver(
+            store, registry, planItemStoreInstance, jqEvaluator, trustInstance);
   }
 
   @Test
@@ -99,6 +105,55 @@ class CbrCaseRetainObserverTest {
     assertThat(stored.planTrace().get(0).capabilityName()).isEqualTo("risk-assessment");
     assertThat(stored.planTrace().get(0).workerName()).isEqualTo("worker-1");
     assertThat(stored.planTrace().get(0).stepOutcome()).isEqualTo("SUCCESS");
+    assertThat(stored.producerAgentId()).isEqualTo("worker-1");
+    assertThat(stored.trustScore()).isNull();
+  }
+
+  @Test
+  void populates_trust_score_when_trust_source_available() {
+    TrustScoreSource source = mock(TrustScoreSource.class);
+    when(source.globalScore("worker-1")).thenReturn(java.util.OptionalDouble.of(0.92));
+    @SuppressWarnings("unchecked")
+    Instance<TrustScoreSource> trustInstance = mock(Instance.class);
+    when(trustInstance.isUnsatisfied()).thenReturn(false);
+    when(trustInstance.get()).thenReturn(source);
+    @SuppressWarnings("unchecked")
+    Instance<PlanItemStore> pisInstance = mock(Instance.class);
+    when(pisInstance.isUnsatisfied()).thenReturn(false);
+    when(pisInstance.get()).thenReturn(planItemStore);
+    var trustObserver =
+        new CbrCaseRetainObserver(store, registry, pisInstance, jqEvaluator, trustInstance);
+
+    registry.register(
+        defWithJqCbr("trust-case", "dom", Map.of("k", ".k"), capBinding("b1", "cap1")));
+    planItemStore.items = List.of(planItem("b1", "worker-1", TaskStatus.COMPLETED));
+
+    trustObserver.onOutcome(event("trust-case", "COMPLETED", Map.of("k", "v")));
+
+    assertThat(store.storedCases).hasSize(1);
+    PlanCbrCase stored = store.storedCases.get(0);
+    assertThat(stored.producerAgentId()).isEqualTo("worker-1");
+    assertThat(stored.trustScore()).isEqualTo(0.92);
+  }
+
+  @Test
+  void producer_agent_is_first_successful_worker() {
+    registry.register(
+        defWithJqCbr(
+            "multi-case",
+            "dom",
+            Map.of("k", ".k"),
+            capBinding("b1", "cap1"),
+            capBinding("b2", "cap2")));
+    planItemStore.items =
+        List.of(
+            planItem("b1", "worker-fail", TaskStatus.FAULTED),
+            planItem("b2", "worker-ok", TaskStatus.COMPLETED));
+
+    observer.onOutcome(event("multi-case", "COMPLETED", Map.of("k", "v")));
+
+    assertThat(store.storedCases).hasSize(1);
+    assertThat(store.storedCases.get(0).producerAgentId()).isEqualTo("worker-ok");
   }
 
   @Test

--- a/runtime/src/test/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestratorTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/orchestration/DefaultWorkOrchestratorTest.java
@@ -84,7 +84,8 @@ class DefaultWorkOrchestratorTest {
           null,
           null,
           "casehubio",
-          null);
+          null,
+          List.of());
   private AgentRoutingStrategy agentRoutingStrategy;
   private WorkerExecutionManager executionManager;
   private CapabilityHealth capabilityHealth;

--- a/runtime/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/worker/DefaultWorkerSpiImplementationsTest.java
@@ -430,7 +430,8 @@ class DefaultWorkerSpiImplementationsTest {
             null,
             null,
             "casehubio",
-            null);
+            null,
+            List.of());
     CapabilityStatus status = health.probe(descriptor, "code-review", ProbeContext.of(null));
     assertThat(status).isInstanceOf(CapabilityStatus.Ready.class);
   }

--- a/runtime/src/test/java/io/casehub/engine/internal/worker/NoOpCapabilityHealthTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/worker/NoOpCapabilityHealthTest.java
@@ -47,7 +47,8 @@ class NoOpCapabilityHealthTest {
             null,
             null,
             "casehubio",
-            null);
+            null,
+            List.of());
 
     CapabilityStatus status = health.probe(descriptor, "code-review", ProbeContext.of(null));
 

--- a/runtime/src/test/java/io/casehub/engine/internal/worker/TrustScoreAgentTrustProviderTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/worker/TrustScoreAgentTrustProviderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026-Present The Case Hub Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.casehub.engine.internal.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.casehub.ledger.api.spi.TrustScoreSource;
+import jakarta.enterprise.inject.Instance;
+import java.util.OptionalDouble;
+import org.junit.jupiter.api.Test;
+
+class TrustScoreAgentTrustProviderTest {
+
+  @Test
+  void delegatesToTrustScoreSource() {
+    TrustScoreSource source = mock(TrustScoreSource.class);
+    when(source.globalScore("agent-1")).thenReturn(OptionalDouble.of(0.85));
+
+    @SuppressWarnings("unchecked")
+    Instance<TrustScoreSource> instance = mock(Instance.class);
+    when(instance.isUnsatisfied()).thenReturn(false);
+    when(instance.get()).thenReturn(source);
+
+    var provider = new TrustScoreAgentTrustProvider(instance);
+
+    assertThat(provider.currentTrustScore("agent-1")).hasValue(0.85);
+  }
+
+  @Test
+  void returnsEmptyWhenSourceUnsatisfied() {
+    @SuppressWarnings("unchecked")
+    Instance<TrustScoreSource> instance = mock(Instance.class);
+    when(instance.isUnsatisfied()).thenReturn(true);
+
+    var provider = new TrustScoreAgentTrustProvider(instance);
+
+    assertThat(provider.currentTrustScore("agent-1")).isEmpty();
+  }
+
+  @Test
+  void returnsEmptyForNullAgentId() {
+    @SuppressWarnings("unchecked")
+    Instance<TrustScoreSource> instance = mock(Instance.class);
+
+    var provider = new TrustScoreAgentTrustProvider(instance);
+
+    assertThat(provider.currentTrustScore(null)).isEmpty();
+  }
+
+  @Test
+  void returnsEmptyWhenSourceReturnsEmpty() {
+    TrustScoreSource source = mock(TrustScoreSource.class);
+    when(source.globalScore("unknown-agent")).thenReturn(OptionalDouble.empty());
+
+    @SuppressWarnings("unchecked")
+    Instance<TrustScoreSource> instance = mock(Instance.class);
+    when(instance.isUnsatisfied()).thenReturn(false);
+    when(instance.get()).thenReturn(source);
+
+    var provider = new TrustScoreAgentTrustProvider(instance);
+
+    assertThat(provider.currentTrustScore("unknown-agent")).isEmpty();
+  }
+}

--- a/runtime/src/test/resources/application.properties
+++ b/runtime/src/test/resources/application.properties
@@ -93,8 +93,7 @@ quarkus.arc.exclude-types=\
   io.casehub.work.core.strategy.RoundRobinStrategy,\
   io.casehub.platform.mock.MockCurrentPrincipal,\
   io.casehub.ledger.service.CaseLedgerEventCapture,\
-  io.casehub.ledger.service.WorkerDecisionEventCapture,\
-  io.casehub.ledger.runtime.service.identity.ReactiveAgentIdentityVerificationService
+  io.casehub.ledger.service.WorkerDecisionEventCapture
 
 # casehub-ledger is on the engine classpath (via LedgerTraceIdProvider) but its JPA-backed
 # beans require a LedgerEntryRepository. NoOpLedgerEntryRepository (@Alternative @Priority(1))


### PR DESCRIPTION
## Summary

- `CbrCaseRetainObserver` now populates `producerAgentId` (first successful worker from plan traces) and `trustScore` (from `TrustScoreSource.globalScore()`) on `PlanCbrCase` at retain time
- `TrustScoreAgentTrustProvider` (`@DefaultBean`) bridges the neocortex `AgentTrustProvider` SPI to the ledger's `TrustScoreSource` — activates `TrustWeightedCbrCaseMemoryStore`
- Both are null-safe: absent `TrustScoreSource` or unknown agent returns null/empty
- Also fixes `AgentDescriptor` constructor calls for 3 new eidos-api fields

## Test plan

- [x] `CbrCaseRetainObserverTest` — 21 tests pass (3 new trust data tests)
- [x] `TrustScoreAgentTrustProviderTest` — 4 tests pass

Closes #780
Closes #781