### PR TITLE
feat(#717): ExperiencePlanStep.stepOutcome String → RoutingOutcome

### DIFF
--- a/api/src/main/java/io/casehub/api/spi/routing/ExperienceAnalyser.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/ExperienceAnalyser.java
@@ -31,12 +31,14 @@ import java.util.Set;
 public final class ExperienceAnalyser {
 
   public static final Map<RoutingOutcome, Double> DEFAULT_OUTCOME_WEIGHTS =
-      Map.of(
-          RoutingOutcome.SUCCESS, 1.0,
-          RoutingOutcome.GATE_EXPIRED, 0.5,
-          RoutingOutcome.GATE_REJECTED, 0.25,
-          RoutingOutcome.FAILURE, 0.0,
-          RoutingOutcome.DECLINED, 0.0);
+      Map.ofEntries(
+          Map.entry(RoutingOutcome.SUCCESS, 1.0),
+          Map.entry(RoutingOutcome.FAILURE, -1.0),
+          Map.entry(RoutingOutcome.GATE_EXPIRED, -0.25),
+          Map.entry(RoutingOutcome.GATE_REJECTED, -0.5),
+          Map.entry(RoutingOutcome.DECLINED, -0.5),
+          Map.entry(RoutingOutcome.CANCELLED, 0.0),
+          Map.entry(RoutingOutcome.OBSOLETE, 0.0));
 
   private ExperienceAnalyser() {}
 
@@ -78,12 +80,7 @@ public final class ExperienceAnalyser {
           continue;
         }
 
-        RoutingOutcome outcome;
-        try {
-          outcome = RoutingOutcome.valueOf(step.stepOutcome());
-        } catch (final IllegalArgumentException e) {
-          continue;
-        }
+        RoutingOutcome outcome = step.stepOutcome();
 
         final double outcomeWeight = outcomeWeights.getOrDefault(outcome, 0.0);
         final double[] stats = workerStats.computeIfAbsent(step.workerName(), k -> new double[2]);

--- a/api/src/main/java/io/casehub/api/spi/routing/ExperienceAnalyser.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/ExperienceAnalyser.java
@@ -53,7 +53,7 @@ public final class ExperienceAnalyser {
    * @param eligibleWorkerIds worker IDs to score
    * @param stepFilter predicate selecting which plan trace steps to include in scoring
    * @param outcomeWeights per-outcome scoring weights
-   * @return per-worker scores in [0.0, 1.0]; empty map when no matching data
+   * @return per-worker scores in [-1.0, 1.0]; empty map when no matching data
    */
   public static Map<String, Double> workerSuccessRates(
       final List<RetrievedExperience> experiences,

--- a/api/src/main/java/io/casehub/api/spi/routing/ExperiencePlanStep.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/ExperiencePlanStep.java
@@ -22,7 +22,7 @@ public record ExperiencePlanStep(
     String bindingName,
     String capabilityName,
     String workerName,
-    String stepOutcome,
+    RoutingOutcome stepOutcome,
     int priority,
     Map<String, Object> parameters,
     String adaptationAction,
@@ -40,7 +40,7 @@ public record ExperiencePlanStep(
       String bindingName,
       String capabilityName,
       String workerName,
-      String stepOutcome,
+      RoutingOutcome stepOutcome,
       int priority,
       Map<String, Object> parameters) {
     this(bindingName, capabilityName, workerName, stepOutcome, priority, parameters, null, null);

--- a/api/src/main/java/io/casehub/api/spi/routing/RoutingOutcome.java
+++ b/api/src/main/java/io/casehub/api/spi/routing/RoutingOutcome.java
@@ -21,19 +21,22 @@ package io.casehub.api.spi.routing;
  *
  * <p>{@link #SUCCESS} and {@link #FAILURE} are recorded from the worker completion path in {@code
  * WorkflowExecutionCompletedHandler}. {@link #GATE_REJECTED} and {@link #GATE_EXPIRED} are recorded
- * directly from the gate resolution handlers. {@link #DECLINED} is stored in plan traces when a
- * worker explicitly declines a task ({@code TaskStatus.REJECTED → "DECLINED"} in {@code
- * CbrCaseRetainObserver}).
+ * directly from the gate resolution handlers. {@link #DECLINED}, {@link #CANCELLED}, and {@link
+ * #OBSOLETE} are recorded from the task lifecycle terminal states.
  */
 public enum RoutingOutcome {
   /** Worker completed successfully (including gate-approved re-dispatch). */
   SUCCESS,
-  /** Worker returned a non-success outcome (Declined, Failed, or Expired). */
+  /** Worker returned a non-success outcome (Failed or Expired). */
   FAILURE,
   /** Worker's planned action was rejected by a human via the oversight gate. */
   GATE_REJECTED,
   /** Worker's planned action gate expired without review. */
   GATE_EXPIRED,
-  /** Worker explicitly declined the task. */
-  DECLINED
+  /** Worker declined the assigned task. */
+  DECLINED,
+  /** Task was cancelled externally (not the worker's fault). */
+  CANCELLED,
+  /** Task became irrelevant before completion (not the worker's fault). */
+  OBSOLETE
 }

--- a/api/src/test/java/io/casehub/api/spi/routing/ExperienceAnalyserTest.java
+++ b/api/src/test/java/io/casehub/api/spi/routing/ExperienceAnalyserTest.java
@@ -38,7 +38,7 @@ class ExperienceAnalyserTest {
 
   @Test
   void noMatchingCapability_returnsEmptyMap() {
-    var exp = experience(0.8, step("agent-a", "style-review", "SUCCESS"));
+    var exp = experience(0.8, step("agent-a", "style-review", RoutingOutcome.SUCCESS));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
@@ -50,7 +50,7 @@ class ExperienceAnalyserTest {
 
   @Test
   void noMatchingWorker_returnsEmptyMap() {
-    var exp = experience(0.8, step("agent-b", "security-review", "SUCCESS"));
+    var exp = experience(0.8, step("agent-b", "security-review", RoutingOutcome.SUCCESS));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
@@ -62,7 +62,7 @@ class ExperienceAnalyserTest {
 
   @Test
   void singleSuccessStep_returnsFullScore() {
-    var exp = experience(0.9, step("agent-a", "security-review", "SUCCESS"));
+    var exp = experience(0.9, step("agent-a", "security-review", RoutingOutcome.SUCCESS));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
@@ -74,44 +74,42 @@ class ExperienceAnalyserTest {
 
   @Test
   void singleFailureStep_returnsZeroScore() {
-    var exp = experience(0.9, step("agent-a", "security-review", "FAILURE"));
+    var exp = experience(0.9, step("agent-a", "security-review", RoutingOutcome.FAILURE));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
             Set.of("agent-a"),
             "security-review",
             ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
-    assertThat(result).containsEntry("agent-a", 0.0);
+    assertThat(result).containsEntry("agent-a", -1.0);
   }
 
   @Test
   void multipleExperiences_weightedAverage() {
-    var exp1 = experience(0.9, step("agent-a", "security-review", "SUCCESS"));
-    var exp2 = experience(0.3, step("agent-a", "security-review", "FAILURE"));
+    var exp1 = experience(0.9, step("agent-a", "security-review", RoutingOutcome.SUCCESS));
+    var exp2 = experience(0.3, step("agent-a", "security-review", RoutingOutcome.FAILURE));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp1, exp2),
             Set.of("agent-a"),
             "security-review",
             ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
-    assertThat(result.get("agent-a")).isCloseTo(0.75, within(0.001));
+    assertThat(result.get("agent-a")).isCloseTo(0.5, within(0.001));
   }
 
   @Test
-  void unknownOutcome_skipped() {
-    var exp = experience(0.8, step("agent-a", "security-review", "UNKNOWN_STATUS"));
+  void outcomeNotInWeightsMap_treatedAsZeroWeight() {
+    var exp = experience(0.8, step("agent-a", "security-review", RoutingOutcome.CANCELLED));
+    var customWeights = Map.of(RoutingOutcome.SUCCESS, 1.0, RoutingOutcome.FAILURE, 0.0);
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
-            List.of(exp),
-            Set.of("agent-a"),
-            "security-review",
-            ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
-    assertThat(result).isEmpty();
+            List.of(exp), Set.of("agent-a"), "security-review", customWeights);
+    assertThat(result).containsEntry("agent-a", 0.0);
   }
 
   @Test
   void zeroSimilarity_experienceSkipped() {
-    var exp = experience(0.0, step("agent-a", "security-review", "SUCCESS"));
+    var exp = experience(0.0, step("agent-a", "security-review", RoutingOutcome.SUCCESS));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
@@ -123,7 +121,7 @@ class ExperienceAnalyserTest {
 
   @Test
   void negativeSimilarity_experienceSkipped() {
-    var exp = experience(-0.5, step("agent-a", "security-review", "SUCCESS"));
+    var exp = experience(-0.5, step("agent-a", "security-review", RoutingOutcome.SUCCESS));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
@@ -138,8 +136,8 @@ class ExperienceAnalyserTest {
     var exp =
         experience(
             0.8,
-            step("agent-a", "security-review", "SUCCESS"),
-            step("agent-b", "security-review", "FAILURE"));
+            step("agent-a", "security-review", RoutingOutcome.SUCCESS),
+            step("agent-b", "security-review", RoutingOutcome.FAILURE));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
@@ -147,7 +145,7 @@ class ExperienceAnalyserTest {
             "security-review",
             ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
     assertThat(result).containsEntry("agent-a", 1.0);
-    assertThat(result).containsEntry("agent-b", 0.0);
+    assertThat(result).containsEntry("agent-b", -1.0);
   }
 
   @Test
@@ -158,7 +156,7 @@ class ExperienceAnalyserTest {
             RoutingOutcome.FAILURE, 0.0,
             RoutingOutcome.GATE_REJECTED, 0.0,
             RoutingOutcome.GATE_EXPIRED, 0.0);
-    var exp = experience(1.0, step("agent-a", "security-review", "SUCCESS"));
+    var exp = experience(1.0, step("agent-a", "security-review", RoutingOutcome.SUCCESS));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp), Set.of("agent-a"), "security-review", customWeights);
@@ -167,32 +165,69 @@ class ExperienceAnalyserTest {
 
   @Test
   void gateExpired_partialWeight() {
-    var exp = experience(1.0, step("agent-a", "security-review", "GATE_EXPIRED"));
+    var exp = experience(1.0, step("agent-a", "security-review", RoutingOutcome.GATE_EXPIRED));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
             Set.of("agent-a"),
             "security-review",
             ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
-    assertThat(result).containsEntry("agent-a", 0.5);
+    assertThat(result).containsEntry("agent-a", -0.25);
   }
 
   @Test
   void gateRejected_weakWeight() {
-    var exp = experience(1.0, step("agent-a", "security-review", "GATE_REJECTED"));
+    var exp = experience(1.0, step("agent-a", "security-review", RoutingOutcome.GATE_REJECTED));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(exp),
             Set.of("agent-a"),
             "security-review",
             ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
-    assertThat(result).containsEntry("agent-a", 0.25);
+    assertThat(result).containsEntry("agent-a", -0.5);
+  }
+
+  @Test
+  void declined_negativeWeight() {
+    var exp = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    Map<String, Double> result =
+        ExperienceAnalyser.workerSuccessRates(
+            List.of(exp),
+            Set.of("agent-a"),
+            "security-review",
+            ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
+    assertThat(result.get("agent-a")).isCloseTo(-0.5, within(0.001));
+  }
+
+  @Test
+  void cancelled_zeroWeight() {
+    var exp = experience(1.0, step("agent-a", "security-review", RoutingOutcome.CANCELLED));
+    Map<String, Double> result =
+        ExperienceAnalyser.workerSuccessRates(
+            List.of(exp),
+            Set.of("agent-a"),
+            "security-review",
+            ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
+    assertThat(result).containsEntry("agent-a", 0.0);
+  }
+
+  @Test
+  void obsolete_zeroWeight() {
+    var exp = experience(1.0, step("agent-a", "security-review", RoutingOutcome.OBSOLETE));
+    Map<String, Double> result =
+        ExperienceAnalyser.workerSuccessRates(
+            List.of(exp),
+            Set.of("agent-a"),
+            "security-review",
+            ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
+    assertThat(result).containsEntry("agent-a", 0.0);
   }
 
   @Test
   void nullWorkerName_stepSkipped() {
     var nullWorkerStep =
-        new ExperiencePlanStep("binding", "security-review", null, "SUCCESS", 0, Map.of());
+        new ExperiencePlanStep(
+            "binding", "security-review", null, RoutingOutcome.SUCCESS, 0, Map.of());
     var exp = experience(0.8, nullWorkerStep);
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
@@ -215,7 +250,7 @@ class ExperienceAnalyserTest {
             "binding-agent-a",
             "security-review",
             "agent-a",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "ADDED",
@@ -225,7 +260,7 @@ class ExperienceAnalyserTest {
             "binding-agent-b",
             "security-review",
             "agent-b",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "RETAINED",
@@ -257,7 +292,7 @@ class ExperienceAnalyserTest {
             "binding-agent-a",
             "security-review",
             "agent-a",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "BOOSTED",
@@ -276,7 +311,7 @@ class ExperienceAnalyserTest {
 
   @Test
   void nullAdaptationAction_includedInStatistics() {
-    var unadaptedStep = step("agent-a", "security-review", "SUCCESS");
+    var unadaptedStep = step("agent-a", "security-review", RoutingOutcome.SUCCESS);
     var exp = experience(0.8, unadaptedStep);
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
@@ -294,7 +329,7 @@ class ExperienceAnalyserTest {
             "binding-agent-a",
             "security-review",
             "agent-a",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "SUBSTITUTED",
@@ -304,7 +339,7 @@ class ExperienceAnalyserTest {
             "binding-agent-b",
             "security-review",
             "agent-b",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "RETAINED",
@@ -336,7 +371,7 @@ class ExperienceAnalyserTest {
             "binding-agent-a",
             "security-review",
             "agent-a",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "SUBSTITUTED",
@@ -346,7 +381,7 @@ class ExperienceAnalyserTest {
             "binding-agent-b",
             "security-review",
             "agent-b",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "ADDED",
@@ -356,7 +391,7 @@ class ExperienceAnalyserTest {
             "binding-agent-c",
             "security-review",
             "agent-c",
-            "FAILURE",
+            RoutingOutcome.FAILURE,
             0,
             Map.of(),
             "BOOSTED",
@@ -379,12 +414,14 @@ class ExperienceAnalyserTest {
             ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
     assertThat(result).doesNotContainKey("agent-a");
     assertThat(result).doesNotContainKey("agent-b");
-    assertThat(result).containsEntry("agent-c", 0.0);
+    assertThat(result).containsEntry("agent-c", -1.0);
   }
 
   @Test
   void predicateOverload_matchesByBindingName() {
-    var step = new ExperiencePlanStep("review-binding", null, "reviewer-a", "SUCCESS", 0, Map.of());
+    var step =
+        new ExperiencePlanStep(
+            "review-binding", null, "reviewer-a", RoutingOutcome.SUCCESS, 0, Map.of());
     var exp =
         new RetrievedExperience(
             "problem", "solution", "COMPLETED", 1.0, 0.8, Map.of(), List.of(step), Map.of());
@@ -399,7 +436,9 @@ class ExperienceAnalyserTest {
 
   @Test
   void predicateOverload_nullCapabilityName_noMatchOnCapabilityString() {
-    var step = new ExperiencePlanStep("review-binding", null, "reviewer-a", "SUCCESS", 0, Map.of());
+    var step =
+        new ExperiencePlanStep(
+            "review-binding", null, "reviewer-a", RoutingOutcome.SUCCESS, 0, Map.of());
     var exp =
         new RetrievedExperience(
             "problem", "solution", "COMPLETED", 1.0, 0.8, Map.of(), List.of(step), Map.of());
@@ -414,29 +453,29 @@ class ExperienceAnalyserTest {
 
   @Test
   void declinedOutcomeContributesToEvidenceMass() {
-    var successExp = experience(1.0, step("agent-a", "security-review", "SUCCESS"));
-    var declinedExp = experience(1.0, step("agent-a", "security-review", "DECLINED"));
+    var successExp = experience(1.0, step("agent-a", "security-review", RoutingOutcome.SUCCESS));
+    var declinedExp = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(successExp, declinedExp),
             Set.of("agent-a"),
             "security-review",
             ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
-    assertThat(result.get("agent-a")).isCloseTo(0.5, within(0.001));
+    assertThat(result.get("agent-a")).isCloseTo(0.25, within(0.001));
   }
 
   @Test
   void frequentDeclinesProduceLowScore() {
-    var declined1 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var declined2 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var declined3 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var declined4 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var declined5 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var declined6 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var declined7 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var declined8 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var declined9 = experience(1.0, step("agent-a", "security-review", "DECLINED"));
-    var success = experience(1.0, step("agent-a", "security-review", "SUCCESS"));
+    var declined1 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var declined2 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var declined3 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var declined4 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var declined5 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var declined6 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var declined7 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var declined8 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var declined9 = experience(1.0, step("agent-a", "security-review", RoutingOutcome.DECLINED));
+    var success = experience(1.0, step("agent-a", "security-review", RoutingOutcome.SUCCESS));
     Map<String, Double> result =
         ExperienceAnalyser.workerSuccessRates(
             List.of(
@@ -445,10 +484,10 @@ class ExperienceAnalyserTest {
             Set.of("agent-a"),
             "security-review",
             ExperienceAnalyser.DEFAULT_OUTCOME_WEIGHTS);
-    assertThat(result.get("agent-a")).isCloseTo(0.1, within(0.001));
+    assertThat(result.get("agent-a")).isCloseTo(-0.35, within(0.001));
   }
 
-  private static ExperiencePlanStep step(String worker, String capability, String outcome) {
+  private static ExperiencePlanStep step(String worker, String capability, RoutingOutcome outcome) {
     return new ExperiencePlanStep("binding-" + worker, capability, worker, outcome, 0, Map.of());
   }
 }

--- a/api/src/test/java/io/casehub/api/spi/routing/ExperiencePlanStepTest.java
+++ b/api/src/test/java/io/casehub/api/spi/routing/ExperiencePlanStepTest.java
@@ -27,7 +27,9 @@ class ExperiencePlanStepTest {
 
   @Test
   void valid_construction() {
-    var step = new ExperiencePlanStep("bind1", "cap1", "worker1", "SUCCESS", 1, Map.of("k", "v"));
+    var step =
+        new ExperiencePlanStep(
+            "bind1", "cap1", "worker1", RoutingOutcome.SUCCESS, 1, Map.of("k", "v"));
     assertEquals("bind1", step.bindingName());
     assertEquals(1, step.priority());
   }
@@ -36,12 +38,12 @@ class ExperiencePlanStepTest {
   void null_bindingName_throws() {
     assertThrows(
         NullPointerException.class,
-        () -> new ExperiencePlanStep(null, "cap", "w", "ok", 0, Map.of()));
+        () -> new ExperiencePlanStep(null, "cap", "w", RoutingOutcome.FAILURE, 0, Map.of()));
   }
 
   @Test
   void null_capabilityName_accepted() {
-    var step = new ExperiencePlanStep("b", null, "w", "ok", 0, Map.of());
+    var step = new ExperiencePlanStep("b", null, "w", RoutingOutcome.FAILURE, 0, Map.of());
     assertNull(step.capabilityName());
   }
 
@@ -49,12 +51,12 @@ class ExperiencePlanStepTest {
   void negative_priority_throws() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> new ExperiencePlanStep("b", "c", "w", "ok", -1, Map.of()));
+        () -> new ExperiencePlanStep("b", "c", "w", RoutingOutcome.FAILURE, -1, Map.of()));
   }
 
   @Test
   void null_parameters_defaults_to_empty() {
-    var step = new ExperiencePlanStep("b", "c", "w", "ok", 0, null);
+    var step = new ExperiencePlanStep("b", "c", "w", RoutingOutcome.FAILURE, 0, null);
     assertTrue(step.parameters().isEmpty());
   }
 
@@ -65,7 +67,7 @@ class ExperiencePlanStepTest {
             "bind1",
             "cap1",
             "worker1",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "BOOSTED",
@@ -77,14 +79,16 @@ class ExperiencePlanStepTest {
   @Test
   void adaptation_fields_nullable() {
     var step =
-        new ExperiencePlanStep("bind1", "cap1", "worker1", "SUCCESS", 0, Map.of(), null, null);
+        new ExperiencePlanStep(
+            "bind1", "cap1", "worker1", RoutingOutcome.SUCCESS, 0, Map.of(), null, null);
     assertNull(step.adaptationAction());
     assertNull(step.adaptationReason());
   }
 
   @Test
   void convenience_constructor_nulls_adaptation_fields() {
-    var step = new ExperiencePlanStep("bind1", "cap1", "worker1", "SUCCESS", 0, Map.of());
+    var step =
+        new ExperiencePlanStep("bind1", "cap1", "worker1", RoutingOutcome.SUCCESS, 0, Map.of());
     assertNull(step.adaptationAction());
     assertNull(step.adaptationReason());
   }

--- a/api/src/test/java/io/casehub/api/spi/routing/RetrievedExperienceTest.java
+++ b/api/src/test/java/io/casehub/api/spi/routing/RetrievedExperienceTest.java
@@ -28,7 +28,7 @@ class RetrievedExperienceTest {
 
   @Test
   void valid_construction() {
-    var step = new ExperiencePlanStep("b1", "cap1", "w1", "SUCCESS", 0, Map.of());
+    var step = new ExperiencePlanStep("b1", "cap1", "w1", RoutingOutcome.SUCCESS, 0, Map.of());
     var exp =
         new RetrievedExperience(
             "problem",

--- a/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/engine/handler/WorkflowExecutionCompletedHandler.java
@@ -66,12 +66,11 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
-import org.jboss.logging.Logger;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jboss.logging.Logger;
 
 /**
  * Applies worker output to the case context, persists the completion event, and notifies listeners

--- a/runtime/src/main/java/io/casehub/engine/internal/memory/CbrCaseRetainObserver.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/memory/CbrCaseRetainObserver.java
@@ -27,6 +27,7 @@ import io.casehub.api.model.cbr.JqFeatureExtractor;
 import io.casehub.api.model.cbr.LambdaFeatureExtractor;
 import io.casehub.api.spi.CaseOutcomeEvent;
 import io.casehub.api.spi.CaseOutcomeObserver;
+import io.casehub.api.spi.routing.RoutingOutcome;
 import io.casehub.engine.common.internal.jq.JQEvaluator;
 import io.casehub.engine.common.internal.jq.ValidationResult;
 import io.casehub.engine.common.internal.model.PlanItemRecord;
@@ -55,13 +56,13 @@ public class CbrCaseRetainObserver implements CaseOutcomeObserver {
   private static final Logger LOG = Logger.getLogger(CbrCaseRetainObserver.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private static final Map<TaskStatus, String> OUTCOME_MAP =
+  private static final Map<TaskStatus, RoutingOutcome> OUTCOME_MAP =
       Map.of(
-          TaskStatus.COMPLETED, "SUCCESS",
-          TaskStatus.FAULTED, "FAILURE",
-          TaskStatus.REJECTED, "DECLINED",
-          TaskStatus.CANCELLED, "CANCELLED",
-          TaskStatus.OBSOLETE, "OBSOLETE");
+          TaskStatus.COMPLETED, RoutingOutcome.SUCCESS,
+          TaskStatus.FAULTED, RoutingOutcome.FAILURE,
+          TaskStatus.REJECTED, RoutingOutcome.DECLINED,
+          TaskStatus.CANCELLED, RoutingOutcome.CANCELLED,
+          TaskStatus.OBSOLETE, RoutingOutcome.OBSOLETE);
 
   private final CbrCaseMemoryStore cbrStore;
   private final CaseDefinitionRegistry registry;
@@ -277,7 +278,7 @@ public class CbrCaseRetainObserver implements CaseOutcomeObserver {
         record.bindingName(),
         capabilityNameMap.get(record.bindingName()),
         record.executorName(),
-        OUTCOME_MAP.getOrDefault(record.status(), record.status().name()),
+        OUTCOME_MAP.getOrDefault(record.status(), RoutingOutcome.FAILURE).name(),
         priority,
         Map.of());
   }

--- a/runtime/src/main/java/io/casehub/engine/internal/routing/CbrRetrievalService.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/routing/CbrRetrievalService.java
@@ -361,6 +361,7 @@ public class CbrRetrievalService {
   }
 
   private static RoutingOutcome parseOutcome(String raw) {
+    if (raw == null) return RoutingOutcome.FAILURE;
     try {
       return RoutingOutcome.valueOf(raw);
     } catch (IllegalArgumentException e) {

--- a/runtime/src/main/java/io/casehub/engine/internal/routing/CbrRetrievalService.java
+++ b/runtime/src/main/java/io/casehub/engine/internal/routing/CbrRetrievalService.java
@@ -27,6 +27,7 @@ import io.casehub.api.model.cbr.JqFeatureExtractor;
 import io.casehub.api.model.cbr.LambdaFeatureExtractor;
 import io.casehub.api.spi.routing.ExperiencePlanStep;
 import io.casehub.api.spi.routing.RetrievedExperience;
+import io.casehub.api.spi.routing.RoutingOutcome;
 import io.casehub.engine.common.internal.jq.JQEvaluator;
 import io.casehub.engine.common.internal.jq.ValidationResult;
 import io.casehub.engine.common.internal.model.CaseInstance;
@@ -333,7 +334,7 @@ public class CbrRetrievalService {
                       s.bindingName(),
                       s.capabilityName(),
                       s.workerName(),
-                      s.stepOutcome(),
+                      parseOutcome(s.stepOutcome()),
                       s.priority(),
                       s.parameters(),
                       s.action().name(),
@@ -353,9 +354,17 @@ public class CbrRetrievalService {
                     t.bindingName(),
                     t.capabilityName(),
                     t.workerName(),
-                    t.stepOutcome(),
+                    parseOutcome(t.stepOutcome()),
                     t.priority(),
                     t.parameters()))
         .toList();
+  }
+
+  private static RoutingOutcome parseOutcome(String raw) {
+    try {
+      return RoutingOutcome.valueOf(raw);
+    } catch (IllegalArgumentException e) {
+      return RoutingOutcome.FAILURE;
+    }
   }
 }

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/CbrHumanTaskRoutingStrategyTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/CbrHumanTaskRoutingStrategyTest.java
@@ -23,6 +23,7 @@ import io.casehub.api.spi.routing.HumanTaskCandidates;
 import io.casehub.api.spi.routing.HumanTaskRoutingContext;
 import io.casehub.api.spi.routing.HumanTaskRoutingResult;
 import io.casehub.api.spi.routing.RetrievedExperience;
+import io.casehub.api.spi.routing.RoutingOutcome;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +54,7 @@ class CbrHumanTaskRoutingStrategyTest {
         "problem", "solution", "COMPLETED", 1.0, similarity, Map.of(), List.of(steps), Map.of());
   }
 
-  private ExperiencePlanStep step(String bindingName, String workerName, String outcome) {
+  private ExperiencePlanStep step(String bindingName, String workerName, RoutingOutcome outcome) {
     return new ExperiencePlanStep(bindingName, null, workerName, outcome, 0, Map.of());
   }
 
@@ -73,7 +74,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void emptyUsersReturnsUnchanged() {
-    var exp = experience(0.9, step("review-task", "alice", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "alice", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)), candidates(Set.of("managers"), Set.of()));
@@ -82,7 +83,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void scoresUsersByBindingName() {
-    var exp = experience(0.9, step("review-task", "alice", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "alice", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)),
@@ -94,10 +95,12 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void enrichesUsersWithSuccessRateScores() {
-    var exp1 = experience(0.9, step("review-task", "alice", "SUCCESS"));
+    var exp1 = experience(0.9, step("review-task", "alice", RoutingOutcome.SUCCESS));
     var exp2 =
         experience(
-            0.9, step("review-task", "alice", "FAILURE"), step("review-task", "bob", "SUCCESS"));
+            0.9,
+            step("review-task", "alice", RoutingOutcome.FAILURE),
+            step("review-task", "bob", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp1, exp2)),
@@ -112,7 +115,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void ignoresUsersNotInCandidateSet() {
-    var exp = experience(0.9, step("review-task", "charlie", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "charlie", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)), candidates(Set.of(), Set.of("alice", "bob")));
@@ -121,7 +124,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void ignoresStepsWithDifferentBindingName() {
-    var exp = experience(0.9, step("other-task", "alice", "SUCCESS"));
+    var exp = experience(0.9, step("other-task", "alice", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)), candidates(Set.of(), Set.of("alice")));
@@ -135,14 +138,14 @@ class CbrHumanTaskRoutingStrategyTest {
             "review-task",
             null,
             "alice",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "ADDED",
             "adapter recommendation");
     var retainedStep =
         new ExperiencePlanStep(
-            "review-task", null, "bob", "SUCCESS", 0, Map.of(), "RETAINED", null);
+            "review-task", null, "bob", RoutingOutcome.SUCCESS, 0, Map.of(), "RETAINED", null);
     var exp = experience(0.9, addedStep, retainedStep);
     var result =
         strategy.select(
@@ -160,14 +163,14 @@ class CbrHumanTaskRoutingStrategyTest {
             "review-task",
             null,
             "alice",
-            "SUCCESS",
+            RoutingOutcome.SUCCESS,
             0,
             Map.of(),
             "SUBSTITUTED",
             "replaced original");
     var retainedStep =
         new ExperiencePlanStep(
-            "review-task", null, "bob", "FAILURE", 0, Map.of(), "RETAINED", null);
+            "review-task", null, "bob", RoutingOutcome.FAILURE, 0, Map.of(), "RETAINED", null);
     var exp = experience(0.9, substitutedStep, retainedStep);
     var result =
         strategy.select(
@@ -175,26 +178,26 @@ class CbrHumanTaskRoutingStrategyTest {
     assertThat(result).isInstanceOf(HumanTaskRoutingResult.Enriched.class);
     var enriched = (HumanTaskRoutingResult.Enriched) result;
     assertThat(enriched.candidateScores()).doesNotContainKey("alice");
-    assertThat(enriched.candidateScores()).containsEntry("bob", 0.0);
+    assertThat(enriched.candidateScores()).containsEntry("bob", -1.0);
   }
 
   @Test
   void similarityWeightingApplied() {
-    var highSimExp = experience(0.95, step("review-task", "alice", "SUCCESS"));
-    var lowSimExp = experience(0.3, step("review-task", "alice", "FAILURE"));
+    var highSimExp = experience(0.95, step("review-task", "alice", RoutingOutcome.SUCCESS));
+    var lowSimExp = experience(0.3, step("review-task", "alice", RoutingOutcome.FAILURE));
     var result =
         strategy.select(
             context("review-task", List.of(highSimExp, lowSimExp)),
             candidates(Set.of(), Set.of("alice")));
     assertThat(result).isInstanceOf(HumanTaskRoutingResult.Enriched.class);
     var enriched = (HumanTaskRoutingResult.Enriched) result;
-    // (1.0*0.95 + 0.0*0.3) / (0.95+0.3) = 0.76
-    assertThat(enriched.candidateScores().get("alice")).isCloseTo(0.76, within(0.01));
+    // (1.0*0.95 + (-1.0)*0.3) / (0.95+0.3) = 0.52
+    assertThat(enriched.candidateScores().get("alice")).isCloseTo(0.52, within(0.01));
   }
 
   @Test
   void groupsPassThroughUnchanged() {
-    var exp = experience(0.9, step("review-task", "alice", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "alice", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)),
@@ -206,7 +209,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void noMatchingTraceDataReturnsUnchanged() {
-    var exp = experience(0.9, step("review-task", "charlie", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "charlie", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)),
@@ -216,7 +219,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void scoresGroupExpandedUsers() {
-    var exp = experience(0.9, step("review-task", "bob", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "bob", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)),
@@ -230,7 +233,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void emptyAllUsersReturnsUnchanged() {
-    var exp = experience(0.9, step("review-task", "alice", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "alice", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)),
@@ -240,7 +243,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void enrichedCandidateUsersContainsAllUsers() {
-    var exp = experience(0.9, step("review-task", "bob", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "bob", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)),
@@ -252,7 +255,7 @@ class CbrHumanTaskRoutingStrategyTest {
 
   @Test
   void overlapBetweenDirectAndGroupProducesSingleScore() {
-    var exp = experience(0.9, step("review-task", "alice", "SUCCESS"));
+    var exp = experience(0.9, step("review-task", "alice", RoutingOutcome.SUCCESS));
     var result =
         strategy.select(
             context("review-task", List.of(exp)),

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRetrievalServiceTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRetrievalServiceTest.java
@@ -532,6 +532,58 @@ class CbrRetrievalServiceTest {
     assertNull(result.get(0).planTrace().get(0).adaptationAction());
   }
 
+  @Test
+  void planTrace_stepOutcome_convertedToRoutingOutcome() {
+    CbrConfig config =
+        CbrConfig.builder().featureExtractor(ctx -> Map.of("f1", "v1")).domain("test").build();
+    CaseDefinition def = buildDefinition(config);
+    PlanTrace planTrace = new PlanTrace("bind1", "cap1", "worker1", "DECLINED", 0, Map.of());
+    PlanCbrCase cbrCase =
+        new PlanCbrCase(
+            "problem1",
+            "solution1",
+            "COMPLETED",
+            0.95,
+            Map.of("f1", FeatureValue.string("v1")),
+            List.of(planTrace),
+            null,
+            null);
+    cbrStore.setResult(List.of(new ScoredCbrCase<>(cbrCase, 0.87)));
+
+    List<RetrievedExperience> result = service.retrieve(def, buildInstance());
+
+    assertEquals(1, result.size());
+    assertEquals(
+        io.casehub.api.spi.routing.RoutingOutcome.DECLINED,
+        result.get(0).planTrace().get(0).stepOutcome());
+  }
+
+  @Test
+  void planTrace_unknownOutcome_fallsBackToFailure() {
+    CbrConfig config =
+        CbrConfig.builder().featureExtractor(ctx -> Map.of("f1", "v1")).domain("test").build();
+    CaseDefinition def = buildDefinition(config);
+    PlanTrace planTrace = new PlanTrace("bind1", "cap1", "worker1", "UNKNOWN_VALUE", 0, Map.of());
+    PlanCbrCase cbrCase =
+        new PlanCbrCase(
+            "problem1",
+            "solution1",
+            "COMPLETED",
+            0.95,
+            Map.of("f1", FeatureValue.string("v1")),
+            List.of(planTrace),
+            null,
+            null);
+    cbrStore.setResult(List.of(new ScoredCbrCase<>(cbrCase, 0.87)));
+
+    List<RetrievedExperience> result = service.retrieve(def, buildInstance());
+
+    assertEquals(1, result.size());
+    assertEquals(
+        io.casehub.api.spi.routing.RoutingOutcome.FAILURE,
+        result.get(0).planTrace().get(0).stepOutcome());
+  }
+
   private CaseDefinition buildDefinition(CbrConfig config) {
     CaseDefinition def =
         CaseDefinition.builder().namespace("ns").name("test-case").version("1.0.0").build();

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRoutingIntegrationTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/CbrRoutingIntegrationTest.java
@@ -22,6 +22,7 @@ import io.casehub.api.engine.YamlCaseHub;
 import io.casehub.api.model.CaseDefinition;
 import io.casehub.api.spi.routing.AgentRoutingContext;
 import io.casehub.api.spi.routing.RetrievedExperience;
+import io.casehub.api.spi.routing.RoutingOutcome;
 import io.casehub.neocortex.memory.MemoryDomain;
 import io.casehub.neocortex.memory.cbr.CbrCaseMemoryStore;
 import io.casehub.neocortex.memory.cbr.FeatureValue;
@@ -119,7 +120,7 @@ class CbrRoutingIntegrationTest {
     assertThat(exp.planTrace().get(0).bindingName()).isEqualTo("plan-on-enemy-sighted");
     assertThat(exp.planTrace().get(0).capabilityName()).isEqualTo("planBattle");
     assertThat(exp.planTrace().get(0).workerName()).isEqualTo("battle-planner");
-    assertThat(exp.planTrace().get(0).stepOutcome()).isEqualTo("SUCCESS");
+    assertThat(exp.planTrace().get(0).stepOutcome()).isEqualTo(RoutingOutcome.SUCCESS);
   }
 
   // ------------------------------------------------------------------ //

--- a/runtime/src/test/java/io/casehub/engine/internal/routing/PersonalitySignalRecorderTest.java
+++ b/runtime/src/test/java/io/casehub/engine/internal/routing/PersonalitySignalRecorderTest.java
@@ -15,16 +15,6 @@
  */
 package io.casehub.engine.internal.routing;
 
-import io.casehub.api.model.CognitiveDemand;
-import io.casehub.eidos.api.DispositionSignalStore;
-import io.casehub.eidos.api.DispositionValue;
-import jakarta.enterprise.inject.Instance;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.Map;
-
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -33,194 +23,204 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.casehub.api.model.CognitiveDemand;
+import io.casehub.eidos.api.DispositionSignalStore;
+import io.casehub.eidos.api.DispositionValue;
+import jakarta.enterprise.inject.Instance;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 class PersonalitySignalRecorderTest {
 
-    private DispositionSignalStore    signalStore;
-    private PersonalitySignalRecorder recorder;
+  private DispositionSignalStore signalStore;
+  private PersonalitySignalRecorder recorder;
 
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    signalStore = mock(DispositionSignalStore.class);
+    Instance<DispositionSignalStore> storeInstance = mock(Instance.class);
+    when(storeInstance.get()).thenReturn(signalStore);
+    when(storeInstance.isResolvable()).thenReturn(true);
+    recorder = new PersonalitySignalRecorder(storeInstance, null, null, null);
+  }
+
+  @Test
+  void reinforcement_dominantMatchesDemand_recordsDominant() {
+    var profile = List.of(new DispositionValue("Ti", 0.5), new DispositionValue("Ne", 0.3));
+    var demand = new CognitiveDemand(Map.of("Ti", 0.6, "Ne", 0.3, "Si", 0.1));
+
+    recorder.recordReinforcement("agent-1", "tenant-1", profile, demand);
+
+    verify(signalStore).recordActivation("agent-1", "tenant-1", "Ti");
+  }
+
+  @Test
+  void reinforcement_auxiliaryMatchesDemand_recordsAuxiliary() {
+    var profile = List.of(new DispositionValue("Ti", 0.5), new DispositionValue("Ne", 0.3));
+    var demand = new CognitiveDemand(Map.of("Ne", 0.7, "Ti", 0.2, "Si", 0.1));
+
+    recorder.recordReinforcement("agent-1", "tenant-1", profile, demand);
+
+    verify(signalStore).recordActivation("agent-1", "tenant-1", "Ne");
+  }
+
+  @Test
+  void compensation_recordsHighestDemandOutsideDomAux() {
+    var profile = List.of(new DispositionValue("Ti", 0.5), new DispositionValue("Ne", 0.3));
+    var demand = new CognitiveDemand(Map.of("Se", 0.5, "Ti", 0.3, "Ne", 0.2));
+
+    recorder.recordCompensation("agent-1", "tenant-1", profile, demand);
+
+    verify(signalStore).recordActivation("agent-1", "tenant-1", "Se");
+  }
+
+  @Test
+  void compensation_allDemandOnDomAux_skipsRecording() {
+    var profile = List.of(new DispositionValue("Ti", 0.5), new DispositionValue("Ne", 0.3));
+    var demand = new CognitiveDemand(Map.of("Ti", 0.6, "Ne", 0.4));
+
+    recorder.recordCompensation("agent-1", "tenant-1", profile, demand);
+
+    verifyNoInteractions(signalStore);
+  }
+
+  @Test
+  void reinforcement_singleFunctionProfile_recordsDominant() {
+    var profile = List.of(new DispositionValue("Ti", 0.8));
+    var demand = new CognitiveDemand(Map.of("Ti", 0.5, "Ne", 0.3, "Si", 0.2));
+
+    recorder.recordReinforcement("agent-1", "tenant-1", profile, demand);
+
+    verify(signalStore).recordActivation("agent-1", "tenant-1", "Ti");
+  }
+
+  @Test
+  void checkReflection_evolutionPending_dampened_callsDecay() {
+    var dispositionHealth = mock(io.casehub.eidos.api.DispositionHealth.class);
+    var dispositionEvolution = mock(io.casehub.eidos.api.DispositionEvolution.class);
     @SuppressWarnings("unchecked")
-    @BeforeEach
-    void setUp() {
-        signalStore = mock(DispositionSignalStore.class);
-        Instance<DispositionSignalStore> storeInstance = mock(Instance.class);
-        when(storeInstance.get()).thenReturn(signalStore);
-        when(storeInstance.isResolvable()).thenReturn(true);
-        recorder = new PersonalitySignalRecorder(storeInstance, null, null, null);
-    }
+    Instance<io.casehub.eidos.api.DispositionHealth> healthInst = mock(Instance.class);
+    when(healthInst.get()).thenReturn(dispositionHealth);
+    when(healthInst.isResolvable()).thenReturn(true);
+    @SuppressWarnings("unchecked")
+    Instance<io.casehub.eidos.api.DispositionEvolution> evolInst = mock(Instance.class);
+    when(evolInst.get()).thenReturn(dispositionEvolution);
+    when(evolInst.isResolvable()).thenReturn(true);
+    @SuppressWarnings("unchecked")
+    Instance<io.casehub.eidos.api.DispositionSignalStore> storeInst = mock(Instance.class);
+    when(storeInst.get()).thenReturn(signalStore);
+    when(storeInst.isResolvable()).thenReturn(true);
+    var recorderWithReflection =
+        new PersonalitySignalRecorder(storeInst, null, healthInst, evolInst);
 
-    @Test
-    void reinforcement_dominantMatchesDemand_recordsDominant() {
-        var profile = List.of(new DispositionValue("Ti", 0.5), new DispositionValue("Ne", 0.3));
-        var demand  = new CognitiveDemand(Map.of("Ti", 0.6, "Ne", 0.3, "Si", 0.1));
+    var descriptor =
+        io.casehub.eidos.api.AgentDescriptor.builder()
+            .agentId("agent-1")
+            .name("agent-1")
+            .slot("test")
+            .tenancyId("t1")
+            .build();
+    var pending =
+        new io.casehub.eidos.api.DispositionHealth.DispositionStatus.EvolutionPending(
+            new io.casehub.eidos.api.EvolutionType() {
+              @Override
+              public String name() {
+                return "ROLE_SWAP";
+              }
+            },
+            "Ne",
+            java.util.Map.of("Ti", 0.4, "Ne", 0.35));
+    when(dispositionHealth.probe(any(), any())).thenReturn(pending);
+    when(dispositionEvolution.evaluate(any(), any()))
+        .thenReturn(new io.casehub.eidos.api.DispositionEvolution.EvolutionResult.Dampened(0.2));
 
-        recorder.recordReinforcement("agent-1", "tenant-1", profile, demand);
+    recorderWithReflection.checkReflection("agent-1", "tenant-1", descriptor);
 
-        verify(signalStore).recordActivation("agent-1", "tenant-1", "Ti");
-    }
+    verify(signalStore).decay("agent-1", "tenant-1", 0.2);
+  }
 
-    @Test
-    void reinforcement_auxiliaryMatchesDemand_recordsAuxiliary() {
-        var profile = List.of(new DispositionValue("Ti", 0.5), new DispositionValue("Ne", 0.3));
-        var demand  = new CognitiveDemand(Map.of("Ne", 0.7, "Ti", 0.2, "Si", 0.1));
+  @Test
+  void checkReflection_evolutionPending_evolved_callsClear() {
+    var dispositionHealth = mock(io.casehub.eidos.api.DispositionHealth.class);
+    var dispositionEvolution = mock(io.casehub.eidos.api.DispositionEvolution.class);
+    @SuppressWarnings("unchecked")
+    Instance<io.casehub.eidos.api.DispositionHealth> healthInst = mock(Instance.class);
+    when(healthInst.get()).thenReturn(dispositionHealth);
+    when(healthInst.isResolvable()).thenReturn(true);
+    @SuppressWarnings("unchecked")
+    Instance<io.casehub.eidos.api.DispositionEvolution> evolInst = mock(Instance.class);
+    when(evolInst.get()).thenReturn(dispositionEvolution);
+    when(evolInst.isResolvable()).thenReturn(true);
+    @SuppressWarnings("unchecked")
+    Instance<io.casehub.eidos.api.DispositionSignalStore> storeInst = mock(Instance.class);
+    when(storeInst.get()).thenReturn(signalStore);
+    when(storeInst.isResolvable()).thenReturn(true);
+    var recorderWithReflection =
+        new PersonalitySignalRecorder(storeInst, null, healthInst, evolInst);
 
-        recorder.recordReinforcement("agent-1", "tenant-1", profile, demand);
+    var descriptor =
+        io.casehub.eidos.api.AgentDescriptor.builder()
+            .agentId("agent-1")
+            .name("agent-1")
+            .slot("test")
+            .tenancyId("t1")
+            .build();
+    var pending =
+        new io.casehub.eidos.api.DispositionHealth.DispositionStatus.EvolutionPending(
+            new io.casehub.eidos.api.EvolutionType() {
+              @Override
+              public String name() {
+                return "ROLE_SWAP";
+              }
+            },
+            "Ne",
+            java.util.Map.of("Ti", 0.4, "Ne", 0.35));
+    when(dispositionHealth.probe(any(), any())).thenReturn(pending);
+    when(dispositionEvolution.evaluate(any(), any()))
+        .thenReturn(
+            new io.casehub.eidos.api.DispositionEvolution.EvolutionResult.Evolved(
+                java.util.List.of(
+                    new io.casehub.eidos.api.DispositionValue("Ne", 0.35),
+                    new io.casehub.eidos.api.DispositionValue("Ti", 0.20)),
+                "TI-NE",
+                "NE-TI"));
 
-        verify(signalStore).recordActivation("agent-1", "tenant-1", "Ne");
-    }
+    recorderWithReflection.checkReflection("agent-1", "tenant-1", descriptor);
 
-    @Test
-    void compensation_recordsHighestDemandOutsideDomAux() {
-        var profile = List.of(new DispositionValue("Ti", 0.5), new DispositionValue("Ne", 0.3));
-        var demand  = new CognitiveDemand(Map.of("Se", 0.5, "Ti", 0.3, "Ne", 0.2));
+    verify(signalStore).clear("agent-1", "tenant-1");
+    verify(signalStore, never()).decay(any(), any(), anyDouble());
+  }
 
-        recorder.recordCompensation("agent-1", "tenant-1", profile, demand);
+  @Test
+  void checkReflection_aligned_noReflection() {
+    var dispositionHealth = mock(io.casehub.eidos.api.DispositionHealth.class);
+    @SuppressWarnings("unchecked")
+    Instance<io.casehub.eidos.api.DispositionHealth> healthInst2 = mock(Instance.class);
+    when(healthInst2.get()).thenReturn(dispositionHealth);
+    when(healthInst2.isResolvable()).thenReturn(true);
+    @SuppressWarnings("unchecked")
+    Instance<io.casehub.eidos.api.DispositionSignalStore> storeInst2 = mock(Instance.class);
+    when(storeInst2.get()).thenReturn(signalStore);
+    when(storeInst2.isResolvable()).thenReturn(true);
+    var recorderWithReflection = new PersonalitySignalRecorder(storeInst2, null, healthInst2, null);
 
-        verify(signalStore).recordActivation("agent-1", "tenant-1", "Se");
-    }
+    var descriptor =
+        io.casehub.eidos.api.AgentDescriptor.builder()
+            .agentId("agent-1")
+            .name("agent-1")
+            .slot("test")
+            .tenancyId("t1")
+            .build();
+    when(dispositionHealth.probe(any(), any()))
+        .thenReturn(
+            new io.casehub.eidos.api.DispositionHealth.DispositionStatus.Aligned(
+                java.util.Map.of()));
 
-    @Test
-    void compensation_allDemandOnDomAux_skipsRecording() {
-        var profile = List.of(new DispositionValue("Ti", 0.5), new DispositionValue("Ne", 0.3));
-        var demand  = new CognitiveDemand(Map.of("Ti", 0.6, "Ne", 0.4));
+    recorderWithReflection.checkReflection("agent-1", "tenant-1", descriptor);
 
-        recorder.recordCompensation("agent-1", "tenant-1", profile, demand);
-
-        verifyNoInteractions(signalStore);
-    }
-
-    @Test
-    void reinforcement_singleFunctionProfile_recordsDominant() {
-        var profile = List.of(new DispositionValue("Ti", 0.8));
-        var demand  = new CognitiveDemand(Map.of("Ti", 0.5, "Ne", 0.3, "Si", 0.2));
-
-        recorder.recordReinforcement("agent-1", "tenant-1", profile, demand);
-
-        verify(signalStore).recordActivation("agent-1", "tenant-1", "Ti");
-    }
-
-    @Test
-    void checkReflection_evolutionPending_dampened_callsDecay() {
-        var dispositionHealth    = mock(io.casehub.eidos.api.DispositionHealth.class);
-        var dispositionEvolution = mock(io.casehub.eidos.api.DispositionEvolution.class);
-        @SuppressWarnings("unchecked")
-        Instance<io.casehub.eidos.api.DispositionHealth> healthInst = mock(Instance.class);
-        when(healthInst.get()).thenReturn(dispositionHealth);
-        when(healthInst.isResolvable()).thenReturn(true);
-        @SuppressWarnings("unchecked")
-        Instance<io.casehub.eidos.api.DispositionEvolution> evolInst = mock(Instance.class);
-        when(evolInst.get()).thenReturn(dispositionEvolution);
-        when(evolInst.isResolvable()).thenReturn(true);
-        @SuppressWarnings("unchecked")
-        Instance<io.casehub.eidos.api.DispositionSignalStore> storeInst = mock(Instance.class);
-        when(storeInst.get()).thenReturn(signalStore);
-        when(storeInst.isResolvable()).thenReturn(true);
-        var recorderWithReflection =
-                new PersonalitySignalRecorder(storeInst, null, healthInst, evolInst);
-
-        var descriptor =
-                io.casehub.eidos.api.AgentDescriptor.builder()
-                                                    .agentId("agent-1")
-                                                    .name("agent-1")
-                                                    .slot("test")
-                                                    .tenancyId("t1")
-                                                    .build();
-        var pending =
-                new io.casehub.eidos.api.DispositionHealth.DispositionStatus.EvolutionPending(
-                        new io.casehub.eidos.api.EvolutionType() {
-                            @Override
-                            public String name() {
-                                return "ROLE_SWAP";
-                            }
-                        },
-                        "Ne",
-                        java.util.Map.of("Ti", 0.4, "Ne", 0.35));
-        when(dispositionHealth.probe(any(), any())).thenReturn(pending);
-        when(dispositionEvolution.evaluate(any(), any()))
-                .thenReturn(new io.casehub.eidos.api.DispositionEvolution.EvolutionResult.Dampened(0.2));
-
-        recorderWithReflection.checkReflection("agent-1", "tenant-1", descriptor);
-
-        verify(signalStore).decay("agent-1", "tenant-1", 0.2);
-    }
-
-    @Test
-    void checkReflection_evolutionPending_evolved_callsClear() {
-        var dispositionHealth    = mock(io.casehub.eidos.api.DispositionHealth.class);
-        var dispositionEvolution = mock(io.casehub.eidos.api.DispositionEvolution.class);
-        @SuppressWarnings("unchecked")
-        Instance<io.casehub.eidos.api.DispositionHealth> healthInst = mock(Instance.class);
-        when(healthInst.get()).thenReturn(dispositionHealth);
-        when(healthInst.isResolvable()).thenReturn(true);
-        @SuppressWarnings("unchecked")
-        Instance<io.casehub.eidos.api.DispositionEvolution> evolInst = mock(Instance.class);
-        when(evolInst.get()).thenReturn(dispositionEvolution);
-        when(evolInst.isResolvable()).thenReturn(true);
-        @SuppressWarnings("unchecked")
-        Instance<io.casehub.eidos.api.DispositionSignalStore> storeInst = mock(Instance.class);
-        when(storeInst.get()).thenReturn(signalStore);
-        when(storeInst.isResolvable()).thenReturn(true);
-        var recorderWithReflection =
-                new PersonalitySignalRecorder(storeInst, null, healthInst, evolInst);
-
-        var descriptor =
-                io.casehub.eidos.api.AgentDescriptor.builder()
-                                                    .agentId("agent-1")
-                                                    .name("agent-1")
-                                                    .slot("test")
-                                                    .tenancyId("t1")
-                                                    .build();
-        var pending =
-                new io.casehub.eidos.api.DispositionHealth.DispositionStatus.EvolutionPending(
-                        new io.casehub.eidos.api.EvolutionType() {
-                            @Override
-                            public String name() {
-                                return "ROLE_SWAP";
-                            }
-                        },
-                        "Ne",
-                        java.util.Map.of("Ti", 0.4, "Ne", 0.35));
-        when(dispositionHealth.probe(any(), any())).thenReturn(pending);
-        when(dispositionEvolution.evaluate(any(), any()))
-                .thenReturn(new io.casehub.eidos.api.DispositionEvolution.EvolutionResult.Evolved(
-                        java.util.List.of(
-                                new io.casehub.eidos.api.DispositionValue("Ne", 0.35),
-                                new io.casehub.eidos.api.DispositionValue("Ti", 0.20)),
-                        "TI-NE", "NE-TI"));
-
-        recorderWithReflection.checkReflection("agent-1", "tenant-1", descriptor);
-
-        verify(signalStore).clear("agent-1", "tenant-1");
-        verify(signalStore, never()).decay(any(), any(), anyDouble());
-    }
-
-
-    @Test
-    void checkReflection_aligned_noReflection() {
-        var dispositionHealth = mock(io.casehub.eidos.api.DispositionHealth.class);
-        @SuppressWarnings("unchecked")
-        Instance<io.casehub.eidos.api.DispositionHealth> healthInst2 = mock(Instance.class);
-        when(healthInst2.get()).thenReturn(dispositionHealth);
-        when(healthInst2.isResolvable()).thenReturn(true);
-        @SuppressWarnings("unchecked")
-        Instance<io.casehub.eidos.api.DispositionSignalStore> storeInst2 = mock(Instance.class);
-        when(storeInst2.get()).thenReturn(signalStore);
-        when(storeInst2.isResolvable()).thenReturn(true);
-        var recorderWithReflection = new PersonalitySignalRecorder(storeInst2, null, healthInst2, null);
-
-        var descriptor =
-                io.casehub.eidos.api.AgentDescriptor.builder()
-                                                    .agentId("agent-1")
-                                                    .name("agent-1")
-                                                    .slot("test")
-                                                    .tenancyId("t1")
-                                                    .build();
-        when(dispositionHealth.probe(any(), any()))
-                .thenReturn(
-                        new io.casehub.eidos.api.DispositionHealth.DispositionStatus.Aligned(
-                                java.util.Map.of()));
-
-        recorderWithReflection.checkReflection("agent-1", "tenant-1", descriptor);
-
-        verifyNoInteractions(signalStore);
-    }
+    verifyNoInteractions(signalStore);
+  }
 }


### PR DESCRIPTION
## Summary

- Expand `RoutingOutcome` enum with `DECLINED`, `CANCELLED`, `OBSOLETE` to cover all `TaskStatus` terminal states
- Change `ExperiencePlanStep.stepOutcome` from `String` to `RoutingOutcome` — compile-time type safety, no more `valueOf()` try/catch
- Update `DEFAULT_OUTCOME_WEIGHTS` to bipolar scale `[-1.0, 1.0]` per design spec (SUCCESS +1.0, FAILURE -1.0, GATE_REJECTED -0.5, GATE_EXPIRED -0.25, DECLINED -0.5, CANCELLED/OBSOLETE 0.0)
- Add `parseOutcome()` boundary conversion in `CbrRetrievalService` for neocortex-memory-api boundary (`PlanTrace`/`AdaptedStep` retain `String`)
- Update `CbrCaseRetainObserver.OUTCOME_MAP` to `Map<TaskStatus, RoutingOutcome>`

## Files changed

- **engine-api** (6 files): `RoutingOutcome`, `ExperiencePlanStep`, `ExperienceAnalyser` + 3 test files
- **engine-runtime** (4 files): `CbrCaseRetainObserver`, `CbrRetrievalService` + 2 test files

## Merge note

`TrustWeightedAgentStrategyTest` was added to `main` after this branch point — 5 `ExperiencePlanStep` constructor calls need `"SUCCESS"` → `RoutingOutcome.SUCCESS` at merge time. Score-magnitude assertions may need recalculation against bipolar weights.

## Test plan

- [x] All api/ module tests pass (846 tests)
- [x] All runtime/ module tests pass
- [x] Full build succeeds (19 modules, 1075 tests)
- [x] New tests: `outcomeNotInWeightsMap_treatedAsZeroWeight`, `declined_negativeWeight`, `cancelled_zeroWeight`, `obsolete_zeroWeight`
- [x] Boundary tests: `planTrace_stepOutcome_convertedToRoutingOutcome`, `planTrace_unknownOutcome_fallsBackToFailure`

Closes #717